### PR TITLE
fix: repare page contacts

### DIFF
--- a/src/main/java/com/supervisor/server/FkMySupervisor.java
+++ b/src/main/java/com/supervisor/server/FkMySupervisor.java
@@ -181,7 +181,7 @@ public final class FkMySupervisor extends FkWrap {
 				),
 				new FkRegex(
 					"/contacts",
-					new TkAnonymous(new TkContact(base))
+					new TkAnonymous(new TkContact())
 				),
 				new FkRegex(
 					"/contacts/send",

--- a/src/main/java/com/supervisor/takes/TkContact.java
+++ b/src/main/java/com/supervisor/takes/TkContact.java
@@ -1,40 +1,45 @@
+/*
+ * Copyright (c) 2018-2022 Minlessika
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.supervisor.takes;
 
-import com.supervisor.sdk.datasource.Base;
-import com.supervisor.sdk.takes.TkForm;
-import com.supervisor.sdk.takes.XeRecaptcha;
 import com.supervisor.sdk.translation.I18n;
-import org.takes.Request;
-import org.takes.rs.xe.XeAppend;
-import org.takes.rs.xe.XeSource;
-
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import org.takes.Request;
+import org.takes.Response;
+import org.takes.Take;
+import org.takes.rs.xe.XeAppend;
+import org.takes.rs.xe.XeChain;
 
-public final class TkContact extends TkForm {
-
-	public TkContact(final Base base) {
-		super(base);
-	}
-
-	@Override
-	protected String xslFormPath() {
-		return I18n.localizeXslt("/xsl/contacts/page.xsl");
-	}
-
-	@Override
-	protected Iterable<XeSource> contentToShow(Request req, XeSource itemToShow) throws IOException {
-		List<XeSource> content = new ArrayList<>();
-		content.add(itemToShow);
-		content.add(new XeAppend("menu", "contact"));
-		content.add(new XeRecaptcha(base.appInfo()));
-		
-		return content;
-	}
+/**
+ * Take that shows contact form to an anonymous user.
+ *
+ * @since 1.0
+ */
+public final class TkContact implements Take {
 
 	@Override
-	protected XeSource preItemDataToShow(Long id, Request req) throws IOException {
-		return XeSource.EMPTY;
+	public Response act(final Request req) throws IOException {
+		return new RsAnonymousPage(
+			I18n.localizeXslt("/xsl/contacts/page.xsl"),
+			req,
+			new XeChain(
+				new XeAppend("menu", "contact"),
+				new XeAppend("lang", I18n.locale().getLanguage())
+			)
+		);
 	}
 }

--- a/src/main/java/com/supervisor/takes/TkSendContact.java
+++ b/src/main/java/com/supervisor/takes/TkSendContact.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018-2022 Minlessika
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to read
+ * the Software only. Permissions is hereby NOT GRANTED to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.supervisor.takes;
 
 import com.supervisor.domain.impl.UserAdmin;
@@ -5,49 +21,49 @@ import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.mailing.InternetWarningMailing;
 import com.supervisor.sdk.secure.GRecaptcha;
 import com.supervisor.sdk.secure.Recaptcha;
-import com.supervisor.sdk.takes.TkBaseWrap;
 import com.supervisor.sdk.translation.I18n;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqGreedy;
 import org.takes.rq.form.RqFormSmart;
-
+import org.takes.tk.TkWrap;
 import java.util.logging.Level;
 
-public final class TkSendContact extends TkBaseWrap {
+/**
+ * Take that allows an anonymous user to contact company team.
+ *
+ * @since 1.0
+ */
+public final class TkSendContact extends TkWrap {
 
+	/**
+	 * Ctor.
+	 * @param base Data source
+	 */
 	public TkSendContact(final Base base) {
 		super(
-				base,
-				req -> {
-					
-					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
-					
-					final String gRecaptchaResponse = form.single("g-recaptcha-response", ""); 
-					
-					Recaptcha recaptcha = new GRecaptcha(base.appInfo());
-					recaptcha.validate(gRecaptchaResponse);
-					
-					final String name = form.single("name");
-					final String email = form.single("email");
-					final String message = form.single("message");
-
-					new InternetWarningMailing().send(
-							new UserAdmin(base).address().email(), 
-							String.format("Contact : %s", name), 
-							String.format("<span>%s (%s) sent you this message :</span> <br /> <span>%s</span>", name, email, message)
-					);
-					
-					final String msg = I18n.localizeText("your_mail_has_been_sent_to_us_with_success");
-					
-					return new RsForward(
-						new RsFlash(
-			                msg,
-			                Level.FINE
-			            ),
-						"/"
-				    );
-				}
+			req -> {
+				final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
+				final String gRecaptchaResponse = form.single("g-recaptcha-response", "");
+				final Recaptcha recaptcha = new GRecaptcha(base.appInfo());
+				recaptcha.validate(gRecaptchaResponse);
+				final String name = form.single("name");
+				final String email = form.single("email");
+				final String message = form.single("message");
+				new InternetWarningMailing().send(
+					new UserAdmin(base).address().email(),
+					String.format("Contact : %s", name),
+					String.format("<span>%s (%s) sent you this message :</span> <br /> <span>%s</span>", name, email, message)
+				);
+				final String msg = I18n.localizeText("your_mail_has_been_sent_to_us_with_success");
+				return new RsForward(
+					new RsFlash(
+						msg,
+						Level.FINE
+					),
+					"/"
+				);
+			}
 		);
 	}
 }

--- a/src/main/resources/xsl/contacts/page.xsl
+++ b/src/main/resources/xsl/contacts/page.xsl
@@ -24,11 +24,11 @@ SOFTWARE.
       <!--Grid column-->
       <div class="col-md-6 mb-5 mt-md-0 mt-5 white-text text-center text-md-left">
         <h1 class="h1-responsive font-weight-bold wow fadeInLeft" data-wow-delay="0.3s">
-          <xsl:value-of select="$lang.contactUs"/>
+          <xsl:value-of select="$i18n.contactUs"/>
         </h1>
         <hr class="hr-light wow fadeInLeft" data-wow-delay="0.3s"/>
         <h6 class="mb-3 wow fadeInLeft" data-wow-delay="0.3s">
-          <xsl:value-of select="$lang.weAreListeningToYou"/>
+          <xsl:value-of select="$i18n.weAreListeningToYou"/>
         </h6>
       </div>
       <!--Grid column-->
@@ -42,7 +42,7 @@ SOFTWARE.
               <div class="text-center">
                 <h3 class="dark-grey-text">
                   <i class="fa fa-pencil-alt grey-text">
-                    <xsl:value-of select="$lang.formTitle"/>
+                    <xsl:value-of select="$i18n.formTitle"/>
                   </i>
                 </h3>
                 <hr class="mt-2 mb-2"/>
@@ -52,14 +52,14 @@ SOFTWARE.
                 <i class="fa fa-user prefix grey-text"/>
                 <input name="name" type="text" id="form3" class="form-control" required=""/>
                 <label for="form3">
-                  <xsl:value-of select="$lang.yourName"/>
+                  <xsl:value-of select="$i18n.yourName"/>
                 </label>
               </div>
               <div class="md-form">
                 <i class="fa fa-envelope prefix grey-text"/>
                 <input name="email" type="text" id="form2" class="form-control" required=""/>
                 <label for="form2">
-                  <xsl:value-of select="$lang.yourEmailAddress"/>
+                  <xsl:value-of select="$i18n.yourEmailAddress"/>
                 </label>
               </div>
               <!--Textarea with icon prefix-->
@@ -67,19 +67,19 @@ SOFTWARE.
                 <i class="fa fa-pencil-alt prefix grey-text"/>
                 <textarea name="message" type="text" id="form8" class="md-textarea form-control" rows="3" required=""/>
                 <label for="form8">
-                  <xsl:value-of select="$lang.yourMessage"/>
+                  <xsl:value-of select="$i18n.yourMessage"/>
                 </label>
               </div>
               <div class="text-center mt-3">
                 <xsl:choose>
                   <xsl:when test="recaptcha/active = 'true'">
                     <button id="submitter" class="btn btn-indigo">
-                      <xsl:value-of select="$lang.submitText"/>
+                      <xsl:value-of select="$i18n.submitText"/>
                     </button>
                   </xsl:when>
                   <xsl:otherwise>
                     <button type="submit" class="btn btn-indigo">
-                      <xsl:value-of select="$lang.submitText"/>
+                      <xsl:value-of select="$i18n.submitText"/>
                     </button>
                   </xsl:otherwise>
                 </xsl:choose>

--- a/src/main/resources/xsl/contacts/page_en_US.xsl
+++ b/src/main/resources/xsl/contacts/page_en_US.xsl
@@ -17,12 +17,12 @@ SOFTWARE.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
   <xsl:output method="html" encoding="UTF-8"/>
-  <xsl:variable name="lang.contactUs" select="'Contact us !'"/>
-  <xsl:variable name="lang.weAreListeningToYou" select="'We are listening to you.'"/>
-  <xsl:variable name="lang.formTitle" select="' Write to us'"/>
-  <xsl:variable name="lang.yourName" select="'Your name'"/>
-  <xsl:variable name="lang.yourEmailAddress" select="'Your e-mail address'"/>
-  <xsl:variable name="lang.yourMessage" select="'Your message'"/>
-  <xsl:variable name="lang.submitText" select="'Send'"/>
-  <xsl:include href="/xslxsl"/>
+  <xsl:variable name="i18n.contactUs" select="'Contact us !'"/>
+  <xsl:variable name="i18n.weAreListeningToYou" select="'We are listening to you.'"/>
+  <xsl:variable name="i18n.formTitle" select="' Write to us'"/>
+  <xsl:variable name="i18n.yourName" select="'Your name'"/>
+  <xsl:variable name="i18n.yourEmailAddress" select="'Your e-mail address'"/>
+  <xsl:variable name="i18n.yourMessage" select="'Your message'"/>
+  <xsl:variable name="i18n.submitText" select="'Send'"/>
+  <xsl:include href="/xsl/contacts/page.xsl"/>
 </xsl:stylesheet>

--- a/src/main/resources/xsl/contacts/page_fr_FR.xsl
+++ b/src/main/resources/xsl/contacts/page_fr_FR.xsl
@@ -17,12 +17,12 @@ SOFTWARE.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
   <xsl:output method="html" encoding="UTF-8"/>
-  <xsl:variable name="lang.contactUs" select="'Contactez-nous !'"/>
-  <xsl:variable name="lang.weAreListeningToYou" select="'Nous sommes à votre écoute.'"/>
-  <xsl:variable name="lang.formTitle" select="' Ecrivez-nous'"/>
-  <xsl:variable name="lang.yourName" select="'Votre nom'"/>
-  <xsl:variable name="lang.yourEmailAddress" select="'Votre adresse mail'"/>
-  <xsl:variable name="lang.yourMessage" select="'Votre message'"/>
-  <xsl:variable name="lang.submitText" select="'Envoyer'"/>
-  <xsl:include href="/xslxsl"/>
+  <xsl:variable name="i18n.contactUs" select="'Contactez-nous !'"/>
+  <xsl:variable name="i18n.weAreListeningToYou" select="'Nous sommes à votre écoute.'"/>
+  <xsl:variable name="i18n.formTitle" select="' Ecrivez-nous'"/>
+  <xsl:variable name="i18n.yourName" select="'Votre nom'"/>
+  <xsl:variable name="i18n.yourEmailAddress" select="'Votre adresse mail'"/>
+  <xsl:variable name="i18n.yourMessage" select="'Votre message'"/>
+  <xsl:variable name="i18n.submitText" select="'Envoyer'"/>
+  <xsl:include href="/xsl/contacts/page.xsl"/>
 </xsl:stylesheet>


### PR DESCRIPTION
The link was broken because of some missing locations of `XSL` pages.

Fix: #48