### PR TITLE
refactor: use uuid instead of bigint as primary key

### DIFF
--- a/src/main/java/com/supervisor/billing/Invoice.java
+++ b/src/main/java/com/supervisor/billing/Invoice.java
@@ -43,7 +43,7 @@ public interface Invoice extends Order {
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}
@@ -55,7 +55,7 @@ public interface Invoice extends Order {
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
@@ -67,19 +67,13 @@ public interface Invoice extends Order {
 		}
 		
 		@Override
-		public Long id() {
+		public UUID id() {
 			
 			return null;
 		}
 		
 		@Override
-		public UUID guid() throws IOException {
-			
-			return null;
-		}
-		
-		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/billing/impl/CurrencyWrap.java
+++ b/src/main/java/com/supervisor/billing/impl/CurrencyWrap.java
@@ -18,13 +18,8 @@ public class CurrencyWrap implements Currency {
 	}
 	
 	@Override
-	public Long id() {
+	public UUID id() {
 		return origin.id();
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		return origin.guid();
 	}
 
 	@Override
@@ -33,7 +28,7 @@ public class CurrencyWrap implements Currency {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return origin.creatorId();
 	}
 
@@ -43,12 +38,12 @@ public class CurrencyWrap implements Currency {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return origin.lastModifierId();
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		return origin.ownerId();
 	}
 

--- a/src/main/java/com/supervisor/billing/impl/PgPendingPayments.java
+++ b/src/main/java/com/supervisor/billing/impl/PgPendingPayments.java
@@ -38,7 +38,7 @@ public final class PgPendingPayments extends DomainRecordables<PaymentRequest, P
 										"	select src.* \r\n" + 
 				                        "   from %s as src \r\n" + 
 										"	left join %s as target on target.id = src.order_id \r\n" + 
-										"   where target.customer_id=%s and src.status = 'PENDING'" + 
+										"   where target.customer_id='%s'::uuid and src.status = 'PENDING'" +
 										") as %s",
 							table.name(),
 							new TableImpl(Order.class).name(),

--- a/src/main/java/com/supervisor/billing/impl/PgUserPaymentReceipts.java
+++ b/src/main/java/com/supervisor/billing/impl/PgUserPaymentReceipts.java
@@ -38,7 +38,7 @@ public final class PgUserPaymentReceipts extends DomainRecordables<PaymentReceip
 										"	select src.* \r\n" + 
 				                        "   from %s as src \r\n" + 
 										"	left join %s as target on target.id = src.order_id \r\n" + 
-										"   where target.customer_id=%s" + 
+										"   where target.customer_id='%s'::uuid" +
 										") as %s",
 							table.name(),
 							new TableImpl(Order.class).name(),

--- a/src/main/java/com/supervisor/billing/impl/PgUserPaymentRequests.java
+++ b/src/main/java/com/supervisor/billing/impl/PgUserPaymentRequests.java
@@ -38,7 +38,7 @@ public final class PgUserPaymentRequests extends DomainRecordables<PaymentReques
 										"	select src.* \r\n" + 
 				                        "   from %s as src \r\n" + 
 										"	left join %s as target on target.id = src.order_id \r\n" + 
-										"   where target.customer_id=%s" + 
+										"   where target.customer_id='%s'::uuid" +
 										") as %s",
 							table.name(),
 							new TableImpl(Order.class).name(),

--- a/src/main/java/com/supervisor/billing/impl/PxPurchaseOrders.java
+++ b/src/main/java/com/supervisor/billing/impl/PxPurchaseOrders.java
@@ -21,6 +21,7 @@ import com.supervisor.sdk.datasource.RecordSet;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.UUID;
 
 public final class PxPurchaseOrders extends DomainRecordables<PurchaseOrder, PurchaseOrders> implements PurchaseOrders {
 
@@ -31,11 +32,11 @@ public final class PxPurchaseOrders extends DomainRecordables<PurchaseOrder, Pur
 	@Override
 	public PurchaseOrder add(Person customer, String description) throws IOException {
 		final User user = new UserOf(this);
-		final Long currencyId;
+		final UUID currencyId;
 		if(user.preferredCurrency().code().equals("XOF")) {
 			currencyId = user.preferredCurrency().id();
 		}else {
-			currencyId = 2L;
+			currencyId = Currency.EUR_ID;
 		}
 		
 		final Currencies currencies = new PxCurrencies(source.of(Currency.class));

--- a/src/main/java/com/supervisor/copying/AbstractActivityWriter.java
+++ b/src/main/java/com/supervisor/copying/AbstractActivityWriter.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+
 import com.supervisor.domain.User;
 import com.supervisor.domain.UserScope;
 import com.supervisor.domain.impl.OwnerOf;
@@ -40,7 +42,7 @@ public abstract class AbstractActivityWriter implements Writer<Activity> {
 	protected final User user;
 	protected final Activity source;
 	protected final Activity target;
-	protected final Map<Long, DataModel> dataModelMappings = new HashMap<>();
+	protected final Map<UUID, DataModel> dataModelMappings = new HashMap<>();
 	
 	public AbstractActivityWriter(final Activity source, final Activity target) throws IOException {
 		this(new OwnerOf(target), source, target);

--- a/src/main/java/com/supervisor/copying/AbstractAggregatedModelWriter.java
+++ b/src/main/java/com/supervisor/copying/AbstractAggregatedModelWriter.java
@@ -2,6 +2,7 @@ package com.supervisor.copying;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.sdk.utils.BasicCodeGenerator;
 import com.supervisor.sdk.utils.CodeGenerator;
@@ -19,21 +20,21 @@ public abstract class AbstractAggregatedModelWriter implements Writer<Aggregated
 	protected final AggregatedModel source;
 	protected final AggregatedModel target;
 	protected final DataModel targetModel;
-	protected final Map<Long, DataModel> dataModelMappings;
+	protected final Map<UUID, DataModel> dataModelMappings;
 	
-	public AbstractAggregatedModelWriter(final String code, final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AbstractAggregatedModelWriter(final String code, final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		this(code, targetActivity, targetModel, source, AggregatedModel.EMPTY, dataModelMappings);
 	}
 	
-	public AbstractAggregatedModelWriter(final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AbstractAggregatedModelWriter(final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		this(StringUtils.EMPTY, targetActivity, targetModel, source, AggregatedModel.EMPTY, dataModelMappings);
 	}
 	
-	public AbstractAggregatedModelWriter(final AggregatedModel source, final AggregatedModel target, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AbstractAggregatedModelWriter(final AggregatedModel source, final AggregatedModel target, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		this(StringUtils.EMPTY, target.activity(), target.model(), source, target, dataModelMappings);
 	}
 	
-	private AbstractAggregatedModelWriter(final String code, final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final AggregatedModel target, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	private AbstractAggregatedModelWriter(final String code, final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final AggregatedModel target, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		this.code = code;
 		this.targetActivity = targetActivity;
 		this.source = source;

--- a/src/main/java/com/supervisor/copying/AbstractDataFieldOfSheetWriter.java
+++ b/src/main/java/com/supervisor/copying/AbstractDataFieldOfSheetWriter.java
@@ -2,6 +2,7 @@ package com.supervisor.copying;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.domain.DataFieldOfSheet;
 import com.supervisor.domain.DataModel;
@@ -21,17 +22,17 @@ public abstract class AbstractDataFieldOfSheetWriter implements Writer<DataField
 	protected final DataSheet targetSheet;
 	protected final DataFieldOfSheet source;
 	protected final DataFieldOfSheet target;
-	protected final Map<Long, DataModel> dataModelMappings;
+	protected final Map<UUID, DataModel> dataModelMappings;
 	
-	public AbstractDataFieldOfSheetWriter(final DataSheet targetSheet, final DataFieldOfSheet source, final Map<Long, DataModel> dataModelMappings) {
+	public AbstractDataFieldOfSheetWriter(final DataSheet targetSheet, final DataFieldOfSheet source, final Map<UUID, DataModel> dataModelMappings) {
 		this(targetSheet, source, DataFieldOfSheet.EMPTY, dataModelMappings);
 	}
 	
-	public AbstractDataFieldOfSheetWriter(final DataFieldOfSheet source, final DataFieldOfSheet target, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AbstractDataFieldOfSheetWriter(final DataFieldOfSheet source, final DataFieldOfSheet target, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		this(target.sheet(), source, target, dataModelMappings);
 	}
 	
-	private AbstractDataFieldOfSheetWriter(final DataSheet targetSheet, final DataFieldOfSheet source, final DataFieldOfSheet target, final Map<Long, DataModel> dataModelMappings) {
+	private AbstractDataFieldOfSheetWriter(final DataSheet targetSheet, final DataFieldOfSheet source, final DataFieldOfSheet target, final Map<UUID, DataModel> dataModelMappings) {
 		this.targetSheet = targetSheet;
 		this.source = source;
 		this.target = target;

--- a/src/main/java/com/supervisor/copying/AbstractDataModelWriter.java
+++ b/src/main/java/com/supervisor/copying/AbstractDataModelWriter.java
@@ -2,6 +2,7 @@ package com.supervisor.copying;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -17,21 +18,21 @@ public abstract class AbstractDataModelWriter implements Writer<DataModel> {
 	protected final Activity targetActivity;
 	protected final DataModel source;
 	protected final DataModel target;
-	protected final Map<Long, DataModel> dataModelMappings;
+	protected final Map<UUID, DataModel> dataModelMappings;
 	
-	public AbstractDataModelWriter(final String code, final Activity targetActivity, final DataModel source, final Map<Long, DataModel> dataModelMappings) {
+	public AbstractDataModelWriter(final String code, final Activity targetActivity, final DataModel source, final Map<UUID, DataModel> dataModelMappings) {
 		this(code, targetActivity, source, DataModel.EMPTY, dataModelMappings);
 	}
 	
-	public AbstractDataModelWriter(final Activity targetActivity, final DataModel source, final Map<Long, DataModel> dataModelMappings) {
+	public AbstractDataModelWriter(final Activity targetActivity, final DataModel source, final Map<UUID, DataModel> dataModelMappings) {
 		this(StringUtils.EMPTY, targetActivity, source, DataModel.EMPTY, dataModelMappings);
 	}
 	
-	public AbstractDataModelWriter(final DataModel source, final DataModel target, final Map<Long, DataModel> dataModelMappings) {
+	public AbstractDataModelWriter(final DataModel source, final DataModel target, final Map<UUID, DataModel> dataModelMappings) {
 		this(StringUtils.EMPTY, Activity.EMPTY, source, target, dataModelMappings);
 	}
 	
-	private AbstractDataModelWriter(final String code, final Activity targetActivity, final DataModel source, final DataModel target, final Map<Long, DataModel> dataModelMappings) {
+	private AbstractDataModelWriter(final String code, final Activity targetActivity, final DataModel source, final DataModel target, final Map<UUID, DataModel> dataModelMappings) {
 		this.code = code;
 		this.targetActivity = targetActivity;
 		this.source = source;

--- a/src/main/java/com/supervisor/copying/AbstractDataSheetModelWriter.java
+++ b/src/main/java/com/supervisor/copying/AbstractDataSheetModelWriter.java
@@ -2,6 +2,7 @@ package com.supervisor.copying;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.domain.Activity;
 import com.supervisor.domain.DataModel;
@@ -13,17 +14,17 @@ public abstract class AbstractDataSheetModelWriter implements Writer<DataSheetMo
 	protected final Activity targetActivity;
 	protected final DataSheetModel source;
 	protected final DataSheetModel target;
-	protected final Map<Long, DataModel> dataModelMappings;
+	protected final Map<UUID, DataModel> dataModelMappings;
 	
-	public AbstractDataSheetModelWriter(final Activity targetActivity, final DataSheetModel source, final Map<Long, DataModel> dataModelMappings) {
+	public AbstractDataSheetModelWriter(final Activity targetActivity, final DataSheetModel source, final Map<UUID, DataModel> dataModelMappings) {
 		this(targetActivity, source, DataSheetModel.EMPTY, dataModelMappings);
 	}
 	
-	public AbstractDataSheetModelWriter(final DataSheetModel source, final DataSheetModel target, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AbstractDataSheetModelWriter(final DataSheetModel source, final DataSheetModel target, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		this(target.activity(), source, target, dataModelMappings);
 	}
 	
-	private AbstractDataSheetModelWriter(final Activity targetActivity, final DataSheetModel source, final DataSheetModel target, final Map<Long, DataModel> dataModelMappings) {
+	private AbstractDataSheetModelWriter(final Activity targetActivity, final DataSheetModel source, final DataSheetModel target, final Map<UUID, DataModel> dataModelMappings) {
 		this.targetActivity = targetActivity;
 		this.source = source;
 		this.target = target;

--- a/src/main/java/com/supervisor/copying/AbstractDataSheetWriter.java
+++ b/src/main/java/com/supervisor/copying/AbstractDataSheetWriter.java
@@ -2,6 +2,7 @@ package com.supervisor.copying;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.domain.DataFieldOfSheet;
 import com.supervisor.domain.DataModel;
@@ -14,17 +15,17 @@ public abstract class AbstractDataSheetWriter implements Writer<DataSheet> {
 	protected final DataSheetModel targetModel;
 	protected final DataSheet source;
 	protected final DataSheet target;
-	protected final Map<Long, DataModel> dataModelMappings;
+	protected final Map<UUID, DataModel> dataModelMappings;
 	
-	public AbstractDataSheetWriter(final DataSheetModel targetModel, final DataSheet source, final Map<Long, DataModel> dataModelMappings) {
+	public AbstractDataSheetWriter(final DataSheetModel targetModel, final DataSheet source, final Map<UUID, DataModel> dataModelMappings) {
 		this(targetModel, source, DataSheet.EMPTY, dataModelMappings);
 	}
 	
-	public AbstractDataSheetWriter(final DataSheet source, final DataSheet target, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AbstractDataSheetWriter(final DataSheet source, final DataSheet target, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		this(target.model(), source, target, dataModelMappings);
 	}
 	
-	private AbstractDataSheetWriter(final DataSheetModel targetModel, final DataSheet source, final DataSheet target, final Map<Long, DataModel> dataModelMappings) {
+	private AbstractDataSheetWriter(final DataSheetModel targetModel, final DataSheet source, final DataSheet target, final Map<UUID, DataModel> dataModelMappings) {
 		this.targetModel = targetModel;
 		this.source = source;
 		this.target = target;

--- a/src/main/java/com/supervisor/copying/AbstractEditableDataFieldWriter.java
+++ b/src/main/java/com/supervisor/copying/AbstractEditableDataFieldWriter.java
@@ -2,6 +2,7 @@ package com.supervisor.copying;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.domain.DataField;
 import com.supervisor.domain.DataFields;
@@ -17,9 +18,9 @@ public abstract class AbstractEditableDataFieldWriter implements Writer<Editable
 
 	protected final EditableDataField source;
 	protected final DataSheetModel targetModel;
-	protected final Map<Long, DataModel> dataModelMappings;
+	protected final Map<UUID, DataModel> dataModelMappings;
 	
-	public AbstractEditableDataFieldWriter(final DataSheetModel targetModel, final EditableDataField source, final Map<Long, DataModel> dataModelMappings) {
+	public AbstractEditableDataFieldWriter(final DataSheetModel targetModel, final EditableDataField source, final Map<UUID, DataModel> dataModelMappings) {
 		this.source = source;
 		this.targetModel = targetModel;
 		this.dataModelMappings = dataModelMappings;

--- a/src/main/java/com/supervisor/copying/AbstractFormularDataFieldWriter.java
+++ b/src/main/java/com/supervisor/copying/AbstractFormularDataFieldWriter.java
@@ -2,6 +2,7 @@ package com.supervisor.copying;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.domain.AggregatedModel;
 import com.supervisor.domain.DataModel;
@@ -25,9 +26,9 @@ public abstract class AbstractFormularDataFieldWriter implements Writer<Formular
 
 	protected final FormularDataField source;
 	protected final AggregatedModel targetModel;
-	protected final Map<Long, DataModel> dataModelMappings;
+	protected final Map<UUID, DataModel> dataModelMappings;
 	
-	public AbstractFormularDataFieldWriter(final AggregatedModel targetModel, final FormularDataField source, final Map<Long, DataModel> dataModelMappings) {
+	public AbstractFormularDataFieldWriter(final AggregatedModel targetModel, final FormularDataField source, final Map<UUID, DataModel> dataModelMappings) {
 		this.source = source;
 		this.targetModel = targetModel;
 		this.dataModelMappings = dataModelMappings;

--- a/src/main/java/com/supervisor/copying/AbstractFormularExtendedToModelExpressionWriter.java
+++ b/src/main/java/com/supervisor/copying/AbstractFormularExtendedToModelExpressionWriter.java
@@ -2,6 +2,7 @@ package com.supervisor.copying;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.domain.DataModel;
 import com.supervisor.domain.FormularDataField;
@@ -12,9 +13,9 @@ public abstract class AbstractFormularExtendedToModelExpressionWriter implements
 	
 	protected final FormularDataField targetFormular;
 	protected final FormularExtendedToModelExpression source;
-	protected final Map<Long, DataModel> dataModelMappings;
+	protected final Map<UUID, DataModel> dataModelMappings;
 	
-	public AbstractFormularExtendedToModelExpressionWriter(final FormularDataField targetFormular, final FormularExtendedToModelExpression source, final Map<Long, DataModel> dataModelMappings) {
+	public AbstractFormularExtendedToModelExpressionWriter(final FormularDataField targetFormular, final FormularExtendedToModelExpression source, final Map<UUID, DataModel> dataModelMappings) {
 		this.targetFormular = targetFormular;
 		this.source = source;
 		this.dataModelMappings = dataModelMappings;

--- a/src/main/java/com/supervisor/copying/AbstractIndicatorWriter.java
+++ b/src/main/java/com/supervisor/copying/AbstractIndicatorWriter.java
@@ -2,6 +2,7 @@ package com.supervisor.copying;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.sdk.time.Periodicity;
 import com.supervisor.domain.Activity;
@@ -21,17 +22,17 @@ public abstract class AbstractIndicatorWriter implements Writer<Indicator> {
 	protected final Activity targetActivity;
 	protected final Indicator source;
 	protected final Indicator target;
-	protected final Map<Long, DataModel> dataModelMappings;
+	protected final Map<UUID, DataModel> dataModelMappings;
 	
-	public AbstractIndicatorWriter(final Activity targetActivity, final Indicator source, final Map<Long, DataModel> dataModelMappings) {
+	public AbstractIndicatorWriter(final Activity targetActivity, final Indicator source, final Map<UUID, DataModel> dataModelMappings) {
 		this(targetActivity, source, Indicator.EMPTY, dataModelMappings);
 	}
 	
-	public AbstractIndicatorWriter(final Indicator source, final Indicator target, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AbstractIndicatorWriter(final Indicator source, final Indicator target, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		this(target.activity(), source, target, dataModelMappings);
 	}
 	
-	private AbstractIndicatorWriter(final Activity targetActivity, final Indicator source, final Indicator target, final Map<Long, DataModel> dataModelMappings) {
+	private AbstractIndicatorWriter(final Activity targetActivity, final Indicator source, final Indicator target, final Map<UUID, DataModel> dataModelMappings) {
 		this.targetActivity = targetActivity;
 		this.source = source;
 		this.target = target;

--- a/src/main/java/com/supervisor/copying/cloning/AggregatedModelCloning.java
+++ b/src/main/java/com/supervisor/copying/cloning/AggregatedModelCloning.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.cloning;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractAggregatedModelWriter;
 import com.supervisor.domain.Activity;
@@ -10,15 +11,15 @@ import com.supervisor.domain.DataModel;
 
 public class AggregatedModelCloning extends AbstractAggregatedModelWriter {
 
-	public AggregatedModelCloning(final String code, final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AggregatedModelCloning(final String code, final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(code, targetActivity, targetModel, source, dataModelMappings);
 	}
 	
-	public AggregatedModelCloning(final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AggregatedModelCloning(final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(targetActivity, targetModel, source, dataModelMappings);
 	}
 	
-	public AggregatedModelCloning(AggregatedModel source, AggregatedModel target, Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AggregatedModelCloning(AggregatedModel source, AggregatedModel target, Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}
 	

--- a/src/main/java/com/supervisor/copying/cloning/DataFieldOfSheetCloning.java
+++ b/src/main/java/com/supervisor/copying/cloning/DataFieldOfSheetCloning.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.cloning;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractDataFieldOfSheetWriter;
 import com.supervisor.copying.generating.DataSheetGenerating;
@@ -15,11 +16,11 @@ import com.supervisor.domain.TableDataFieldOfSheetRow;
 
 public final class DataFieldOfSheetCloning extends AbstractDataFieldOfSheetWriter {
 
-	public DataFieldOfSheetCloning(DataFieldOfSheet source, DataFieldOfSheet target, Map<Long, DataModel> dataModelMappings) throws IOException {
+	public DataFieldOfSheetCloning(DataFieldOfSheet source, DataFieldOfSheet target, Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}
 
-	public DataFieldOfSheetCloning(final DataSheet targetSheet, final DataFieldOfSheet source, final Map<Long, DataModel> dataModelMappings) {
+	public DataFieldOfSheetCloning(final DataSheet targetSheet, final DataFieldOfSheet source, final Map<UUID, DataModel> dataModelMappings) {
 		super(targetSheet, source, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/cloning/DataModelCloning.java
+++ b/src/main/java/com/supervisor/copying/cloning/DataModelCloning.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.cloning;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractDataModelWriter;
 import com.supervisor.domain.Activity;
@@ -11,15 +12,15 @@ import com.supervisor.domain.DataSheetModel;
 
 public final class DataModelCloning extends AbstractDataModelWriter {
 	
-	public DataModelCloning(String code, Activity targetActivity, DataModel source, Map<Long, DataModel> dataModelMappings) {
+	public DataModelCloning(String code, Activity targetActivity, DataModel source, Map<UUID, DataModel> dataModelMappings) {
 		super(code, targetActivity, source, dataModelMappings);
 	}
 	
-	public DataModelCloning(Activity targetActivity, DataModel source, Map<Long, DataModel> dataModelMappings) {
+	public DataModelCloning(Activity targetActivity, DataModel source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetActivity, source, dataModelMappings);
 	}
 	
-	public DataModelCloning(final DataModel source, final DataModel target, final Map<Long, DataModel> dataModelMappings) {
+	public DataModelCloning(final DataModel source, final DataModel target, final Map<UUID, DataModel> dataModelMappings) {
 		super(source, target, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/cloning/DataSheetCloning.java
+++ b/src/main/java/com/supervisor/copying/cloning/DataSheetCloning.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.cloning;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractDataSheetWriter;
 import com.supervisor.domain.DataFieldOfSheet;
@@ -11,11 +12,11 @@ import com.supervisor.domain.DataSheetModel;
 
 public final class DataSheetCloning extends AbstractDataSheetWriter {
 
-	public DataSheetCloning(final DataSheetModel targetModel, final DataSheet source, final Map<Long, DataModel> dataModelMappings) {
+	public DataSheetCloning(final DataSheetModel targetModel, final DataSheet source, final Map<UUID, DataModel> dataModelMappings) {
 		super(targetModel, source, dataModelMappings);
 	}
 	
-	public DataSheetCloning(DataSheet source, DataSheet target, Map<Long, DataModel> dataModelMappings) throws IOException {
+	public DataSheetCloning(DataSheet source, DataSheet target, Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/cloning/DataSheetModelCloning.java
+++ b/src/main/java/com/supervisor/copying/cloning/DataSheetModelCloning.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.cloning;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractDataSheetModelWriter;
 import com.supervisor.domain.Activity;
@@ -10,11 +11,11 @@ import com.supervisor.domain.DataSheetModel;
 
 public final class DataSheetModelCloning extends AbstractDataSheetModelWriter {
 
-	public DataSheetModelCloning(Activity targetActivity, DataSheetModel source, Map<Long, DataModel> dataModelMappings) {
+	public DataSheetModelCloning(Activity targetActivity, DataSheetModel source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetActivity, source, dataModelMappings);
 	}
 	
-	public DataSheetModelCloning(final DataSheetModel source, final DataSheetModel target, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public DataSheetModelCloning(final DataSheetModel source, final DataSheetModel target, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}	
 }

--- a/src/main/java/com/supervisor/copying/cloning/EditableDataFieldCloning.java
+++ b/src/main/java/com/supervisor/copying/cloning/EditableDataFieldCloning.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.cloning;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractEditableDataFieldWriter;
 import com.supervisor.domain.DataModel;
@@ -12,7 +13,7 @@ import com.supervisor.domain.ListDataFieldSource;
 
 public class EditableDataFieldCloning extends AbstractEditableDataFieldWriter {
 
-	public EditableDataFieldCloning(DataSheetModel targetModel, EditableDataField source, Map<Long, DataModel> dataModelMappings) {
+	public EditableDataFieldCloning(DataSheetModel targetModel, EditableDataField source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetModel, source, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/cloning/FormularDataFieldCloning.java
+++ b/src/main/java/com/supervisor/copying/cloning/FormularDataFieldCloning.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.cloning;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractFormularDataFieldWriter;
 import com.supervisor.domain.AggregatedModel;
@@ -13,7 +14,7 @@ import com.supervisor.domain.FormularExtendedToParentExpression;
 
 public final class FormularDataFieldCloning extends AbstractFormularDataFieldWriter {
 
-	public FormularDataFieldCloning(AggregatedModel targetModel, FormularDataField source, Map<Long, DataModel> dataModelMappings) {
+	public FormularDataFieldCloning(AggregatedModel targetModel, FormularDataField source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetModel, source, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/cloning/FormularExtendedToModelExpressionCloning.java
+++ b/src/main/java/com/supervisor/copying/cloning/FormularExtendedToModelExpressionCloning.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.cloning;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractFormularExtendedToModelExpressionWriter;
 import com.supervisor.domain.DataModel;
@@ -12,7 +13,7 @@ import com.supervisor.domain.FormularExtendedToModelSource;
 
 public final class FormularExtendedToModelExpressionCloning extends AbstractFormularExtendedToModelExpressionWriter {
 
-	public FormularExtendedToModelExpressionCloning(FormularDataField targetFormular, FormularExtendedToModelExpression source, Map<Long, DataModel> dataModelMappings) {
+	public FormularExtendedToModelExpressionCloning(FormularDataField targetFormular, FormularExtendedToModelExpression source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetFormular, source, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/cloning/IndicatorCloning.java
+++ b/src/main/java/com/supervisor/copying/cloning/IndicatorCloning.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.cloning;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractIndicatorWriter;
 import com.supervisor.domain.Activity;
@@ -11,11 +12,11 @@ import com.supervisor.indicator.Indicator;
 
 public final class IndicatorCloning extends AbstractIndicatorWriter {
 
-	public IndicatorCloning(Activity targetActivity, Indicator source, Map<Long, DataModel> dataModelMappings) {
+	public IndicatorCloning(Activity targetActivity, Indicator source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetActivity, source, dataModelMappings);
 	}
 
-	public IndicatorCloning(final Indicator source, final Indicator target, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public IndicatorCloning(final Indicator source, final Indicator target, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/generating/AggregatedModelGenerating.java
+++ b/src/main/java/com/supervisor/copying/generating/AggregatedModelGenerating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.generating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractAggregatedModelWriter;
 import com.supervisor.sharing.AggregatedModelSharing;
@@ -12,15 +13,15 @@ import com.supervisor.domain.DataModel;
 
 public final class AggregatedModelGenerating extends AbstractAggregatedModelWriter {
 	
-	public AggregatedModelGenerating(final String code, final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AggregatedModelGenerating(final String code, final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(code, targetActivity, targetModel, source, dataModelMappings);
 	}
 	
-	public AggregatedModelGenerating(final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AggregatedModelGenerating(final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(targetActivity, targetModel, source, dataModelMappings);
 	}
 	
-	public AggregatedModelGenerating(final AggregatedModel source, final AggregatedModel target, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AggregatedModelGenerating(final AggregatedModel source, final AggregatedModel target, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}
 	

--- a/src/main/java/com/supervisor/copying/generating/DataFieldOfSheetGenerating.java
+++ b/src/main/java/com/supervisor/copying/generating/DataFieldOfSheetGenerating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.generating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractDataFieldOfSheetWriter;
 import com.supervisor.sharing.DataSheetSharing;
@@ -17,11 +18,11 @@ import com.supervisor.domain.impl.PxTableDataFieldOfSheetRow;
 
 public final class DataFieldOfSheetGenerating extends AbstractDataFieldOfSheetWriter {
 
-	public DataFieldOfSheetGenerating(DataFieldOfSheet source, DataFieldOfSheet target, Map<Long, DataModel> dataModelMappings) throws IOException {
+	public DataFieldOfSheetGenerating(DataFieldOfSheet source, DataFieldOfSheet target, Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}
 
-	public DataFieldOfSheetGenerating(final DataSheet targetSheet, final DataFieldOfSheet source, final Map<Long, DataModel> dataModelMappings) {
+	public DataFieldOfSheetGenerating(final DataSheet targetSheet, final DataFieldOfSheet source, final Map<UUID, DataModel> dataModelMappings) {
 		super(targetSheet, source, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/generating/DataModelGenerating.java
+++ b/src/main/java/com/supervisor/copying/generating/DataModelGenerating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.generating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractDataModelWriter;
 import com.supervisor.domain.Activity;
@@ -11,15 +12,15 @@ import com.supervisor.domain.DataSheetModel;
 
 public final class DataModelGenerating extends AbstractDataModelWriter {
 	
-	public DataModelGenerating(String code, Activity targetActivity, DataModel source, Map<Long, DataModel> dataModelMappings) {
+	public DataModelGenerating(String code, Activity targetActivity, DataModel source, Map<UUID, DataModel> dataModelMappings) {
 		super(code, targetActivity, source, dataModelMappings);
 	}
 	
-	public DataModelGenerating(Activity targetActivity, DataModel source, Map<Long, DataModel> dataModelMappings) {
+	public DataModelGenerating(Activity targetActivity, DataModel source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetActivity, source, dataModelMappings);
 	}
 	
-	public DataModelGenerating(final DataModel source, final DataModel target, final Map<Long, DataModel> dataModelMappings) {
+	public DataModelGenerating(final DataModel source, final DataModel target, final Map<UUID, DataModel> dataModelMappings) {
 		super(source, target, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/generating/DataSheetGenerating.java
+++ b/src/main/java/com/supervisor/copying/generating/DataSheetGenerating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.generating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractDataSheetWriter;
 import com.supervisor.sharing.DataSheetSharingImpl;
@@ -12,11 +13,11 @@ import com.supervisor.domain.DataSheetModel;
 
 public final class DataSheetGenerating extends AbstractDataSheetWriter {
 
-	public DataSheetGenerating(final DataSheetModel targetModel, final DataSheet source, final Map<Long, DataModel> dataModelMappings) {
+	public DataSheetGenerating(final DataSheetModel targetModel, final DataSheet source, final Map<UUID, DataModel> dataModelMappings) {
 		super(targetModel, source, dataModelMappings);
 	}
 	
-	public DataSheetGenerating(DataSheet source, DataSheet target, Map<Long, DataModel> dataModelMappings) throws IOException {
+	public DataSheetGenerating(DataSheet source, DataSheet target, Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/generating/DataSheetModelGenerating.java
+++ b/src/main/java/com/supervisor/copying/generating/DataSheetModelGenerating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.generating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractDataSheetModelWriter;
 import com.supervisor.domain.Activity;
@@ -10,11 +11,11 @@ import com.supervisor.domain.DataSheetModel;
 
 public final class DataSheetModelGenerating extends AbstractDataSheetModelWriter {
 
-	public DataSheetModelGenerating(Activity targetActivity, DataSheetModel source, Map<Long, DataModel> dataModelMappings) {
+	public DataSheetModelGenerating(Activity targetActivity, DataSheetModel source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetActivity, source, dataModelMappings);
 	}
 	
-	public DataSheetModelGenerating(final DataSheetModel source, final DataSheetModel target, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public DataSheetModelGenerating(final DataSheetModel source, final DataSheetModel target, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}	
 }

--- a/src/main/java/com/supervisor/copying/generating/EditableDataFieldGenerating.java
+++ b/src/main/java/com/supervisor/copying/generating/EditableDataFieldGenerating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.generating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.domain.impl.UserOf;
 import com.supervisor.copying.AbstractEditableDataFieldWriter;
@@ -19,7 +20,7 @@ import com.supervisor.domain.impl.PgActivities;
 
 public final class EditableDataFieldGenerating extends AbstractEditableDataFieldWriter {
 	
-	public EditableDataFieldGenerating(DataSheetModel targetModel, EditableDataField source, Map<Long, DataModel> dataModelMappings) {
+	public EditableDataFieldGenerating(DataSheetModel targetModel, EditableDataField source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetModel, source, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/generating/FormularDataFieldGenerating.java
+++ b/src/main/java/com/supervisor/copying/generating/FormularDataFieldGenerating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.generating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.domain.impl.UserOf;
 import com.supervisor.copying.AbstractFormularDataFieldWriter;
@@ -17,7 +18,7 @@ import com.supervisor.domain.impl.PgActivities;
 
 public final class FormularDataFieldGenerating extends AbstractFormularDataFieldWriter {
 
-	public FormularDataFieldGenerating(AggregatedModel targetModel, FormularDataField source, Map<Long, DataModel> dataModelMappings) {
+	public FormularDataFieldGenerating(AggregatedModel targetModel, FormularDataField source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetModel, source, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/generating/FormularExtendedToModelExpressionGenerating.java
+++ b/src/main/java/com/supervisor/copying/generating/FormularExtendedToModelExpressionGenerating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.generating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.domain.impl.UserOf;
 import com.supervisor.copying.AbstractFormularExtendedToModelExpressionWriter;
@@ -16,7 +17,7 @@ import com.supervisor.domain.impl.PgActivities;
 
 public final class FormularExtendedToModelExpressionGenerating extends AbstractFormularExtendedToModelExpressionWriter {
 
-	public FormularExtendedToModelExpressionGenerating(FormularDataField targetFormular, FormularExtendedToModelExpression source, Map<Long, DataModel> dataModelMappings) {
+	public FormularExtendedToModelExpressionGenerating(FormularDataField targetFormular, FormularExtendedToModelExpression source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetFormular, source, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/generating/IndicatorGenerating.java
+++ b/src/main/java/com/supervisor/copying/generating/IndicatorGenerating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.generating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.domain.impl.UserOf;
 import com.supervisor.copying.AbstractIndicatorWriter;
@@ -18,11 +19,11 @@ import com.supervisor.indicator.Indicator;
 
 public final class IndicatorGenerating extends AbstractIndicatorWriter {
 
-	public IndicatorGenerating(Activity targetActivity, Indicator source, Map<Long, DataModel> dataModelMappings) {
+	public IndicatorGenerating(Activity targetActivity, Indicator source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetActivity, source, dataModelMappings);
 	}
 
-	public IndicatorGenerating(final Indicator source, final Indicator target, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public IndicatorGenerating(final Indicator source, final Indicator target, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/templating/AggregatedModelTemplating.java
+++ b/src/main/java/com/supervisor/copying/templating/AggregatedModelTemplating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.templating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractAggregatedModelWriter;
 import com.supervisor.sharing.AggregatedModelSharing;
@@ -12,15 +13,15 @@ import com.supervisor.domain.DataModel;
 
 public class AggregatedModelTemplating extends AbstractAggregatedModelWriter {
 
-	public AggregatedModelTemplating(final String code, final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AggregatedModelTemplating(final String code, final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(code, targetActivity, targetModel, source, dataModelMappings);
 	}
 	
-	public AggregatedModelTemplating(final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AggregatedModelTemplating(final Activity targetActivity, final DataModel targetModel, final AggregatedModel source, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(targetActivity, targetModel, source, dataModelMappings);
 	}
 	
-	public AggregatedModelTemplating(AggregatedModel source, AggregatedModel target, Map<Long, DataModel> dataModelMappings) throws IOException {
+	public AggregatedModelTemplating(AggregatedModel source, AggregatedModel target, Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}
 	

--- a/src/main/java/com/supervisor/copying/templating/DataFieldOfSheetTemplating.java
+++ b/src/main/java/com/supervisor/copying/templating/DataFieldOfSheetTemplating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.templating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractDataFieldOfSheetWriter;
 import com.supervisor.sharing.DataSheetSharing;
@@ -17,11 +18,11 @@ import com.supervisor.domain.impl.PxTableDataFieldOfSheetRow;
 
 public final class DataFieldOfSheetTemplating extends AbstractDataFieldOfSheetWriter {
 
-	public DataFieldOfSheetTemplating(DataFieldOfSheet source, DataFieldOfSheet target, Map<Long, DataModel> dataModelMappings) throws IOException {
+	public DataFieldOfSheetTemplating(DataFieldOfSheet source, DataFieldOfSheet target, Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}
 
-	public DataFieldOfSheetTemplating(final DataSheet targetSheet, final DataFieldOfSheet source, final Map<Long, DataModel> dataModelMappings) {
+	public DataFieldOfSheetTemplating(final DataSheet targetSheet, final DataFieldOfSheet source, final Map<UUID, DataModel> dataModelMappings) {
 		super(targetSheet, source, dataModelMappings);
 	}
 	

--- a/src/main/java/com/supervisor/copying/templating/DataModelTemplating.java
+++ b/src/main/java/com/supervisor/copying/templating/DataModelTemplating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.templating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractDataModelWriter;
 import com.supervisor.domain.Activity;
@@ -11,15 +12,15 @@ import com.supervisor.domain.DataSheetModel;
 
 public final class DataModelTemplating extends AbstractDataModelWriter {
 
-	public DataModelTemplating(String code, Activity targetActivity, DataModel source, Map<Long, DataModel> dataModelMappings) {
+	public DataModelTemplating(String code, Activity targetActivity, DataModel source, Map<UUID, DataModel> dataModelMappings) {
 		super(code, targetActivity, source, dataModelMappings);
 	}
 	
-	public DataModelTemplating(Activity targetActivity, DataModel source, Map<Long, DataModel> dataModelMappings) {
+	public DataModelTemplating(Activity targetActivity, DataModel source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetActivity, source, dataModelMappings);
 	}
 	
-	public DataModelTemplating(final DataModel source, final DataModel target, final Map<Long, DataModel> dataModelMappings) {
+	public DataModelTemplating(final DataModel source, final DataModel target, final Map<UUID, DataModel> dataModelMappings) {
 		super(source, target, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/templating/DataSheetModelTemplating.java
+++ b/src/main/java/com/supervisor/copying/templating/DataSheetModelTemplating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.templating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractDataSheetModelWriter;
 import com.supervisor.domain.Activity;
@@ -10,11 +11,11 @@ import com.supervisor.domain.DataSheetModel;
 
 public final class DataSheetModelTemplating extends AbstractDataSheetModelWriter {
 
-	public DataSheetModelTemplating(Activity targetActivity, DataSheetModel source, Map<Long, DataModel> dataModelMappings) {
+	public DataSheetModelTemplating(Activity targetActivity, DataSheetModel source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetActivity, source, dataModelMappings);
 	}
 	
-	public DataSheetModelTemplating(final DataSheetModel source, final DataSheetModel target, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public DataSheetModelTemplating(final DataSheetModel source, final DataSheetModel target, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}
 	

--- a/src/main/java/com/supervisor/copying/templating/DataSheetTemplating.java
+++ b/src/main/java/com/supervisor/copying/templating/DataSheetTemplating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.templating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractDataSheetWriter;
 import com.supervisor.sharing.DataSheetSharingImpl;
@@ -12,11 +13,11 @@ import com.supervisor.domain.DataSheetModel;
 
 public final class DataSheetTemplating extends AbstractDataSheetWriter {
 
-	public DataSheetTemplating(final DataSheetModel targetModel, final DataSheet source, final Map<Long, DataModel> dataModelMappings) {
+	public DataSheetTemplating(final DataSheetModel targetModel, final DataSheet source, final Map<UUID, DataModel> dataModelMappings) {
 		super(targetModel, source, dataModelMappings);
 	}
 	
-	public DataSheetTemplating(DataSheet source, DataSheet target, Map<Long, DataModel> dataModelMappings) throws IOException {
+	public DataSheetTemplating(DataSheet source, DataSheet target, Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}
 	

--- a/src/main/java/com/supervisor/copying/templating/EditableDataFieldTemplating.java
+++ b/src/main/java/com/supervisor/copying/templating/EditableDataFieldTemplating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.templating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractEditableDataFieldWriter;
 import com.supervisor.sharing.ListDataFieldSourceSharing;
@@ -17,7 +18,7 @@ import com.supervisor.domain.ListDataFieldSource;
 
 public final class EditableDataFieldTemplating extends AbstractEditableDataFieldWriter {
 
-	public EditableDataFieldTemplating(DataSheetModel targetModel, EditableDataField source, Map<Long, DataModel> dataModelMappings) {
+	public EditableDataFieldTemplating(DataSheetModel targetModel, EditableDataField source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetModel, source, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/templating/FormularDataFieldTemplating.java
+++ b/src/main/java/com/supervisor/copying/templating/FormularDataFieldTemplating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.templating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.domain.impl.OwnerOf;
 import com.supervisor.copying.AbstractFormularDataFieldWriter;
@@ -16,7 +17,7 @@ import com.supervisor.domain.FormularExtendedToParentExpression;
 
 public final class FormularDataFieldTemplating extends AbstractFormularDataFieldWriter {
 
-	public FormularDataFieldTemplating(AggregatedModel targetModel, FormularDataField source, Map<Long, DataModel> dataModelMappings) {
+	public FormularDataFieldTemplating(AggregatedModel targetModel, FormularDataField source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetModel, source, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/templating/FormularExtendedToModelExpressionTemplating.java
+++ b/src/main/java/com/supervisor/copying/templating/FormularExtendedToModelExpressionTemplating.java
@@ -2,6 +2,7 @@ package com.supervisor.copying.templating;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.domain.impl.OwnerOf;
 import com.supervisor.copying.AbstractFormularExtendedToModelExpressionWriter;
@@ -15,7 +16,7 @@ import com.supervisor.domain.FormularExtendedToModelSource;
 
 public final class FormularExtendedToModelExpressionTemplating extends AbstractFormularExtendedToModelExpressionWriter {
 
-	public FormularExtendedToModelExpressionTemplating(FormularDataField targetFormular, FormularExtendedToModelExpression source, final Map<Long, DataModel> dataModelMappings) {
+	public FormularExtendedToModelExpressionTemplating(FormularDataField targetFormular, FormularExtendedToModelExpression source, final Map<UUID, DataModel> dataModelMappings) {
 		super(targetFormular, source, dataModelMappings);
 	}
 

--- a/src/main/java/com/supervisor/copying/templating/IndicatorTemplating.java
+++ b/src/main/java/com/supervisor/copying/templating/IndicatorTemplating.java
@@ -3,6 +3,7 @@ package com.supervisor.copying.templating;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.copying.AbstractIndicatorWriter;
 import com.supervisor.sharing.AggregatedModelUniqueSharing;
@@ -19,11 +20,11 @@ import com.supervisor.indicator.IndicatorTemplate;
 
 public final class IndicatorTemplating extends AbstractIndicatorWriter {
 
-	public IndicatorTemplating(Activity targetActivity, Indicator source, Map<Long, DataModel> dataModelMappings) {
+	public IndicatorTemplating(Activity targetActivity, Indicator source, Map<UUID, DataModel> dataModelMappings) {
 		super(targetActivity, source, dataModelMappings);
 	}
 
-	public IndicatorTemplating(final Indicator source, final Indicator target, final Map<Long, DataModel> dataModelMappings) throws IOException {
+	public IndicatorTemplating(final Indicator source, final Indicator target, final Map<UUID, DataModel> dataModelMappings) throws IOException {
 		super(source, target, dataModelMappings);
 	}
 	

--- a/src/main/java/com/supervisor/domain/Activity.java
+++ b/src/main/java/com/supervisor/domain/Activity.java
@@ -80,7 +80,7 @@ public interface Activity extends com.supervisor.sdk.datasource.Recordable {
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}
@@ -92,7 +92,7 @@ public interface Activity extends com.supervisor.sdk.datasource.Recordable {
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
@@ -104,19 +104,13 @@ public interface Activity extends com.supervisor.sdk.datasource.Recordable {
 		}
 		
 		@Override
-		public Long id() {
+		public UUID id() {
 			
 			return null;
 		}
 		
 		@Override
-		public UUID guid() throws IOException {
-			
-			return null;
-		}
-		
-		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/ActivityTemplate.java
+++ b/src/main/java/com/supervisor/domain/ActivityTemplate.java
@@ -50,7 +50,7 @@ public interface ActivityTemplate extends Activity {
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			return null;
 		}
 		
@@ -60,7 +60,7 @@ public interface ActivityTemplate extends Activity {
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			return null;
 		}
 		
@@ -70,17 +70,12 @@ public interface ActivityTemplate extends Activity {
 		}
 		
 		@Override
-		public Long id() {
-			return 0L;
-		}
-		
-		@Override
-		public UUID guid() throws IOException {
+		public UUID id() {
 			return null;
 		}
 		
 		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			return null;
 		}
 		

--- a/src/main/java/com/supervisor/domain/ActivityTemplateParamRequest.java
+++ b/src/main/java/com/supervisor/domain/ActivityTemplateParamRequest.java
@@ -1,7 +1,9 @@
 package com.supervisor.domain;
 
+import java.util.UUID;
+
 public interface ActivityTemplateParamRequest {
-	Long modelId();
+	UUID modelId();
 	String code();
 	String value();
 }

--- a/src/main/java/com/supervisor/domain/AggregatedModel.java
+++ b/src/main/java/com/supervisor/domain/AggregatedModel.java
@@ -65,12 +65,12 @@ public interface AggregatedModel extends DataModel, Sharable {
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			return null;
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			return null;
 		}
 		
@@ -80,17 +80,12 @@ public interface AggregatedModel extends DataModel, Sharable {
 		}
 		
 		@Override
-		public Long id() {
-			return 0L;
-		}
-		
-		@Override
-		public UUID guid() throws IOException {
+		public UUID id() {
 			return null;
 		}
 		
 		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			return null;
 		}
 		

--- a/src/main/java/com/supervisor/domain/Currency.java
+++ b/src/main/java/com/supervisor/domain/Currency.java
@@ -4,13 +4,16 @@ import com.supervisor.sdk.datasource.Recordable;
 import com.supervisor.sdk.metadata.Field;
 
 import java.io.IOException;
+import java.util.UUID;
 
 @com.supervisor.sdk.metadata.Recordable(
 	name="base_currency", 
 	label="Devise"
 )
 public interface Currency extends Recordable {
-	
+
+	UUID EUR_ID = UUID.fromString("75932d0b-f391-4def-a2e0-854e45376f07");
+
 	@Field(label="Code")
 	String code() throws IOException;
 	

--- a/src/main/java/com/supervisor/domain/DataField.java
+++ b/src/main/java/com/supervisor/domain/DataField.java
@@ -43,13 +43,7 @@ public interface DataField extends com.supervisor.sdk.datasource.Recordable {
 	DataField EMPTY = new DataField() {
 
 		@Override
-		public Long id() {
-			return 0L;
-		}
-
-		@Override
-		public UUID guid() throws IOException {
-			
+		public UUID id() {
 			return null;
 		}
 
@@ -60,7 +54,7 @@ public interface DataField extends com.supervisor.sdk.datasource.Recordable {
 		}
 
 		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}
@@ -72,13 +66,13 @@ public interface DataField extends com.supervisor.sdk.datasource.Recordable {
 		}
 
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
 
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/DataFieldOfSheet.java
+++ b/src/main/java/com/supervisor/domain/DataFieldOfSheet.java
@@ -106,13 +106,7 @@ public interface DataFieldOfSheet extends EditableDataField {
 		}
 
 		@Override
-		public Long id() {
-			
-			return null;
-		}
-
-		@Override
-		public UUID guid() throws IOException {
+		public UUID id() {
 			
 			return null;
 		}
@@ -124,7 +118,7 @@ public interface DataFieldOfSheet extends EditableDataField {
 		}
 
 		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}
@@ -136,13 +130,13 @@ public interface DataFieldOfSheet extends EditableDataField {
 		}
 
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
 
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/DataFields.java
+++ b/src/main/java/com/supervisor/domain/DataFields.java
@@ -1,13 +1,14 @@
 package com.supervisor.domain;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainSet;
 import com.supervisor.sdk.utils.CodeContainer;
 
 public interface DataFields extends DomainSet<DataField, DataFields>, CodeContainer {
 	
-	Long add(String code, String name, DataFieldType type, DataFieldStyle style, String description) throws IOException;
+	UUID add(String code, String name, DataFieldType type, DataFieldStyle style, String description) throws IOException;
 	DataField get(String code) throws IOException;
 	
 	EditableDataFields editables() throws IOException;

--- a/src/main/java/com/supervisor/domain/DataLink.java
+++ b/src/main/java/com/supervisor/domain/DataLink.java
@@ -59,12 +59,12 @@ public interface DataLink extends com.supervisor.sdk.datasource.Recordable, Shar
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			return null;
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			return null;
 		}
 		
@@ -74,17 +74,12 @@ public interface DataLink extends com.supervisor.sdk.datasource.Recordable, Shar
 		}
 		
 		@Override
-		public Long id() {
-			return 0L;
-		}
-		
-		@Override
-		public UUID guid() throws IOException {
+		public UUID id() {
 			return null;
 		}
 		
 		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			return null;
 		}
 		

--- a/src/main/java/com/supervisor/domain/DataModel.java
+++ b/src/main/java/com/supervisor/domain/DataModel.java
@@ -59,13 +59,7 @@ public interface DataModel extends com.supervisor.sdk.datasource.Recordable, Int
 	DataModel EMPTY = new DataModel() {
 
 		@Override
-		public Long id() {
-			
-			return null;
-		}
-
-		@Override
-		public UUID guid() throws IOException {
+		public UUID id() {
 			
 			return null;
 		}
@@ -77,7 +71,7 @@ public interface DataModel extends com.supervisor.sdk.datasource.Recordable, Int
 		}
 
 		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}
@@ -89,13 +83,13 @@ public interface DataModel extends com.supervisor.sdk.datasource.Recordable, Int
 		}
 
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
 
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/DataSheet.java
+++ b/src/main/java/com/supervisor/domain/DataSheet.java
@@ -46,12 +46,12 @@ public interface DataSheet extends com.supervisor.sdk.datasource.Recordable, Sha
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			return null;
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			return null;
 		}
 		
@@ -61,17 +61,12 @@ public interface DataSheet extends com.supervisor.sdk.datasource.Recordable, Sha
 		}
 		
 		@Override
-		public Long id() {
+		public UUID id() {
 			return null;
 		}
 		
 		@Override
-		public UUID guid() throws IOException {
-			return null;
-		}
-		
-		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			return null;
 		}
 		

--- a/src/main/java/com/supervisor/domain/DataSheetModel.java
+++ b/src/main/java/com/supervisor/domain/DataSheetModel.java
@@ -90,13 +90,7 @@ public interface DataSheetModel extends DataModel, Sharable {
 		}
 
 		@Override
-		public Long id() {
-			return 0L;
-		}
-
-		@Override
-		public UUID guid() throws IOException {
-			
+		public UUID id() {
 			return null;
 		}
 
@@ -107,7 +101,7 @@ public interface DataSheetModel extends DataModel, Sharable {
 		}
 
 		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}
@@ -119,13 +113,13 @@ public interface DataSheetModel extends DataModel, Sharable {
 		}
 
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
 
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/ExpressionArg.java
+++ b/src/main/java/com/supervisor/domain/ExpressionArg.java
@@ -44,7 +44,7 @@ public interface ExpressionArg extends com.supervisor.sdk.datasource.Recordable 
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}
@@ -62,7 +62,7 @@ public interface ExpressionArg extends com.supervisor.sdk.datasource.Recordable 
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
@@ -74,19 +74,13 @@ public interface ExpressionArg extends com.supervisor.sdk.datasource.Recordable 
 		}
 		
 		@Override
-		public Long id() {
+		public UUID id() {
 			
 			return null;
 		}
 		
 		@Override
-		public UUID guid() throws IOException {
-			
-			return null;
-		}
-		
-		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/ExtendedDataSheetModels.java
+++ b/src/main/java/com/supervisor/domain/ExtendedDataSheetModels.java
@@ -2,9 +2,10 @@ package com.supervisor.domain;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 public interface ExtendedDataSheetModels {
 	List<DataSheetModel> items() throws IOException;
-	DataSheetModel get(Long id) throws IOException;
+	DataSheetModel get(UUID id) throws IOException;
 	boolean contains(DataSheetModel item) throws IOException;
 }

--- a/src/main/java/com/supervisor/domain/FormularCondition.java
+++ b/src/main/java/com/supervisor/domain/FormularCondition.java
@@ -54,13 +54,7 @@ public interface FormularCondition extends com.supervisor.sdk.datasource.Recorda
 		}
 
 		@Override
-		public Long id() {
-			return 0L;
-		}
-
-		@Override
-		public UUID guid() throws IOException {
-			
+		public UUID id() {
 			return null;
 		}
 
@@ -71,7 +65,7 @@ public interface FormularCondition extends com.supervisor.sdk.datasource.Recorda
 		}
 
 		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}
@@ -83,13 +77,13 @@ public interface FormularCondition extends com.supervisor.sdk.datasource.Recorda
 		}
 
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
 
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/FormularDataField.java
+++ b/src/main/java/com/supervisor/domain/FormularDataField.java
@@ -60,13 +60,7 @@ public interface FormularDataField extends DataField {
 		}
 
 		@Override
-		public Long id() {
-
-			return null;
-		}
-
-		@Override
-		public UUID guid() throws IOException {
+		public UUID id() {
 
 			return null;
 		}
@@ -78,7 +72,7 @@ public interface FormularDataField extends DataField {
 		}
 
 		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 
 			return null;
 		}
@@ -90,13 +84,13 @@ public interface FormularDataField extends DataField {
 		}
 
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 
 			return null;
 		}
 
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/FormularExtendedToModelSource.java
+++ b/src/main/java/com/supervisor/domain/FormularExtendedToModelSource.java
@@ -68,13 +68,7 @@ public interface FormularExtendedToModelSource extends com.supervisor.sdk.dataso
 	final FormularExtendedToModelSource EMPTY = new FormularExtendedToModelSource() {
 
 		@Override
-		public Long id() {
-			
-			return null;
-		}
-
-		@Override
-		public UUID guid() throws IOException {
+		public UUID id() {
 			
 			return null;
 		}
@@ -86,8 +80,8 @@ public interface FormularExtendedToModelSource extends com.supervisor.sdk.dataso
 		}
 
 		@Override
-		public Long creatorId() throws IOException {
-			
+		public UUID creatorId() throws IOException {
+
 			return null;
 		}
 
@@ -98,13 +92,13 @@ public interface FormularExtendedToModelSource extends com.supervisor.sdk.dataso
 		}
 
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
 
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/FormularExtendedToParentSource.java
+++ b/src/main/java/com/supervisor/domain/FormularExtendedToParentSource.java
@@ -72,13 +72,7 @@ public interface FormularExtendedToParentSource extends com.supervisor.sdk.datas
 		}
 
 		@Override
-		public Long id() {
-			
-			return null;
-		}
-
-		@Override
-		public UUID guid() throws IOException {
+		public UUID id() {
 			
 			return null;
 		}
@@ -90,7 +84,7 @@ public interface FormularExtendedToParentSource extends com.supervisor.sdk.datas
 		}
 
 		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}
@@ -102,13 +96,13 @@ public interface FormularExtendedToParentSource extends com.supervisor.sdk.datas
 		}
 
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
 
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/ListDataField.java
+++ b/src/main/java/com/supervisor/domain/ListDataField.java
@@ -107,13 +107,7 @@ public interface ListDataField extends EditableDataField, MustEditOnceOption, Re
 		}
 
 		@Override
-		public Long id() {
-			
-			return 0L;
-		}
-
-		@Override
-		public UUID guid() throws IOException {
+		public UUID id() {
 			
 			return null;
 		}
@@ -125,7 +119,7 @@ public interface ListDataField extends EditableDataField, MustEditOnceOption, Re
 		}
 
 		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}
@@ -137,13 +131,13 @@ public interface ListDataField extends EditableDataField, MustEditOnceOption, Re
 		}
 
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
 
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/ListDataFieldSource.java
+++ b/src/main/java/com/supervisor/domain/ListDataFieldSource.java
@@ -66,7 +66,7 @@ public interface ListDataFieldSource extends com.supervisor.sdk.datasource.Recor
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}
@@ -84,7 +84,7 @@ public interface ListDataFieldSource extends com.supervisor.sdk.datasource.Recor
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
@@ -96,19 +96,13 @@ public interface ListDataFieldSource extends com.supervisor.sdk.datasource.Recor
 		}
 		
 		@Override
-		public Long id() {
+		public UUID id() {
 			
 			return null;
 		}
 		
 		@Override
-		public UUID guid() throws IOException {
-			
-			return null;
-		}
-		
-		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/ParamDataField.java
+++ b/src/main/java/com/supervisor/domain/ParamDataField.java
@@ -69,13 +69,7 @@ public interface ParamDataField extends DataField {
 		}
 
 		@Override
-		public Long id() {
-			
-			return 0L;
-		}
-
-		@Override
-		public UUID guid() throws IOException {
+		public UUID id() {
 			
 			return null;
 		}
@@ -87,7 +81,7 @@ public interface ParamDataField extends DataField {
 		}
 
 		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}
@@ -99,13 +93,13 @@ public interface ParamDataField extends DataField {
 		}
 
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
 
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/Params.java
+++ b/src/main/java/com/supervisor/domain/Params.java
@@ -1,8 +1,9 @@
 package com.supervisor.domain;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public interface Params {
-	boolean contains(long id) throws IOException;
-	ParamDataField get(long id) throws IOException;
+	boolean contains(UUID id) throws IOException;
+	ParamDataField get(UUID id) throws IOException;
 }

--- a/src/main/java/com/supervisor/domain/PlanSubscriptionContract.java
+++ b/src/main/java/com/supervisor/domain/PlanSubscriptionContract.java
@@ -37,7 +37,7 @@ public interface PlanSubscriptionContract extends SubscriptionContract {
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}
@@ -55,7 +55,7 @@ public interface PlanSubscriptionContract extends SubscriptionContract {
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
@@ -67,19 +67,13 @@ public interface PlanSubscriptionContract extends SubscriptionContract {
 		}
 		
 		@Override
-		public Long id() {
+		public UUID id() {
 			
 			return null;
 		}
 		
 		@Override
-		public UUID guid() throws IOException {
-			
-			return null;
-		}
-		
-		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/Profile.java
+++ b/src/main/java/com/supervisor/domain/Profile.java
@@ -72,12 +72,7 @@ public interface Profile extends Recordable {
 		}
 
 		@Override
-		public Long id() {
-			return null;
-		}
-
-		@Override
-		public UUID guid() throws IOException {
+		public UUID id() {
 			return null;
 		}
 
@@ -87,7 +82,7 @@ public interface Profile extends Recordable {
 		}
 
 		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			return null;
 		}
 
@@ -97,12 +92,12 @@ public interface Profile extends Recordable {
 		}
 
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			return null;
 		}
 
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			return null;
 		}
 

--- a/src/main/java/com/supervisor/domain/Resources.java
+++ b/src/main/java/com/supervisor/domain/Resources.java
@@ -3,9 +3,10 @@ package com.supervisor.domain;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface Resources {
 	List<Resource> items() throws IOException;
-	Optional<Resource> resourceIfPresent(ResourceType type, Long id) throws IOException;
-	Resource resource(ResourceType type, Long id) throws IOException;
+	Optional<Resource> resourceIfPresent(ResourceType type, UUID id) throws IOException;
+	Resource resource(ResourceType type, UUID id) throws IOException;
 }

--- a/src/main/java/com/supervisor/domain/SharedResource.java
+++ b/src/main/java/com/supervisor/domain/SharedResource.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.metadata.Field;
 import com.supervisor.sdk.metadata.Relation;
@@ -14,7 +15,7 @@ public interface SharedResource extends com.supervisor.sdk.datasource.Recordable
 	String name() throws IOException;
 	
 	@Field(label="ID de la ressource")
-	Long resourceId() throws IOException;
+	UUID resourceId() throws IOException;
 	
 	@Field(label="Type")
 	ResourceType type() throws IOException;

--- a/src/main/java/com/supervisor/domain/Sharing.java
+++ b/src/main/java/com/supervisor/domain/Sharing.java
@@ -2,12 +2,13 @@ package com.supervisor.domain;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainSet;
 
 public interface Sharing extends DomainSet<SharedResource, Sharing> {
-	SharedResource share(Long resourceId, ResourceType type, User subscriber) throws IOException;
-	SharedResource share(Long resourceId, ResourceType type, String email) throws IOException;
+	SharedResource share(UUID resourceId, ResourceType type, User subscriber) throws IOException;
+	SharedResource share(UUID resourceId, ResourceType type, String email) throws IOException;
 	void unsubscribe(SharedResource resource) throws IOException;
-	Optional<SharedResource> resource(Long resourceId, ResourceType type, User subscriber) throws IOException;
+	Optional<SharedResource> resource(UUID resourceId, ResourceType type, User subscriber) throws IOException;
 }

--- a/src/main/java/com/supervisor/domain/SimpleDataField.java
+++ b/src/main/java/com/supervisor/domain/SimpleDataField.java
@@ -89,13 +89,7 @@ public interface SimpleDataField extends EditableDataField, TakeLastValueOption,
 		}
 
 		@Override
-		public Long id() {
-			
-			return 0L;
-		}
-
-		@Override
-		public UUID guid() throws IOException {
+		public UUID id() {
 			
 			return null;
 		}
@@ -107,7 +101,7 @@ public interface SimpleDataField extends EditableDataField, TakeLastValueOption,
 		}
 
 		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}
@@ -119,13 +113,13 @@ public interface SimpleDataField extends EditableDataField, TakeLastValueOption,
 		}
 
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
 
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/domain/Subscription.java
+++ b/src/main/java/com/supervisor/domain/Subscription.java
@@ -2,10 +2,11 @@ package com.supervisor.domain;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainSet;
 
 public interface Subscription extends DomainSet<SharedResource, Subscription> {
 	void unsubscribe(SharedResource resource) throws IOException;
-	Optional<SharedResource> resource(Long resourceId, ResourceType type) throws IOException;
+	Optional<SharedResource> resource(UUID resourceId, ResourceType type) throws IOException;
 }

--- a/src/main/java/com/supervisor/domain/User.java
+++ b/src/main/java/com/supervisor/domain/User.java
@@ -24,6 +24,9 @@ import java.util.UUID;
 )
 public interface User extends Person {
 
+	UUID ADMIN_ID = UUID.fromString("8c996d5d-ed4f-4fc2-8bea-4fcd4c9ef625");
+	UUID ANONYMOUS_ID = UUID.fromString("337b67c9-7232-436f-8978-30968b969b33");
+
 	@Field(label="Mot de passe")
 	String password() throws IOException;
 	
@@ -70,7 +73,7 @@ public interface User extends Person {
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			return null;
 		}
 		
@@ -80,7 +83,7 @@ public interface User extends Person {
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			return null;
 		}
 		
@@ -90,17 +93,12 @@ public interface User extends Person {
 		}
 		
 		@Override
-		public Long id() {
+		public UUID id() {
 			return null;
 		}
 		
 		@Override
-		public UUID guid() throws IOException {
-			return null;
-		}
-		
-		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			return null;
 		}
 		

--- a/src/main/java/com/supervisor/domain/impl/ActivityNotificationImpl.java
+++ b/src/main/java/com/supervisor/domain/impl/ActivityNotificationImpl.java
@@ -50,7 +50,7 @@ public final class ActivityNotificationImpl implements ActivityNotification {
 							
 							final ActivityData activityData; 
 							
-							if(activityDatas.stream().noneMatch(c -> c.getId() == activity.id())) {
+							if(activityDatas.stream().noneMatch(c -> c.getId().equals(activity.id()))) {
 								activityData = new ActivityData(activity.id(), new ArrayList<>());
 								activityDatas.add(activityData);
 							}else {

--- a/src/main/java/com/supervisor/domain/impl/ActivityWrap.java
+++ b/src/main/java/com/supervisor/domain/impl/ActivityWrap.java
@@ -31,13 +31,8 @@ public class ActivityWrap implements Activity {
 	}
 	
 	@Override
-	public Long id() {
+	public UUID id() {
 		return origin.id();
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		return origin.guid();
 	}
 
 	@Override
@@ -46,7 +41,7 @@ public class ActivityWrap implements Activity {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return origin.creatorId();
 	}
 
@@ -56,12 +51,12 @@ public class ActivityWrap implements Activity {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return origin.lastModifierId();
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		return origin.ownerId();
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/DataFieldOfSheetWrap.java
+++ b/src/main/java/com/supervisor/domain/impl/DataFieldOfSheetWrap.java
@@ -110,13 +110,8 @@ public class DataFieldOfSheetWrap implements DataFieldOfSheet {
 	}
 
 	@Override
-	public Long id() {
+	public UUID id() {
 		return origin.id();
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		return origin.guid();
 	}
 
 	@Override
@@ -125,7 +120,7 @@ public class DataFieldOfSheetWrap implements DataFieldOfSheet {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return origin.creatorId();
 	}
 
@@ -135,12 +130,12 @@ public class DataFieldOfSheetWrap implements DataFieldOfSheet {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return origin.lastModifierId();
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		return origin.ownerId();
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/DataFieldWrap.java
+++ b/src/main/java/com/supervisor/domain/impl/DataFieldWrap.java
@@ -58,13 +58,8 @@ public class DataFieldWrap implements DataField {
 	}
 
 	@Override
-	public Long id() {
+	public UUID id() {
 		return origin.id();
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		return origin.guid();
 	}
 
 	@Override
@@ -73,7 +68,7 @@ public class DataFieldWrap implements DataField {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return origin.creatorId();
 	}
 
@@ -83,12 +78,12 @@ public class DataFieldWrap implements DataField {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return origin.lastModifierId();
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		return origin.ownerId();
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/DataModelWrap.java
+++ b/src/main/java/com/supervisor/domain/impl/DataModelWrap.java
@@ -23,13 +23,8 @@ public class DataModelWrap implements DataModel {
 	}
 	
 	@Override
-	public Long id() {
+	public UUID id() {
 		return origin.id();
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		return origin.guid();
 	}
 
 	@Override
@@ -38,7 +33,7 @@ public class DataModelWrap implements DataModel {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return origin.creatorId();
 	}
 
@@ -48,12 +43,12 @@ public class DataModelWrap implements DataModel {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return origin.lastModifierId();
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		return origin.ownerId();
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/DataSheetModelChildren.java
+++ b/src/main/java/com/supervisor/domain/impl/DataSheetModelChildren.java
@@ -2,6 +2,7 @@ package com.supervisor.domain.impl;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.utils.ListOfUniqueRecord;
 import com.supervisor.domain.DataModel;
@@ -41,7 +42,7 @@ public final class DataSheetModelChildren implements ExtendedDataSheetModels {
 	}
 
 	@Override
-	public DataSheetModel get(Long id) throws IOException {
+	public DataSheetModel get(UUID id) throws IOException {
 		for (DataSheetModel m : items()) {
 			if(m.id().equals(id)) {
 				return m;

--- a/src/main/java/com/supervisor/domain/impl/DataSheetModelParents.java
+++ b/src/main/java/com/supervisor/domain/impl/DataSheetModelParents.java
@@ -2,6 +2,7 @@ package com.supervisor.domain.impl;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.utils.ListOfUniqueRecord;
 import com.supervisor.domain.DataModel;
@@ -50,7 +51,7 @@ public final class DataSheetModelParents implements ExtendedDataSheetModels {
 	}
 	
 	@Override
-	public DataSheetModel get(Long id) throws IOException {
+	public DataSheetModel get(UUID id) throws IOException {
 		for (DataSheetModel m : items()) {
 			if(m.id().equals(id)) {
 				return m;

--- a/src/main/java/com/supervisor/domain/impl/DmMembership.java
+++ b/src/main/java/com/supervisor/domain/impl/DmMembership.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
+import java.util.UUID;
 
 public final class DmMembership implements Membership {
 
@@ -56,7 +57,7 @@ public final class DmMembership implements Membership {
 	public DmMembership(final Base base) throws IOException {
 		this(
 			base, 
-			new DmUser(base, 2L)
+			new DmUser(base, User.ANONYMOUS_ID)
 		);
 	}
 	

--- a/src/main/java/com/supervisor/domain/impl/DmPersons.java
+++ b/src/main/java/com/supervisor/domain/impl/DmPersons.java
@@ -13,6 +13,7 @@ import com.supervisor.sdk.datasource.Record;
 import com.supervisor.sdk.datasource.RecordSet;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public final class DmPersons extends DomainRecordables<Person, Persons> implements Persons {
 
@@ -44,10 +45,10 @@ public final class DmPersons extends DomainRecordables<Person, Persons> implemen
 						      		  .entryOf(Person::isCompany, false)
 						      		  .entryOf(Person::photo, defaultPhoto)
 						      		  .entryOf(Person::timeZoneId, user.timeZoneId())
-						      		  .entryOf(Person::preferredLanguage, 1) // English
+						      		  .entryOf(Person::preferredLanguage, UUID.fromString("602667bc-8014-4a02-be12-164a8e1c29cb")) // English
 						      		  .entryOf(Person::address, address.id())
 						      		  .entryOf(Person::billingAddress, billingAddress.id())
-						      		  .entryOf(Person::preferredCurrency, 2) // Euro
+						      		  .entryOf(Person::preferredCurrency, UUID.fromString("75932d0b-f391-4def-a2e0-854e45376f07")) // Euro
 						      		  .add();
 		
 		return domainOf(record);

--- a/src/main/java/com/supervisor/domain/impl/DmUser.java
+++ b/src/main/java/com/supervisor/domain/impl/DmUser.java
@@ -30,6 +30,7 @@ import java.time.LocalDateTime;
 import java.time.format.FormatStyle;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.UUID;
 
 public final class DmUser extends DomainRecordable<User> implements User {
 
@@ -37,7 +38,7 @@ public final class DmUser extends DomainRecordable<User> implements User {
 	
 	private final Person origin;
 	
-	public DmUser(final Base base, long userId) throws IOException {
+	public DmUser(final Base base, final UUID userId) throws IOException {
 		super(base.select(User.class, userId));
 		this.origin = new DmPerson(base.select(Person.class, userId));
 	}
@@ -91,7 +92,7 @@ public final class DmUser extends DomainRecordable<User> implements User {
 			throw new IOException(e);
 		}
 		
-		return ownerId == record.id();
+		return ownerId.equals(record.id());
 	}
 
 	@Override
@@ -235,12 +236,12 @@ public final class DmUser extends DomainRecordable<User> implements User {
 
 	@Override
 	public boolean isAnonymous() throws IOException {
-		return id().equals(2L);
+		return id().equals(User.ANONYMOUS_ID);
 	}
 
 	@Override
 	public boolean isAdmin() throws IOException {
-		return id().equals(1L);
+		return id().equals(User.ADMIN_ID);
 	}
 
 	@Override

--- a/src/main/java/com/supervisor/domain/impl/FieldDate.java
+++ b/src/main/java/com/supervisor/domain/impl/FieldDate.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.supervisor.domain.User;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.datasource.RecordSet;
 import com.supervisor.sdk.datasource.Recordable;
@@ -16,12 +17,7 @@ import com.supervisor.domain.DataModel;
 public final class FieldDate implements DataField {
 	
 	@Override
-	public Long id() {
-		return -1L;
-	}
-
-	@Override
-	public UUID guid() throws IOException {
+	public UUID id() {
 		return UUID.randomUUID();
 	}
 
@@ -31,8 +27,8 @@ public final class FieldDate implements DataField {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
-		return 1L;
+	public UUID creatorId() throws IOException {
+		return User.ADMIN_ID;
 	}
 
 	@Override
@@ -41,13 +37,13 @@ public final class FieldDate implements DataField {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
-		return 1L;
+	public UUID lastModifierId() throws IOException {
+		return User.ADMIN_ID;
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
-		return 1L;
+	public UUID ownerId() throws IOException {
+		return User.ADMIN_ID;
 	}
 
 	@Override

--- a/src/main/java/com/supervisor/domain/impl/FieldID.java
+++ b/src/main/java/com/supervisor/domain/impl/FieldID.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.supervisor.domain.User;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.datasource.RecordSet;
 import com.supervisor.sdk.datasource.Recordable;
@@ -16,12 +17,7 @@ import com.supervisor.domain.DataModel;
 public final class FieldID implements DataField {
 	
 	@Override
-	public Long id() {
-		return -2L;
-	}
-
-	@Override
-	public UUID guid() throws IOException {
+	public UUID id() {
 		return UUID.randomUUID();
 	}
 
@@ -31,8 +27,8 @@ public final class FieldID implements DataField {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
-		return 1L;
+	public UUID creatorId() throws IOException {
+		return User.ADMIN_ID;
 	}
 
 	@Override
@@ -41,13 +37,13 @@ public final class FieldID implements DataField {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
-		return 1L;
+	public UUID lastModifierId() throws IOException {
+		return User.ADMIN_ID;
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
-		return 1L;
+	public UUID ownerId() throws IOException {
+		return User.ADMIN_ID;
 	}
 
 	@Override

--- a/src/main/java/com/supervisor/domain/impl/GeneratedListDataFieldOfSheet.java
+++ b/src/main/java/com/supervisor/domain/impl/GeneratedListDataFieldOfSheet.java
@@ -74,13 +74,8 @@ public final class GeneratedListDataFieldOfSheet implements ListDataFieldOfSheet
 	}
 
 	@Override
-	public Long id() {
-		return 0L;
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		return this.origin.guid();
+	public UUID id() {
+		return null;
 	}
 
 	@Override
@@ -89,7 +84,7 @@ public final class GeneratedListDataFieldOfSheet implements ListDataFieldOfSheet
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return this.origin.creatorId();
 	}
 
@@ -99,12 +94,12 @@ public final class GeneratedListDataFieldOfSheet implements ListDataFieldOfSheet
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return this.origin.lastModifierId();
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		return this.origin.ownerId();
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/GeneratedMappedDataField.java
+++ b/src/main/java/com/supervisor/domain/impl/GeneratedMappedDataField.java
@@ -30,12 +30,7 @@ public final class GeneratedMappedDataField implements MappedDataField {
 	}
 
 	@Override
-	public Long id() {
-		return 0L;
-	}
-
-	@Override
-	public UUID guid() throws IOException {
+	public UUID id() {
 		return null;
 	}
 
@@ -45,7 +40,7 @@ public final class GeneratedMappedDataField implements MappedDataField {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return null;
 	}
 
@@ -55,12 +50,12 @@ public final class GeneratedMappedDataField implements MappedDataField {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return null;
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		return null;
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/GeneratedSimpleDataFieldOfSheet.java
+++ b/src/main/java/com/supervisor/domain/impl/GeneratedSimpleDataFieldOfSheet.java
@@ -84,13 +84,8 @@ public final class GeneratedSimpleDataFieldOfSheet implements SimpleDataFieldOfS
 	}
 
 	@Override
-	public Long id() {
-		return 0L;
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		return this.origin.guid();
+	public UUID id() {
+		return null;
 	}
 
 	@Override
@@ -99,7 +94,7 @@ public final class GeneratedSimpleDataFieldOfSheet implements SimpleDataFieldOfS
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return this.origin.creatorId();
 	}
 
@@ -109,12 +104,12 @@ public final class GeneratedSimpleDataFieldOfSheet implements SimpleDataFieldOfS
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return this.origin.lastModifierId();
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		return this.origin.ownerId();
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/GeneratedTableDataFieldOfSheet.java
+++ b/src/main/java/com/supervisor/domain/impl/GeneratedTableDataFieldOfSheet.java
@@ -66,13 +66,8 @@ public final class GeneratedTableDataFieldOfSheet implements TableDataFieldOfShe
 	}
 
 	@Override
-	public Long id() {
-		return 0L;
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		return this.origin.guid();
+	public UUID id() {
+		return null;
 	}
 
 	@Override
@@ -81,7 +76,7 @@ public final class GeneratedTableDataFieldOfSheet implements TableDataFieldOfShe
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return this.origin.creatorId();
 	}
 
@@ -91,12 +86,12 @@ public final class GeneratedTableDataFieldOfSheet implements TableDataFieldOfShe
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return this.origin.lastModifierId();
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		return this.origin.ownerId();
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/MIdentity.java
+++ b/src/main/java/com/supervisor/domain/impl/MIdentity.java
@@ -24,7 +24,7 @@ public final class MIdentity implements Identity {
 		props.putAll(properties);
 		
 		this.origin = new Simple(
-						String.format("urn:minlessika:%d", user.id()),
+						String.format("urn:minlessika:%s", user.id()),
 						props
 					  );
 	}

--- a/src/main/java/com/supervisor/domain/impl/NoDataFieldDependencies.java
+++ b/src/main/java/com/supervisor/domain/impl/NoDataFieldDependencies.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.datasource.OrderDirection;
@@ -65,17 +66,17 @@ public final class NoDataFieldDependencies implements DataFieldDependencies {
 	}
 
 	@Override
-	public DataField get(Long id) throws IOException {
+	public DataField get(final UUID id) throws IOException {
 		throw new UnsupportedOperationException("PgNoDependencies#get");
 	}
 
 	@Override
-	public Optional<DataField> getOrDefault(Long id) throws IOException {
+	public Optional<DataField> getOrDefault(final UUID id) throws IOException {
 		throw new UnsupportedOperationException("PgNoDependencies#getOrDefault");
 	}
 
 	@Override
-	public boolean contains(Long id) throws IOException {
+	public boolean contains(final UUID id) throws IOException {
 		return false;
 	}
 
@@ -105,7 +106,7 @@ public final class NoDataFieldDependencies implements DataFieldDependencies {
 	}
 
 	@Override
-	public void remove(Long id) throws IOException {
+	public void remove(final UUID id) throws IOException {
 		throw new UnsupportedOperationException("PgNoDependencies#remove");
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/ParamsImpl.java
+++ b/src/main/java/com/supervisor/domain/impl/ParamsImpl.java
@@ -3,6 +3,7 @@ package com.supervisor.domain.impl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.domain.ActivityParam;
 import com.supervisor.domain.DataLinkParam;
@@ -26,20 +27,20 @@ public final class ParamsImpl implements Params {
 	}
 	
 	@Override
-	public boolean contains(long id) throws IOException {
-		return linkParams.stream().anyMatch(c -> c.id() == id) || activityParams.stream().anyMatch(c -> c.id() == id) || ruleParams.stream().anyMatch(c -> c.id() == id);
+	public boolean contains(final UUID id) throws IOException {
+		return linkParams.stream().anyMatch(c -> c.id().equals(id)) || activityParams.stream().anyMatch(c -> c.id().equals(id)) || ruleParams.stream().anyMatch(c -> c.id().equals(id));
 	}
 
 	@Override
-	public ParamDataField get(long id) throws IOException {
+	public ParamDataField get(final UUID id) throws IOException {
 		
 		final ParamDataField param;
-		if(linkParams.stream().anyMatch(c -> c.id() == id)) {
-			param = linkParams.stream().filter(c -> c.id() == id).findFirst().get();
-		} else if(activityParams.stream().anyMatch(c -> c.id() == id)) {
-			param = activityParams.stream().filter(c -> c.id() == id).findFirst().get();						
-		} else if(ruleParams.stream().anyMatch(c -> c.id() == id)) {
-			param = ruleParams.stream().filter(c -> c.id() == id).findFirst().get();						
+		if(linkParams.stream().anyMatch(c -> c.id().equals(id))) {
+			param = linkParams.stream().filter(c -> c.id().equals(id)).findFirst().get();
+		} else if(activityParams.stream().anyMatch(c -> c.id().equals(id))) {
+			param = activityParams.stream().filter(c -> c.id().equals(id)).findFirst().get();
+		} else if(ruleParams.stream().anyMatch(c -> c.id().equals(id))) {
+			param = ruleParams.stream().filter(c -> c.id().equals(id)).findFirst().get();
 		} else {
 			throw new IllegalArgumentException(String.format("Parameter with id=%s not found", id));
 		}

--- a/src/main/java/com/supervisor/domain/impl/PgActivities.java
+++ b/src/main/java/com/supervisor/domain/impl/PgActivities.java
@@ -2,6 +2,7 @@ package com.supervisor.domain.impl;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.UUID;
 
 import com.supervisor.domain.User;
 import com.supervisor.sdk.datasource.DomainRecordables;
@@ -41,8 +42,8 @@ public final class PgActivities extends DomainRecordables<Activity, Activities> 
 	
 	private static RecordSet<Activity> viewSource(final User user) throws IOException {
 		
-		Table table = new TableImpl(Activity.class);
-		Long ownerId = user.id();
+		final Table table = new TableImpl(Activity.class);
+		final UUID ownerId = user.id();
 		
 		String viewScript = String.format("(\r\n" + 
 							"	select * from %s \r\n" + 
@@ -63,7 +64,7 @@ public final class PgActivities extends DomainRecordables<Activity, Activities> 
 		
 		return user.base()
 				   .select(Activity.class, viewScript)
-				   .orderBy(Activity::id, OrderDirection.DESC);
+				   .orderBy(Activity::creationDate, OrderDirection.DESC);
 	}
 
 	@Override

--- a/src/main/java/com/supervisor/domain/impl/PgActivities.java
+++ b/src/main/java/com/supervisor/domain/impl/PgActivities.java
@@ -47,12 +47,12 @@ public final class PgActivities extends DomainRecordables<Activity, Activities> 
 		
 		String viewScript = String.format("(\r\n" + 
 							"	select * from %s \r\n" + 
-							"	where owner_id = %s \r\n" + 
+							"	where owner_id = '%s'::uuid \r\n" +
 							"	UNION ALL\r\n" + 
 							"	select act.* \r\n" + 
 							"	from %s act\r\n" + 
 							"	left join %s res on res.resource_id = act.id\r\n" + 
-							"	where res.type = 'ACTIVITY' and res.subscriber_id = %s\r\n" + 
+							"	where res.type = 'ACTIVITY' and res.subscriber_id = '%s'::uuid\r\n" +
 							") as %s",
 							table.name(),
 							ownerId,

--- a/src/main/java/com/supervisor/domain/impl/PgActivityTemplates.java
+++ b/src/main/java/com/supervisor/domain/impl/PgActivityTemplates.java
@@ -37,7 +37,7 @@ public final class PgActivityTemplates extends DomainRecordables<ActivityTemplat
 											"	select DISTINCT ON (src.id) src.* \r\n" + 
 					                        "   from %s as src \r\n" + 
 											"	left join %s as target on target.template_id = src.id \r\n" +
-											"   where (src.owner_id=%s or target.user_id=%s) and src.is_template=true" + 
+											"   where (src.owner_id='%s'::uuid or target.user_id='%s'::uuid) and src.is_template=true" +
 										  ") as %s",
 										table.name(),
 										new TableImpl(ActivityTemplateSubscription.class).name(),										

--- a/src/main/java/com/supervisor/domain/impl/PgActivityTemplatesPublished.java
+++ b/src/main/java/com/supervisor/domain/impl/PgActivityTemplatesPublished.java
@@ -66,7 +66,7 @@ public final class PgActivityTemplatesPublished extends DomainRecordables<Activi
 		
 		source.isRequired(ActivityTemplatePublished::icon, icon);
 		
-		if(template.designer().id() != base().currentUserId())
+		if(!base().currentUserId().equals(template.designer().id()))
 			throw new IllegalArgumentException("Vous ne pouvez pas publier une activité dont vous n'êtes pas le concepteur !");
 		
 		Record<ActivityTemplatePublished> record = source.entryOf(ActivityTemplatePublished::id, template.id())

--- a/src/main/java/com/supervisor/domain/impl/PgDataFields.java
+++ b/src/main/java/com/supervisor/domain/impl/PgDataFields.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordables;
 import com.supervisor.sdk.datasource.Record;
@@ -134,7 +135,7 @@ public final class PgDataFields extends DomainRecordables<DataField, DataFields>
 	}
 
 	@Override
-	public Long add(String code, String name, DataFieldType type, DataFieldStyle style, String description) throws IOException {
+	public UUID add(String code, String name, DataFieldType type, DataFieldStyle style, String description) throws IOException {
 		
 		if(model.type() == DataModelType.DATA_SHEET_MODEL) {
 			new UserOf(this).profile().validateAccessibility("NEW_DATA_FIELD");

--- a/src/main/java/com/supervisor/domain/impl/PgDataFields.java
+++ b/src/main/java/com/supervisor/domain/impl/PgDataFields.java
@@ -47,7 +47,7 @@ public final class PgDataFields extends DomainRecordables<DataField, DataFields>
 		return String.format(
 					"select src.* \r\n" + 
 					"from %s as src \r\n" + 
-					"where src.model_id = %s",
+					"where src.model_id = '%s'::uuid",
 					table.name(),									
 					model.id()
 			   );

--- a/src/main/java/com/supervisor/domain/impl/PgDataModels.java
+++ b/src/main/java/com/supervisor/domain/impl/PgDataModels.java
@@ -57,7 +57,7 @@ public final class PgDataModels extends DomainRecordables<DataModel, DataModels>
 								"(\r\n" + 
 								"	select src.* \r\n" + 
 								"   from %s src \r\n"+
-								"   where src.activity_id=%s \r\n"+ 
+								"   where src.activity_id='%s'::uuid \r\n"+
 								") as %s",
 								tableModel.name(),
 								activity.id(),
@@ -68,7 +68,7 @@ public final class PgDataModels extends DomainRecordables<DataModel, DataModels>
 								"(\r\n" + 
 								"	select src.* \r\n" + 
 								"   from %s src \r\n"+
-								"   where src.owner_id=%s \r\n"+ 
+								"   where src.owner_id='%s'::uuid \r\n"+
 								") as %s",
 								tableModel.name(),
 								user.id(),

--- a/src/main/java/com/supervisor/domain/impl/PgDataSheetModels.java
+++ b/src/main/java/com/supervisor/domain/impl/PgDataSheetModels.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.domain.User;
 import com.supervisor.sdk.datasource.DomainRecordables;
@@ -53,7 +54,7 @@ public final class PgDataSheetModels extends DomainRecordables<DataSheetModel, D
 		
 		Table tableModel = new TableImpl(DataSheetModel.class);
 		Table tableCoreModel = new TableImpl(DataModel.class);
-		Long ownerId = user.id();
+		final UUID ownerId = user.id();
 		
 		String viewScript = String.format(
 								"(\r\n" + 

--- a/src/main/java/com/supervisor/domain/impl/PgDataSheetModels.java
+++ b/src/main/java/com/supervisor/domain/impl/PgDataSheetModels.java
@@ -61,13 +61,13 @@ public final class PgDataSheetModels extends DomainRecordables<DataSheetModel, D
 								"	select src.*, core.interacting, core.code, core.type, core.active, core.activity_id, core.name, core.description, core.is_template \r\n" + 
 								"   from %s src \r\n"+ 
 								"   left join %s core on core.id = src.id \r\n" + 
-								"	where core.owner_id = %s \r\n" + 
+								"	where core.owner_id = '%s'::uuid \r\n" +
 								"	UNION ALL \r\n" + 
 								"	select model.*, core.interacting, core.code, core.type, core.active, core.activity_id, core.name, core.description, core.is_template \r\n" + 
 								"	from %s model \r\n" + 
 								"   left join %s core on core.id = model.id \r\n" +
 								"	left join %s res on res.resource_id = model.id \r\n" + 
-								"	where res.type = 'DATA_SHEET_MODEL' and res.subscriber_id = %s\r\n" + 
+								"	where res.type = 'DATA_SHEET_MODEL' and res.subscriber_id = '%s'::uuid\r\n" +
 								") as %s",
 								tableModel.name(),
 								tableCoreModel.name(),

--- a/src/main/java/com/supervisor/domain/impl/PgDataSheets.java
+++ b/src/main/java/com/supervisor/domain/impl/PgDataSheets.java
@@ -1,6 +1,8 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
+
 import com.supervisor.domain.User;
 import com.supervisor.sdk.datasource.DomainRecordables;
 import com.supervisor.sdk.datasource.RecordSet;
@@ -35,7 +37,7 @@ public final class PgDataSheets extends DomainRecordables<DataSheet, DataSheets>
 		
 		Table table = new TableImpl(DataSheet.class);
 		Table tableModel = new TableImpl(DataSheetModel.class);
-		Long ownerId = user.id();
+		final UUID ownerId = user.id();
 		
 		String viewScript = String.format(
 					            "(\r\n" +

--- a/src/main/java/com/supervisor/domain/impl/PgDataSheets.java
+++ b/src/main/java/com/supervisor/domain/impl/PgDataSheets.java
@@ -43,13 +43,13 @@ public final class PgDataSheets extends DomainRecordables<DataSheet, DataSheets>
 					            "(\r\n" +
 								"	select sheet.* from (\r\n" + 
 								"		select * from %s \r\n" + 
-								"		where owner_id = %s\r\n" + 
+								"		where owner_id = '%s'::uuid\r\n" +
 								"		UNION ALL\r\n" + 
 								"		select sheet.* \r\n" + 
 								"		from %s sheet\r\n" + 
 								"		left join %s as model on model.id = sheet.model_id\r\n" + 
 								"		left join %s res on res.resource_id = model.id\r\n" + 
-								"		where res.type = 'DATA_SHEET_MODEL' and res.subscriber_id = %s and sheet.creator_id = %s\r\n" + 
+								"		where res.type = 'DATA_SHEET_MODEL' and res.subscriber_id = '%s'::uuid and sheet.creator_id = '%s'::uuid\r\n" +
 								"	) as sheet \r\n" +
 								"   left join %s as model on model.id = sheet.model_id \r\n" +
 								"   where model.is_template = false \r\n" +

--- a/src/main/java/com/supervisor/domain/impl/PgEditableDataFieldDependencies.java
+++ b/src/main/java/com/supervisor/domain/impl/PgEditableDataFieldDependencies.java
@@ -58,12 +58,12 @@ public final class PgEditableDataFieldDependencies extends DomainRecordables<Dat
 						    "   where src.id in (\r\n" +
 						    "		select field_to_display_id \r\n" + 
 						    "       from %s list_source \r\n " + 
-						    "       where list_source.field_id = %s \r\n" +
+						    "       where list_source.field_id = '%s'::uuid \r\n" +
 						    "   ) \r\n" + 
 						    "   or src.id in (\r\n" +
 						    "		select order_field_id \r\n" + 
 						    "       from %s list_source \r\n " + 
-						    "       where list_source.field_id = %s \r\n" +
+						    "       where list_source.field_id = '%s'::uuid \r\n" +
 						    "   ) \r\n" + 
 							") as %s \r\n",
 							table.name(),
@@ -78,7 +78,7 @@ public final class PgEditableDataFieldDependencies extends DomainRecordables<Dat
 							"(\r\n" + 
 						    "	select src.* \r\n" + 
 		                    "   from %s as src \r\n" + 
-						    "   where src.id = -1 \r\n" +
+						    "   where src.id IS NULL \r\n" +
 							") as %s \r\n",
 							table.name(),
 							table.name()

--- a/src/main/java/com/supervisor/domain/impl/PgEditableDataFields.java
+++ b/src/main/java/com/supervisor/domain/impl/PgEditableDataFields.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.domain.UserScope;
 import com.supervisor.sdk.datasource.DomainRecordables;
@@ -84,7 +85,7 @@ public final class PgEditableDataFields extends DomainRecordables<EditableDataFi
 	@Override
 	public EditableDataField add(String code, String name, DataFieldType type, DataFieldStyle style, UserScope userScope, boolean isMandatory, String description) throws IOException {
 		
-		final Long fieldId = new PgDataFields(model).add(code, name, type, style, description);
+		final UUID fieldId = new PgDataFields(model).add(code, name, type, style, description);
 		
 		Record<EditableDataField> record0 = source.entryOf(EditableDataField::id, fieldId)
 												  .entryOf(EditableDataField::userScope, userScope)

--- a/src/main/java/com/supervisor/domain/impl/PgEditableDataFields.java
+++ b/src/main/java/com/supervisor/domain/impl/PgEditableDataFields.java
@@ -39,7 +39,7 @@ public final class PgEditableDataFields extends DomainRecordables<EditableDataFi
 					"select src.*, target.code, target.model_id, target.name, target.description, target.type, target.style \r\n" + 
 		            "from %s as src \r\n" + 
 		            "left join %s as target on target.id = src.id \r\n" +
-					"where target.model_id = %s", 
+					"where target.model_id = '%s'::uuid",
 					table.name(),
 					new TableImpl(DataField.class).name(),										
 					model.id()

--- a/src/main/java/com/supervisor/domain/impl/PgFormularDataFields.java
+++ b/src/main/java/com/supervisor/domain/impl/PgFormularDataFields.java
@@ -41,7 +41,7 @@ public final class PgFormularDataFields extends DomainRecordables<FormularDataFi
 					"select src.*, target.code, target.model_id, target.name, target.description, target.type, target.style \r\n" + 
 		            "from %s as src \r\n" + 
 		            "left join %s as target on target.id = src.id \r\n" +
-					"where target.model_id = %s", 
+					"where target.model_id = '%s'::uuid",
 					table.name(),
 					new TableImpl(DataField.class).name(),										
 					model.id()

--- a/src/main/java/com/supervisor/domain/impl/PgFormularDataFields.java
+++ b/src/main/java/com/supervisor/domain/impl/PgFormularDataFields.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordables;
 import com.supervisor.sdk.datasource.OrderDirection;
@@ -97,7 +98,7 @@ public final class PgFormularDataFields extends DomainRecordables<FormularDataFi
 		if(type == DataFieldType.TABLE)
 			throw new IllegalArgumentException("Formular data cannot be table !");
 		
-		final Long fieldId = new PgDataFields(model).add(code, name, type, DataFieldStyle.FORMULAR, StringUtils.EMPTY);
+		final UUID fieldId = new PgDataFields(model).add(code, name, type, DataFieldStyle.FORMULAR, StringUtils.EMPTY);
 		
 		Record<FormularDataField> record = source.entryOf(FormularDataField::id, fieldId)	
 										         .add();

--- a/src/main/java/com/supervisor/domain/impl/PgFormularDependencies.java
+++ b/src/main/java/com/supervisor/domain/impl/PgFormularDependencies.java
@@ -61,25 +61,25 @@ public final class PgFormularDependencies extends DomainRecordables<DataField, D
 							    "       from %s data_arg \r\n " + 
 							    "       left join %s arg on arg.id = data_arg.id \r\n" + 
 							    "       left join %s expr on expr.id = arg.expression_id \r\n" +
-							    "       where expr.formular_id = %s \r\n" +
+							    "       where expr.formular_id = '%s'::uuid \r\n" +
 							    "   ) \r\n" + 
 							    "   or src.id in (\r\n" +
 							    "		select model_field_id \r\n" + 
 							    "       from %s source \r\n " + 
 							    "       left join %s expr on expr.id = source.expr_id \r\n" +
-							    "       where expr.formular_id = %s \r\n" +
+							    "       where expr.formular_id = '%s'::uid \r\n" +
 							    "   ) \r\n" + 
 							    "   or src.id in (\r\n" +
 							    "		select reference_id \r\n" + 
 							    "       from %s source \r\n " + 
 							    "       left join %s expr on expr.id = source.expr_id \r\n" +
-							    "       where expr.formular_id = %s \r\n" +
+							    "       where expr.formular_id = '%s'::uuid \r\n" +
 							    "   ) \r\n" + 
 							    "   or src.id in (\r\n" +
 							    "		select field_to_extend_id \r\n" + 
 							    "       from %s source \r\n " + 
 							    "       left join %s expr on expr.id = source.expr_id \r\n" +
-							    "       where expr.formular_id = %s \r\n" +
+							    "       where expr.formular_id = '%s'::uuid \r\n" +
 							    "   ) \r\n" + 
 								") as %s \r\n",
 								table.name(),

--- a/src/main/java/com/supervisor/domain/impl/PgListDataFields.java
+++ b/src/main/java/com/supervisor/domain/impl/PgListDataFields.java
@@ -41,7 +41,7 @@ public final class PgListDataFields extends DomainRecordables<ListDataField, Lis
 					"select src.*, target.code, target.model_id, target.name, target.description, target.type, target.style \r\n" + 
 		            "from %s as src \r\n" + 
 		            "left join %s as target on target.id = src.id \r\n" +
-					"where target.model_id = %s", 
+					"where target.model_id = '%s'::uuid",
 					table.name(),
 					new TableImpl(DataField.class).name(),										
 					model.id()

--- a/src/main/java/com/supervisor/domain/impl/PgModelFilters.java
+++ b/src/main/java/com/supervisor/domain/impl/PgModelFilters.java
@@ -36,7 +36,7 @@ public final class PgModelFilters extends DomainRecordables<ModelFilter, ModelFi
 		return String.format(
 					"select src.* \r\n" + 
 					"from %s as src \r\n" + 
-					"where src.model_id = %s",
+					"where src.model_id = '%s'::uuid",
 					table.name(),									
 					model.id()
 			   );

--- a/src/main/java/com/supervisor/domain/impl/PgParamDataFields.java
+++ b/src/main/java/com/supervisor/domain/impl/PgParamDataFields.java
@@ -41,7 +41,7 @@ public final class PgParamDataFields extends DomainRecordables<ParamDataField, P
 					"select src.*, target.code, target.model_id, target.name, target.description, target.type, target.style \r\n" + 
 		            "from %s as src \r\n" + 
 		            "left join %s as target on target.id = src.id \r\n" +
-					"where target.model_id = %s", 
+					"where target.model_id = '%s'::uuid",
 					table.name(),
 					new TableImpl(DataField.class).name(),										
 					model.id()

--- a/src/main/java/com/supervisor/domain/impl/PgParamDataFields.java
+++ b/src/main/java/com/supervisor/domain/impl/PgParamDataFields.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordables;
 import com.supervisor.sdk.datasource.OrderDirection;
@@ -99,7 +100,7 @@ public final class PgParamDataFields extends DomainRecordables<ParamDataField, P
 		
 		new DataFieldValueImpl(type, value).validate();
 		
-		final Long fieldId = new PgDataFields(model).add(code, name, type, DataFieldStyle.PARAMETER, StringUtils.EMPTY);		
+		final UUID fieldId = new PgDataFields(model).add(code, name, type, DataFieldStyle.PARAMETER, StringUtils.EMPTY);
 		
 		Record<ParamDataField> record = source.entryOf(ParamDataField::id, fieldId)	
 											  .entryOf(ParamDataField::value, new DataFieldValueImpl(type, value).cleaned())

--- a/src/main/java/com/supervisor/domain/impl/PgPlans.java
+++ b/src/main/java/com/supervisor/domain/impl/PgPlans.java
@@ -13,6 +13,7 @@ import com.supervisor.sdk.datasource.Table;
 import com.supervisor.sdk.datasource.TableImpl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public final class PgPlans extends DomainRecordables<Plan, Plans> implements Plans {
 
@@ -35,7 +36,7 @@ public final class PgPlans extends DomainRecordables<Plan, Plans> implements Pla
 	}
 	
 	@Override
-	protected Plan domainOf(final Long id) throws IOException {
+	protected Plan domainOf(final UUID id) throws IOException {
 		Product origin = catalog.products().get(id);
 		return new PxPlan(origin);					
 	}

--- a/src/main/java/com/supervisor/domain/impl/PgProfileAccessParams.java
+++ b/src/main/java/com/supervisor/domain/impl/PgProfileAccessParams.java
@@ -61,7 +61,7 @@ public final class PgProfileAccessParams extends DomainRecordables<ProfileAccess
 		source.isRequired(ProfileAccessParam::value, value);
 		
 		// vérifier que le paramètre appartient au droit d'accès hérité
-		if(param.access().id() != access.accessInherited().id())
+		if(!param.access().id().equals(access.accessInherited().id()))
 			throw new IllegalArgumentException(String.format("Le paramètre %s n'appartient pas au droit d'accès %s", param.name(), access.name()));
 		
 		ProfileAccessParam pParam;

--- a/src/main/java/com/supervisor/domain/impl/PgSimpleDataFields.java
+++ b/src/main/java/com/supervisor/domain/impl/PgSimpleDataFields.java
@@ -37,7 +37,7 @@ public final class PgSimpleDataFields extends DomainRecordables<SimpleDataField,
 		
 		this.model = model;
 		this.source = source.where(SimpleDataField::style, DataFieldStyle.SIMPLE)
-							.orderBy(SimpleDataField::id);
+							.orderBy(SimpleDataField::creationDate);
 	}
 	
 	private static String scriptOf(final DataModel model) {

--- a/src/main/java/com/supervisor/domain/impl/PgSimpleDataFields.java
+++ b/src/main/java/com/supervisor/domain/impl/PgSimpleDataFields.java
@@ -46,7 +46,7 @@ public final class PgSimpleDataFields extends DomainRecordables<SimpleDataField,
 					"select src.*, target.code, target.model_id, target.name, target.description, target.type, target.style \r\n" + 
 		            "from %s as src \r\n" + 
 		            "left join %s as target on target.id = src.id \r\n" +
-					"where target.model_id = %s", 
+					"where target.model_id = '%s'::uuid",
 					table.name(),
 					new TableImpl(DataField.class).name(),										
 					model.id()

--- a/src/main/java/com/supervisor/domain/impl/PgTableDataFields.java
+++ b/src/main/java/com/supervisor/domain/impl/PgTableDataFields.java
@@ -46,7 +46,7 @@ public final class PgTableDataFields extends DomainRecordables<TableDataField, T
 					"select src.*, target.code, target.model_id, target.name, target.description, target.type, target.style \r\n" + 
 		            "from %s as src \r\n" + 
 		            "left join %s as target on target.id = src.id \r\n" +
-					"where target.model_id = %s", 
+					"where target.model_id = '%s'::uuid",
 					table.name(),
 					new TableImpl(DataField.class).name(),										
 					model.id()

--- a/src/main/java/com/supervisor/domain/impl/PgTableDataFields.java
+++ b/src/main/java/com/supervisor/domain/impl/PgTableDataFields.java
@@ -37,7 +37,7 @@ public final class PgTableDataFields extends DomainRecordables<TableDataField, T
 		
 		this.model = model;
 		this.source = source.where(TableDataField::style, DataFieldStyle.STRUCTURE)
-							.orderBy(TableDataField::id);
+							.orderBy(TableDataField::creationDate);
 	}
 	
 	private static String scriptOf(final DataModel model) {

--- a/src/main/java/com/supervisor/domain/impl/PgUserAggregatedModels.java
+++ b/src/main/java/com/supervisor/domain/impl/PgUserAggregatedModels.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.domain.User;
 import com.supervisor.sdk.datasource.DomainRecordables;
@@ -35,7 +36,7 @@ public final class PgUserAggregatedModels extends DomainRecordables<AggregatedMo
 	private static RecordSet<AggregatedModel> viewSource(final User user) throws IOException {
 		
 		Table tableModel = new TableImpl(AggregatedModel.class);
-		Long ownerId = user.id();
+		final UUID ownerId = user.id();
 		
 		String viewScript = String.format(
 								"(\r\n" + 

--- a/src/main/java/com/supervisor/domain/impl/PgUserAggregatedModels.java
+++ b/src/main/java/com/supervisor/domain/impl/PgUserAggregatedModels.java
@@ -45,7 +45,7 @@ public final class PgUserAggregatedModels extends DomainRecordables<AggregatedMo
 								"   left join %s model on model.id = am.model_id \r\n" +
 								"   left join %s dmodel on dmodel.id = model.id \r\n" + 
 								"   left join %s core on core.id = am.id \r\n" +
-								"	where am.owner_id = %s\r\n" + 
+								"	where am.owner_id = '%s'::uuid\r\n" +
 								") as %s",
 								tableModel.name(),
 								new TableImpl(DataSheetModel.class).name(),

--- a/src/main/java/com/supervisor/domain/impl/PgUserDataModels.java
+++ b/src/main/java/com/supervisor/domain/impl/PgUserDataModels.java
@@ -43,7 +43,7 @@ public final class PgUserDataModels extends DomainRecordables<DataModel, UserDat
 								"(\r\n" + 
 								"	select src.* \r\n" + 
 								"   from %s src \r\n"+ 
-								"	where src.owner_id = %s \r\n" +
+								"	where src.owner_id = '%s'::uuid \r\n" +
 								") as %s",
 								table.name(),
 								user.id(),

--- a/src/main/java/com/supervisor/domain/impl/PxActivityTemplate.java
+++ b/src/main/java/com/supervisor/domain/impl/PxActivityTemplate.java
@@ -3,6 +3,7 @@ package com.supervisor.domain.impl;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.domain.User;
 import com.supervisor.sdk.datasource.Record;
@@ -115,7 +116,7 @@ public final class PxActivityTemplate extends ActivityWrap implements ActivityTe
 	@Override
 	public void changeDesigner(User newDesigner) throws IOException {
 		
-		final Long ownerId = newDesigner.id();
+		final UUID ownerId = newDesigner.id();
 		
 		if(ownerId.equals(designer().id()))
 			throw new IllegalArgumentException("Vous devez sélectionner un utilisateur différent du concepteur actuel !");

--- a/src/main/java/com/supervisor/domain/impl/PxBasicFormularExpression.java
+++ b/src/main/java/com/supervisor/domain/impl/PxBasicFormularExpression.java
@@ -2,6 +2,7 @@ package com.supervisor.domain.impl;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordable;
 import com.supervisor.sdk.datasource.Record;
@@ -22,7 +23,7 @@ public abstract class PxBasicFormularExpression extends DomainRecordable<Formula
 	
 	@Override
 	public FormularDataField formular() throws IOException {
-		final Long formularId = record.valueOf(FormularExpression::formular);
+		final UUID formularId = record.valueOf(FormularExpression::formular);
 		return new PxFormularDataField(record.of(DataField.class, formularId));
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/PxDataFieldOfSheet.java
+++ b/src/main/java/com/supervisor/domain/impl/PxDataFieldOfSheet.java
@@ -2,6 +2,7 @@ package com.supervisor.domain.impl;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordable;
 import com.supervisor.sdk.datasource.Record;
@@ -25,7 +26,7 @@ public final class PxDataFieldOfSheet extends DomainRecordable<DataFieldOfSheet>
 	public PxDataFieldOfSheet(final Record<DataFieldOfSheet> record) throws IOException {
 		super(record);
 		
-		final Long originId = record.valueOf(DataFieldOfSheet::origin);
+		final UUID originId = record.valueOf(DataFieldOfSheet::origin);
 		this.origin = (EditableDataField)TypedDataField.convert(record.of(DataField.class, originId)); 
 	}
 
@@ -62,7 +63,7 @@ public final class PxDataFieldOfSheet extends DomainRecordable<DataFieldOfSheet>
 
 	@Override
 	public DataSheet sheet() throws IOException {
-		Long id = record.valueOf(DataFieldOfSheet::sheet);
+		final UUID id = record.valueOf(DataFieldOfSheet::sheet);
 		return new PxDataSheet(
 			record.of(DataSheet.class, id)
 		);

--- a/src/main/java/com/supervisor/domain/impl/PxDataLinks.java
+++ b/src/main/java/com/supervisor/domain/impl/PxDataLinks.java
@@ -19,7 +19,7 @@ public final class PxDataLinks extends DomainRecordables<DataLink, DataLinks> im
 		
 		this.indicator = indicator;
 		this.source = source.where(DataLink::indicator, indicator.id())
-						    .orderBy(DataLink::id);
+						    .orderBy(DataLink::creationDate);
 	}
 
 	@Override

--- a/src/main/java/com/supervisor/domain/impl/PxEditableDataFieldArg.java
+++ b/src/main/java/com/supervisor/domain/impl/PxEditableDataFieldArg.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordable;
 import com.supervisor.domain.EditableDataFieldArg;
@@ -45,7 +46,7 @@ public final class PxEditableDataFieldArg extends DomainRecordable<EditableDataF
 
 	@Override
 	public EditableDataField field() throws IOException {
-		final Long fieldId = record.valueOf(EditableDataFieldArg::field);
+		final UUID fieldId = record.valueOf(EditableDataFieldArg::field);
 		return (EditableDataField)TypedDataField.convert(record.of(DataField.class, fieldId));
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/PxFormularArg.java
+++ b/src/main/java/com/supervisor/domain/impl/PxFormularArg.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordable;
 import com.supervisor.domain.DataField;
@@ -45,7 +46,7 @@ public final class PxFormularArg extends DomainRecordable<FormularArg> implement
 
 	@Override
 	public FormularDataField field() throws IOException {
-		final Long fieldId = record.valueOf(FormularArg::field);
+		final UUID fieldId = record.valueOf(FormularArg::field);
 		return new PxFormularDataField(record.of(DataField.class, fieldId));
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/PxFormularCondition.java
+++ b/src/main/java/com/supervisor/domain/impl/PxFormularCondition.java
@@ -2,6 +2,7 @@ package com.supervisor.domain.impl;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordable;
 import com.supervisor.sdk.datasource.Record;
@@ -19,7 +20,7 @@ public final class PxFormularCondition extends DomainRecordable<FormularConditio
 
 	@Override
 	public ParamDataField param() throws IOException {
-		final Long paramId = record.valueOf(FormularCondition::param);
+		final UUID paramId = record.valueOf(FormularCondition::param);
 		return new PxParamDataField(record.of(DataField.class, paramId));
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/PxFormularExpressions.java
+++ b/src/main/java/com/supervisor/domain/impl/PxFormularExpressions.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordables;
 import com.supervisor.sdk.datasource.Record;
@@ -141,7 +142,7 @@ public final class PxFormularExpressions extends DomainRecordables<FormularExpre
 				break;
 			case CASE:
 			    FormularCaseExpression caseItem = (FormularCaseExpression)item;
-			    Long defaultArgId = caseItem.defaultValue().id();
+			    final UUID defaultArgId = caseItem.defaultValue().id();
 			    caseItem.cases().remove();			    
 			    source.of(ExpressionArg.class).remove(defaultArgId); 
 				break;

--- a/src/main/java/com/supervisor/domain/impl/PxFormularExtendedToModelSource.java
+++ b/src/main/java/com/supervisor/domain/impl/PxFormularExtendedToModelSource.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordable;
 import com.supervisor.sdk.datasource.Record;
@@ -23,13 +24,13 @@ public final class PxFormularExtendedToModelSource extends DomainRecordable<Form
 
 	@Override
 	public DataField reference() throws IOException {
-		final Long fieldId = record.valueOf(FormularExtendedToModelSource::reference);
+		final UUID fieldId = record.valueOf(FormularExtendedToModelSource::reference);
 		return TypedDataField.convert(record.of(DataField.class, fieldId));
 	}
 
 	@Override
 	public EditableDataField modelField() throws IOException {
-		final Long fieldId = record.valueOf(FormularExtendedToModelSource::modelField);
+		final UUID fieldId = record.valueOf(FormularExtendedToModelSource::modelField);
 		return (EditableDataField)TypedDataField.convert(record.of(DataField.class, fieldId));
 	}
 	
@@ -85,7 +86,7 @@ public final class PxFormularExtendedToModelSource extends DomainRecordable<Form
 
 	@Override
 	public DataSheetModel model() throws IOException {
-		final Long modelId = record.valueOf(FormularExtendedToModelSource::model);		
+		final UUID modelId = record.valueOf(FormularExtendedToModelSource::model);
 		return (DataSheetModel)TypedDataModel.convert(record.of(DataModel.class, modelId));
 	}
 
@@ -129,7 +130,7 @@ public final class PxFormularExtendedToModelSource extends DomainRecordable<Form
 
 	@Override
 	public EditableDataField fieldToExtend() throws IOException {
-		final Long fieldId = record.valueOf(FormularExtendedToModelSource::fieldToExtend);
+		final UUID fieldId = record.valueOf(FormularExtendedToModelSource::fieldToExtend);
 		return (EditableDataField)TypedDataField.convert(record.of(DataField.class, fieldId));
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/PxFormularExtendedToParentSource.java
+++ b/src/main/java/com/supervisor/domain/impl/PxFormularExtendedToParentSource.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordable;
 import com.supervisor.sdk.datasource.Record;
@@ -24,7 +25,7 @@ public final class PxFormularExtendedToParentSource extends DomainRecordable<For
 
 	@Override
 	public EditableDataField field() throws IOException {
-		final Long fieldId = record.valueOf(FormularExtendedToParentSource::field);
+		final UUID fieldId = record.valueOf(FormularExtendedToParentSource::field);
 		return (EditableDataField)TypedDataField.convert(record.of(DataField.class, fieldId));
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/PxListDataFieldSource.java
+++ b/src/main/java/com/supervisor/domain/impl/PxListDataFieldSource.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordable;
 import com.supervisor.sdk.datasource.Record;
@@ -22,7 +23,7 @@ public final class PxListDataFieldSource extends DomainRecordable<ListDataFieldS
 
 	@Override
 	public ListDataField field() throws IOException {
-		final Long fieldId = record.valueOf(ListDataFieldSource::field);
+		final UUID fieldId = record.valueOf(ListDataFieldSource::field);
 		return new PxListDataField(
 					record.of(DataField.class, fieldId)
 			   );
@@ -35,7 +36,7 @@ public final class PxListDataFieldSource extends DomainRecordable<ListDataFieldS
 
 	@Override
 	public DataField fieldToDisplay() throws IOException {
-		final Long fieldId = record.valueOf(ListDataFieldSource::fieldToDisplay);
+		final UUID fieldId = record.valueOf(ListDataFieldSource::fieldToDisplay);
 		return TypedDataField.convert(
 				record.of(DataField.class, fieldId)
 			   );
@@ -43,7 +44,7 @@ public final class PxListDataFieldSource extends DomainRecordable<ListDataFieldS
 
 	@Override
 	public DataField orderField() throws IOException {
-		final Long fieldId = record.valueOf(ListDataFieldSource::orderField);
+		final UUID fieldId = record.valueOf(ListDataFieldSource::orderField);
 		return TypedDataField.convert(
 				record.of(DataField.class, fieldId)
 			   );

--- a/src/main/java/com/supervisor/domain/impl/PxListDataFieldSources.java
+++ b/src/main/java/com/supervisor/domain/impl/PxListDataFieldSources.java
@@ -24,7 +24,7 @@ public final class PxListDataFieldSources extends DomainRecordables<ListDataFiel
 		
 		this.field = field;
 		this.source = source.where(ListDataFieldSource::field, field.id())
-						    .orderBy(ListDataFieldSource::id);
+						    .orderBy(ListDataFieldSource::creationDate);
 	}
 
 	@Override

--- a/src/main/java/com/supervisor/domain/impl/PxMappedDataFields.java
+++ b/src/main/java/com/supervisor/domain/impl/PxMappedDataFields.java
@@ -22,7 +22,7 @@ public final class PxMappedDataFields extends DomainRecordables<MappedDataField,
 		
 		this.link = link;
 		this.source = source.where(MappedDataField::link, link.id())
-				            .orderBy(MappedDataField::id, OrderDirection.ASC);
+				            .orderBy(MappedDataField::creationDate, OrderDirection.ASC);
 	}
 	
 	@Override

--- a/src/main/java/com/supervisor/domain/impl/PxModelFilterConditions.java
+++ b/src/main/java/com/supervisor/domain/impl/PxModelFilterConditions.java
@@ -23,7 +23,7 @@ public final class PxModelFilterConditions extends DomainRecordables<ModelFilter
 		
 		this.filter = filter;
 		this.source = source.where(ModelFilterCondition::filter, filter.id())
-				            .orderBy(ModelFilterCondition::id);
+				            .orderBy(ModelFilterCondition::creationDate);
 	}
 	
 	@Override

--- a/src/main/java/com/supervisor/domain/impl/PxParamArg.java
+++ b/src/main/java/com/supervisor/domain/impl/PxParamArg.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordable;
 import com.supervisor.domain.DataField;
@@ -45,7 +46,7 @@ public final class PxParamArg extends DomainRecordable<ParamArg> implements Para
 
 	@Override
 	public ParamDataField field() throws IOException {
-		final Long fieldId = record.valueOf(ParamArg::field);
+		final UUID fieldId = record.valueOf(ParamArg::field);
 		return new PxParamDataField(record.of(DataField.class, fieldId));
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/PxPlanFeatures.java
+++ b/src/main/java/com/supervisor/domain/impl/PxPlanFeatures.java
@@ -8,6 +8,7 @@ import com.supervisor.sdk.datasource.Record;
 import com.supervisor.sdk.datasource.RecordSet;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public final class PxPlanFeatures extends DomainRecordables<PlanFeature, PlanFeatures> implements PlanFeatures {
 
@@ -31,7 +32,7 @@ public final class PxPlanFeatures extends DomainRecordables<PlanFeature, PlanFea
 	}
 	
 	@Override
-	protected PlanFeature domainOf(final Long id) throws IOException {
+	protected PlanFeature domainOf(final UUID id) throws IOException {
 		return new PxPlanFeature(source.get(id), plan);					
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/PxSharedResource.java
+++ b/src/main/java/com/supervisor/domain/impl/PxSharedResource.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.domain.User;
 import com.supervisor.sdk.datasource.DomainRecordable;
@@ -24,7 +25,7 @@ public final class PxSharedResource extends DomainRecordable<SharedResource> imp
 	}
 
 	@Override
-	public Long resourceId() throws IOException {
+	public UUID resourceId() throws IOException {
 		return record.valueOf(SharedResource::resourceId);
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/PxSharing.java
+++ b/src/main/java/com/supervisor/domain/impl/PxSharing.java
@@ -2,6 +2,7 @@ package com.supervisor.domain.impl;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordables;
 import com.supervisor.sdk.datasource.Record;
@@ -25,7 +26,7 @@ public final class PxSharing extends DomainRecordables<SharedResource, Sharing> 
 	}
 
 	@Override
-	public SharedResource share(Long resourceId, ResourceType type, User subscriber) throws IOException {
+	public SharedResource share(UUID resourceId, ResourceType type, User subscriber) throws IOException {
 		
 		User follower = new DmUser(
 							source.of(User.class)
@@ -79,7 +80,7 @@ public final class PxSharing extends DomainRecordables<SharedResource, Sharing> 
 	}
 
 	@Override
-	public Optional<SharedResource> resource(Long resourceId, ResourceType type, User subscriber) throws IOException {
+	public Optional<SharedResource> resource(UUID resourceId, ResourceType type, User subscriber) throws IOException {
 		
 		Sharing resourceToSearch =  where(SharedResource::resourceId, resourceId)
 				                   .where(SharedResource::type, type)
@@ -96,7 +97,7 @@ public final class PxSharing extends DomainRecordables<SharedResource, Sharing> 
 	}
 
 	@Override
-	public SharedResource share(Long resourceId, ResourceType type, String email) throws IOException {
+	public SharedResource share(UUID resourceId, ResourceType type, String email) throws IOException {
 		
 		if(StringUtils.isBlank(email))
 			throw new IllegalArgumentException("Vous devez spécifier une adresse email !");

--- a/src/main/java/com/supervisor/domain/impl/PxSubscription.java
+++ b/src/main/java/com/supervisor/domain/impl/PxSubscription.java
@@ -2,6 +2,7 @@ package com.supervisor.domain.impl;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordables;
 import com.supervisor.sdk.datasource.RecordSet;
@@ -24,7 +25,7 @@ public final class PxSubscription extends DomainRecordables<SharedResource, Subs
 	}
 
 	@Override
-	public Optional<SharedResource> resource(Long resourceId, ResourceType type) throws IOException {
+	public Optional<SharedResource> resource(UUID resourceId, ResourceType type) throws IOException {
 		Subscription resourceToSearch =  where(SharedResource::resourceId, resourceId)
                 				        .where(SharedResource::type, type);
 

--- a/src/main/java/com/supervisor/domain/impl/PxWhenCases.java
+++ b/src/main/java/com/supervisor/domain/impl/PxWhenCases.java
@@ -1,6 +1,7 @@
 package com.supervisor.domain.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordables;
 import com.supervisor.sdk.datasource.Record;
@@ -74,9 +75,9 @@ public final class PxWhenCases extends DomainRecordables<WhenCase, WhenCases> im
 	@Override
 	public void remove(WhenCase item) throws IOException{
 		
-		Long leftArgId = item.leftArg().id();
-		Long rightArgId = item.rightArg().id();
-		Long resultId = item.result().id();
+		UUID leftArgId = item.leftArg().id();
+		UUID rightArgId = item.rightArg().id();
+		UUID resultId = item.result().id();
 		super.remove(item);
 		
 		RecordSet<ExpressionArg> argSource = source.of(ExpressionArg.class);

--- a/src/main/java/com/supervisor/domain/impl/ResourceImpl.java
+++ b/src/main/java/com/supervisor/domain/impl/ResourceImpl.java
@@ -38,7 +38,7 @@ public final class ResourceImpl implements Resource {
 	}
 	
 	@Override
-	public Long id() {
+	public UUID id() {
 		return record.id();
 	}
 
@@ -53,13 +53,8 @@ public final class ResourceImpl implements Resource {
 	}
 
 	@Override
-	public Long ownerId() throws IOException { 
+	public UUID ownerId() throws IOException {
 		return record.ownerId();
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		return record.guid();
 	}
 
 	@Override
@@ -68,7 +63,7 @@ public final class ResourceImpl implements Resource {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return record.creatorId();
 	}
 
@@ -78,7 +73,7 @@ public final class ResourceImpl implements Resource {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return record.lastModifierId();
 	}
 

--- a/src/main/java/com/supervisor/domain/impl/ResourcesImpl.java
+++ b/src/main/java/com/supervisor/domain/impl/ResourcesImpl.java
@@ -3,6 +3,7 @@ package com.supervisor.domain.impl;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import com.supervisor.domain.User;
 import com.supervisor.sdk.datasource.RecordSet;
@@ -31,7 +32,7 @@ public final class ResourcesImpl implements Resources {
 	}
 
 	@Override
-	public Optional<Resource> resourceIfPresent(ResourceType type, Long id) throws IOException {
+	public Optional<Resource> resourceIfPresent(ResourceType type, UUID id) throws IOException {
 		
 		Resource resource = null;
 		
@@ -69,7 +70,7 @@ public final class ResourcesImpl implements Resources {
 	}
 
 	@Override
-	public Resource resource(ResourceType type, Long id) throws IOException {
+	public Resource resource(ResourceType type, UUID id) throws IOException {
 		Optional<Resource> res = resourceIfPresent(type, id);
 		if(!res.isPresent())
 			throw new IllegalArgumentException("La resource demandée n'existe pas !");

--- a/src/main/java/com/supervisor/domain/impl/UserAdmin.java
+++ b/src/main/java/com/supervisor/domain/impl/UserAdmin.java
@@ -10,13 +10,13 @@ public final class UserAdmin extends UserWrap {
 
 	public UserAdmin(final Base base) throws IOException {
 		super(
-			new DmUser(base.select(User.class).get(1L))
+			new DmUser(base.select(User.class).get(User.ADMIN_ID))
 		);
 	}
 
 	public UserAdmin(final User currentUser) throws IOException {
 		super(
-			new DmUser(currentUser.listOf(User.class).get(1L))
+			new DmUser(currentUser.listOf(User.class).get(User.ADMIN_ID))
 		);
 	}
 	
@@ -26,7 +26,7 @@ public final class UserAdmin extends UserWrap {
 					entity.base()
 					      .select(
 				    		  User.class, 
-				    		  1L
+				    		  User.ADMIN_ID
 					      )
 				)
 		);

--- a/src/main/java/com/supervisor/domain/impl/UserAnonymous.java
+++ b/src/main/java/com/supervisor/domain/impl/UserAnonymous.java
@@ -10,13 +10,13 @@ public final class UserAnonymous extends UserWrap {
 
 	public UserAnonymous(final Base base) throws IOException {
 		super(
-			new DmUser(base.select(User.class).get(2L))
+			new DmUser(base.select(User.class).get(User.ANONYMOUS_ID))
 		);
 	}
 
 	public UserAnonymous(final User currentUser) throws IOException {
 		super(
-			new DmUser(currentUser.listOf(User.class).get(2L))
+			new DmUser(currentUser.listOf(User.class).get(User.ANONYMOUS_ID))
 		);
 	}
 	
@@ -26,7 +26,7 @@ public final class UserAnonymous extends UserWrap {
 					entity.base()
 					      .select(
 				    		  User.class, 
-				    		  2L
+				    		  User.ANONYMOUS_ID
 					      )
 				)
 		);

--- a/src/main/java/com/supervisor/domain/impl/UserWrap.java
+++ b/src/main/java/com/supervisor/domain/impl/UserWrap.java
@@ -41,17 +41,12 @@ public class UserWrap implements User {
 	}
 
 	@Override
-	public UUID guid() throws IOException {
-		return origin.guid();
-	}
-
-	@Override
 	public LocalDateTime creationDate() throws IOException {
 		return origin.creationDate();
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return origin.creatorId();
 	}
 
@@ -61,12 +56,12 @@ public class UserWrap implements User {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return origin.lastModifierId();
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		return origin.ownerId();
 	}
 
@@ -76,7 +71,7 @@ public class UserWrap implements User {
 	}
 
 	@Override
-	public Long id() {
+	public UUID id() {
 		return origin.id();
 	}
 

--- a/src/main/java/com/supervisor/indicator/BasePeriodicity.java
+++ b/src/main/java/com/supervisor/indicator/BasePeriodicity.java
@@ -25,7 +25,7 @@ public interface BasePeriodicity extends Periodicity, com.supervisor.sdk.datasou
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}
@@ -43,7 +43,7 @@ public interface BasePeriodicity extends Periodicity, com.supervisor.sdk.datasou
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
@@ -55,19 +55,13 @@ public interface BasePeriodicity extends Periodicity, com.supervisor.sdk.datasou
 		}
 		
 		@Override
-		public Long id() {
+		public UUID id() {
 			
 			return null;
 		}
 		
 		@Override
-		public UUID guid() throws IOException {
-			
-			return null;
-		}
-		
-		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/indicator/Indicator.java
+++ b/src/main/java/com/supervisor/indicator/Indicator.java
@@ -128,7 +128,7 @@ public interface Indicator extends com.supervisor.sdk.datasource.Recordable {
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}
@@ -146,7 +146,7 @@ public interface Indicator extends com.supervisor.sdk.datasource.Recordable {
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
@@ -158,19 +158,13 @@ public interface Indicator extends com.supervisor.sdk.datasource.Recordable {
 		}
 		
 		@Override
-		public Long id() {
+		public UUID id() {
 			
 			return null;
 		}
 		
 		@Override
-		public UUID guid() throws IOException {
-			
-			return null;
-		}
-		
-		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/indicator/IndicatorDynamicParam.java
+++ b/src/main/java/com/supervisor/indicator/IndicatorDynamicParam.java
@@ -44,7 +44,7 @@ public interface IndicatorDynamicParam extends IndicatorTypeDynamicParam {
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			
 			return null;
 		}
@@ -56,7 +56,7 @@ public interface IndicatorDynamicParam extends IndicatorTypeDynamicParam {
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			
 			return null;
 		}
@@ -68,19 +68,13 @@ public interface IndicatorDynamicParam extends IndicatorTypeDynamicParam {
 		}
 		
 		@Override
-		public Long id() {
+		public UUID id() {
 			
 			return null;
 		}
 		
 		@Override
-		public UUID guid() throws IOException {
-			
-			return null;
-		}
-		
-		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			
 			return null;
 		}

--- a/src/main/java/com/supervisor/indicator/IndicatorTemplate.java
+++ b/src/main/java/com/supervisor/indicator/IndicatorTemplate.java
@@ -41,7 +41,7 @@ public interface IndicatorTemplate extends Indicator {
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			return null;
 		}
 		
@@ -51,7 +51,7 @@ public interface IndicatorTemplate extends Indicator {
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			return null;
 		}
 		
@@ -61,17 +61,12 @@ public interface IndicatorTemplate extends Indicator {
 		}
 		
 		@Override
-		public Long id() {
+		public UUID id() {
 			return null;
 		}
 		
 		@Override
-		public UUID guid() throws IOException {
-			return null;
-		}
-		
-		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			return null;
 		}
 		

--- a/src/main/java/com/supervisor/indicator/IndicatorTemplating.java
+++ b/src/main/java/com/supervisor/indicator/IndicatorTemplating.java
@@ -2,9 +2,10 @@ package com.supervisor.indicator;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.UUID;
 
 public interface IndicatorTemplating {
 	IndicatorTemplate process() throws IOException;
-	Map<Long, Long> aggregatedModelMapping();
-	Map<Long, Long> dataSheetModelMapping();
+	Map<UUID, UUID> aggregatedModelMapping();
+	Map<UUID, UUID> dataSheetModelMapping();
 }

--- a/src/main/java/com/supervisor/indicator/IndicatorTypeParam.java
+++ b/src/main/java/com/supervisor/indicator/IndicatorTypeParam.java
@@ -49,12 +49,12 @@ public interface IndicatorTypeParam extends com.supervisor.sdk.datasource.Record
 		}
 		
 		@Override
-		public Long ownerId() throws IOException {
+		public UUID ownerId() throws IOException {
 			return null;
 		}
 		
 		@Override
-		public Long lastModifierId() throws IOException {
+		public UUID lastModifierId() throws IOException {
 			return null;
 		}
 		
@@ -64,17 +64,12 @@ public interface IndicatorTypeParam extends com.supervisor.sdk.datasource.Record
 		}
 		
 		@Override
-		public Long id() {
+		public UUID id() {
 			return null;
 		}
 		
 		@Override
-		public UUID guid() throws IOException {
-			return null;
-		}
-		
-		@Override
-		public Long creatorId() throws IOException {
+		public UUID creatorId() throws IOException {
 			return null;
 		}
 		

--- a/src/main/java/com/supervisor/indicator/NamingOfModel.java
+++ b/src/main/java/com/supervisor/indicator/NamingOfModel.java
@@ -1,6 +1,8 @@
 package com.supervisor.indicator;
 
+import java.util.UUID;
+
 public interface NamingOfModel {
-	Long ruleId();
+	UUID ruleId();
 	String newModelName();
 }

--- a/src/main/java/com/supervisor/indicator/ReplacingOfModel.java
+++ b/src/main/java/com/supervisor/indicator/ReplacingOfModel.java
@@ -1,9 +1,10 @@
 package com.supervisor.indicator;
 
 import java.util.Map;
+import java.util.UUID;
 
 public interface ReplacingOfModel {
-	Long ruleId();
-	Long replacingModelId();
+	UUID ruleId();
+	UUID replacingModelId();
 	Map<String, String> fieldMappings();
 }

--- a/src/main/java/com/supervisor/indicator/impl/ActivityTemplateParamRequestImpl.java
+++ b/src/main/java/com/supervisor/indicator/impl/ActivityTemplateParamRequestImpl.java
@@ -2,14 +2,16 @@ package com.supervisor.indicator.impl;
 
 import com.supervisor.domain.ActivityTemplateParamRequest;
 
+import java.util.UUID;
+
 public final class ActivityTemplateParamRequestImpl implements ActivityTemplateParamRequest {
 
-	private final Long modelId;
+	private final UUID modelId;
 	private final String code;
 	private final String value;
 
 	public ActivityTemplateParamRequestImpl(
-			final Long modelId,
+			final UUID modelId,
 			final String code,
 			final String value
 	) {
@@ -19,7 +21,7 @@ public final class ActivityTemplateParamRequestImpl implements ActivityTemplateP
 	}
 	
 	@Override
-	public Long modelId() {
+	public UUID modelId() {
 		return modelId;
 	}
 	

--- a/src/main/java/com/supervisor/indicator/impl/IndicatorWrap.java
+++ b/src/main/java/com/supervisor/indicator/impl/IndicatorWrap.java
@@ -29,13 +29,8 @@ public class IndicatorWrap implements Indicator {
 	}
 	
 	@Override
-	public Long id() {
+	public UUID id() {
 		return origin.id();
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		return origin.guid();
 	}
 
 	@Override
@@ -44,7 +39,7 @@ public class IndicatorWrap implements Indicator {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return origin.creatorId();
 	}
 
@@ -54,12 +49,12 @@ public class IndicatorWrap implements Indicator {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return origin.lastModifierId();
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		return origin.ownerId();
 	}
 

--- a/src/main/java/com/supervisor/indicator/impl/NamingOfModelImpl.java
+++ b/src/main/java/com/supervisor/indicator/impl/NamingOfModelImpl.java
@@ -2,18 +2,20 @@ package com.supervisor.indicator.impl;
 
 import com.supervisor.indicator.NamingOfModel;
 
+import java.util.UUID;
+
 public final class NamingOfModelImpl implements NamingOfModel {
 
-	private final Long ruleId;
+	private final UUID ruleId;
 	private final String newModelName;
 	
-	public NamingOfModelImpl(final Long ruleId, final String newModelName) {
+	public NamingOfModelImpl(final UUID ruleId, final String newModelName) {
 		this.ruleId = ruleId;
 		this.newModelName = newModelName;
 	}
 	
 	@Override
-	public Long ruleId() {
+	public UUID ruleId() {
 		return ruleId;
 	}
 

--- a/src/main/java/com/supervisor/indicator/impl/PxGaugeZones.java
+++ b/src/main/java/com/supervisor/indicator/impl/PxGaugeZones.java
@@ -1,6 +1,7 @@
 package com.supervisor.indicator.impl;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
 
 import com.supervisor.sdk.colors.Color;
@@ -30,7 +31,13 @@ public final class PxGaugeZones extends DomainRecordables<GaugeZone, GaugeZones>
 	@Override
 	public List<GaugeZone> items() throws IOException {
 		List<GaugeZone> items = super.items();
-		items.sort((c1, c2) -> Long.compare(c1.id(), c2.id()));
+		items.sort((c1, c2) -> {
+			try {
+				return Double.compare(c1.min(), c2.min());
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		});
 		
 		return items;           
 	}

--- a/src/main/java/com/supervisor/indicator/impl/PxIndicatorDynamicParam.java
+++ b/src/main/java/com/supervisor/indicator/impl/PxIndicatorDynamicParam.java
@@ -1,6 +1,7 @@
 package com.supervisor.indicator.impl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordable;
 import com.supervisor.sdk.datasource.Record;
@@ -53,7 +54,7 @@ public final class PxIndicatorDynamicParam extends DomainRecordable<IndicatorDyn
 	@Override
 	public IndicatorTypeDynamicParam origin() throws IOException {
 		
-		Long id = record.valueOf(IndicatorDynamicParam::origin);
+		final UUID id = record.valueOf(IndicatorDynamicParam::origin);
 		Record<IndicatorTypeParam> rec = record.of(IndicatorTypeParam.class, id);
 		
 		return new PxIndicatorTypeDynamicParam(

--- a/src/main/java/com/supervisor/indicator/impl/PxIndicatorStaticParam.java
+++ b/src/main/java/com/supervisor/indicator/impl/PxIndicatorStaticParam.java
@@ -2,6 +2,7 @@ package com.supervisor.indicator.impl;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.DomainRecordable;
 import com.supervisor.sdk.datasource.Record;
@@ -57,7 +58,7 @@ public final class PxIndicatorStaticParam extends DomainRecordable<IndicatorStat
 
 	@Override
 	public IndicatorTypeStaticParam origin() throws IOException {
-		Long id = record.valueOf(IndicatorStaticParam::origin);
+		final UUID id = record.valueOf(IndicatorStaticParam::origin);
 		Record<IndicatorTypeParam> rec = record.of(IndicatorTypeParam.class, id);
 		
 		return new PxIndicatorTypeStaticParam(

--- a/src/main/java/com/supervisor/indicator/impl/PxIndicatorTypeDynamicParams.java
+++ b/src/main/java/com/supervisor/indicator/impl/PxIndicatorTypeDynamicParams.java
@@ -26,7 +26,7 @@ public final class PxIndicatorTypeDynamicParams extends DomainRecordables<Indica
 		this.indicatorType = indicatorType;
 		this.source = source.where(IndicatorTypeDynamicParam::indicatorType, indicatorType.id())
 						    .where(IndicatorTypeDynamicParam::category, IndicatorTypeParamCategory.DYNAMIC)
-						    .orderBy(IndicatorTypeDynamicParam::id); 
+						    .orderBy(IndicatorTypeDynamicParam::creationDate);
 	}
 	
 	@Override

--- a/src/main/java/com/supervisor/indicator/impl/PxIndicatorTypeStaticParams.java
+++ b/src/main/java/com/supervisor/indicator/impl/PxIndicatorTypeStaticParams.java
@@ -26,7 +26,7 @@ public final class PxIndicatorTypeStaticParams extends DomainRecordables<Indicat
 		this.indicatorType = indicatorType;
 		this.source = source.where(IndicatorTypeStaticParam::indicatorType, indicatorType.id())
 				            .where(IndicatorTypeStaticParam::category, IndicatorTypeParamCategory.STATIC)
-				            .orderBy(IndicatorTypeStaticParam::id);
+				            .orderBy(IndicatorTypeStaticParam::creationDate);
 	}
 	
 	@Override

--- a/src/main/java/com/supervisor/indicator/impl/ReplacingOfModelImpl.java
+++ b/src/main/java/com/supervisor/indicator/impl/ReplacingOfModelImpl.java
@@ -1,28 +1,29 @@
 package com.supervisor.indicator.impl;
 
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.indicator.ReplacingOfModel;
 
 public final class ReplacingOfModelImpl implements ReplacingOfModel {
 
-	private final Long ruleId;
-	private final Long replacingModelId;
+	private final UUID ruleId;
+	private final UUID replacingModelId;
 	private final Map<String, String> fieldMappings;
 	
-	public ReplacingOfModelImpl(final Long ruleId, final Long replacingModelId, final Map<String, String> fieldMappings) {
+	public ReplacingOfModelImpl(final UUID ruleId, final UUID replacingModelId, final Map<String, String> fieldMappings) {
 		this.ruleId = ruleId;
 		this.replacingModelId = replacingModelId;
 		this.fieldMappings = fieldMappings;
 	}
 	
 	@Override
-	public Long ruleId() {
+	public UUID ruleId() {
 		return ruleId;
 	}
 
 	@Override
-	public Long replacingModelId() {
+	public UUID replacingModelId() {
 		return replacingModelId;
 	}
 

--- a/src/main/java/com/supervisor/sdk/datasource/Base.java
+++ b/src/main/java/com/supervisor/sdk/datasource/Base.java
@@ -5,15 +5,16 @@ import org.takes.Request;
 import java.io.IOException;
 import java.sql.Connection;
 import java.util.List;
+import java.util.UUID;
 
 public interface Base {
 	WebSocketServer wsServer();
-	long currentUserId();
+	UUID currentUserId();
 	
 	void start(boolean inTransaction) throws IOException;
-	void start(boolean inTransaction, long currentUserId) throws IOException;
+	void start(boolean inTransaction, UUID currentUserId) throws IOException;
 	void start(boolean inTransaction, Request request) throws IOException;
-	void changeUser(long userId) throws IOException;
+	void changeUser(UUID userId) throws IOException;
 	
 	void commit() throws IOException;
 	void rollback() throws IOException;
@@ -25,7 +26,7 @@ public interface Base {
 	
 	<A1 extends Recordable> RecordSet<A1> select(Class<A1> clazz) throws IOException;
 	<A1 extends Recordable> RecordSet<A1> select(Class<A1> clazz, String viewScript) throws IOException;
-	<A1 extends Recordable> Record<A1> select(Class<A1> clazz, Long id) throws IOException;
+	<A1 extends Recordable> Record<A1> select(Class<A1> clazz, UUID id) throws IOException;
 	
 	<A1 extends Recordable> void register(Class<A1> clazz) throws IOException;
 	
@@ -43,7 +44,7 @@ public interface Base {
 		}
 		
 		@Override
-		public <A1 extends Recordable> Record<A1> select(Class<A1> clazz, Long id) throws IOException {
+		public <A1 extends Recordable> Record<A1> select(Class<A1> clazz, UUID id) throws IOException {
 			return null;
 		}
 		
@@ -106,12 +107,12 @@ public interface Base {
 		}
 
 		@Override
-		public long currentUserId() {
-			return 0;
+		public UUID currentUserId() {
+			return null;
 		}
 
 		@Override
-		public void start(boolean inTransaction, long currentUserId) throws IOException {
+		public void start(boolean inTransaction, UUID currentUserId) throws IOException {
 			
 			
 		}
@@ -135,7 +136,7 @@ public interface Base {
 		}
 
 		@Override
-		public void changeUser(long userId) throws IOException {
+		public void changeUser(UUID userId) throws IOException {
 			
 			
 		}

--- a/src/main/java/com/supervisor/sdk/datasource/DomainRecordable.java
+++ b/src/main/java/com/supervisor/sdk/datasource/DomainRecordable.java
@@ -15,13 +15,8 @@ public class DomainRecordable<A1 extends Recordable> implements Recordable {
 	}
 	
 	@Override
-	public Long id() {
+	public UUID id() {
 		return record.id();
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		return record.guid();
 	}
 
 	@Override
@@ -35,12 +30,12 @@ public class DomainRecordable<A1 extends Recordable> implements Recordable {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return record.lastModifierId();
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		return record.ownerId();
 	}
 
@@ -50,7 +45,7 @@ public class DomainRecordable<A1 extends Recordable> implements Recordable {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return record.creatorId();
 	}
 

--- a/src/main/java/com/supervisor/sdk/datasource/DomainRecordableWrap.java
+++ b/src/main/java/com/supervisor/sdk/datasource/DomainRecordableWrap.java
@@ -13,13 +13,8 @@ public class DomainRecordableWrap implements Recordable {
 	}
 	
 	@Override
-	public Long id() {
+	public UUID id() {
 		return origin.id();
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		return origin.guid();
 	}
 
 	@Override
@@ -33,12 +28,12 @@ public class DomainRecordableWrap implements Recordable {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return origin.lastModifierId();
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		return origin.ownerId();
 	}
 
@@ -48,7 +43,7 @@ public class DomainRecordableWrap implements Recordable {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return origin.creatorId();
 	}
 

--- a/src/main/java/com/supervisor/sdk/datasource/DomainRecordables.java
+++ b/src/main/java/com/supervisor/sdk/datasource/DomainRecordables.java
@@ -12,6 +12,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public class DomainRecordables<A1 extends Recordable, D extends DomainSet<A1, D>> implements DomainSet<A1, D> {
 
@@ -29,7 +30,7 @@ public class DomainRecordables<A1 extends Recordable, D extends DomainSet<A1, D>
 		return domainOf(record.id());				
 	}
 	
-	protected A1 domainOf(final Long id) throws IOException {
+	protected A1 domainOf(final UUID id) throws IOException {
 		Constructor<? extends A1> constructor;
 		try {			
 			constructor = clazzImpl.getConstructor(Record.class);
@@ -161,12 +162,12 @@ public class DomainRecordables<A1 extends Recordable, D extends DomainSet<A1, D>
 	}
 
 	@Override
-	public A1 get(Long id) throws IOException {
+	public A1 get(final UUID id) throws IOException {
 		return domainOf(source.get(id));
 	}
 
 	@Override
-	public Optional<A1> getOrDefault(Long id) throws IOException {
+	public Optional<A1> getOrDefault(final UUID id) throws IOException {
 		
 		A1 item = null;
 		
@@ -180,17 +181,17 @@ public class DomainRecordables<A1 extends Recordable, D extends DomainSet<A1, D>
 	}
 
 	@Override
-	public boolean contains(Long id) throws IOException {
+	public boolean contains(final UUID id) throws IOException {
 		return source.contains(id);
 	}
 
 	@Override
-	public boolean contains(A1 item) throws IOException {
+	public boolean contains(final A1 item) throws IOException {
 		return source.contains(item.id()); 
 	}
 
 	@Override
-	public final void remove(Long id) throws IOException {
+	public final void remove(final UUID id) throws IOException {
 		if(contains(id)) {
 			final A1 item = get(id);
 			remove(item);

--- a/src/main/java/com/supervisor/sdk/datasource/DomainSet.java
+++ b/src/main/java/com/supervisor/sdk/datasource/DomainSet.java
@@ -3,10 +3,10 @@ package com.supervisor.sdk.datasource;
 import com.supervisor.sdk.datasource.comparators.Matcher;
 import com.supervisor.sdk.datasource.conditions.Filter;
 import com.supervisor.sdk.metadata.MethodReferenceUtils.MethodRefWithoutArg;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface DomainSet<T, D> {
 	
@@ -20,10 +20,10 @@ public interface DomainSet<T, D> {
 	T first() throws IOException;
 	T last() throws IOException;
 	
-	T get(Long id) throws IOException;
-	Optional<T> getOrDefault(Long id) throws IOException;
+	T get(UUID id) throws IOException;
+	Optional<T> getOrDefault(UUID id) throws IOException;
 	
-	boolean contains(Long id) throws IOException; 
+	boolean contains(UUID id) throws IOException;
 	boolean contains(T item) throws IOException;
 	
 	long count() throws IOException;
@@ -31,7 +31,7 @@ public interface DomainSet<T, D> {
 	boolean any() throws IOException;
 	
 	void remove() throws IOException;
-	void remove(Long id) throws IOException;
+	void remove(UUID id) throws IOException;
 	void remove(T item) throws IOException;
 	
 	D where(MethodRefWithoutArg<T> methodRef, Object value) throws IOException;

--- a/src/main/java/com/supervisor/sdk/datasource/EntitySet.java
+++ b/src/main/java/com/supervisor/sdk/datasource/EntitySet.java
@@ -3,6 +3,7 @@ package com.supervisor.sdk.datasource;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface EntitySet<T> {
 	List<T> items() throws IOException;
@@ -10,10 +11,10 @@ public interface EntitySet<T> {
 	T first() throws IOException;
 	T last() throws IOException;
 	
-	T get(Long id) throws IOException;
-	Optional<T> getOrDefault(Long id) throws IOException;
+	T get(UUID id) throws IOException;
+	Optional<T> getOrDefault(UUID id) throws IOException;
 	
-	boolean contains(Long id) throws IOException; 
+	boolean contains(UUID id) throws IOException;
 	boolean contains(T item) throws IOException;
 	
 	long count() throws IOException;
@@ -21,6 +22,6 @@ public interface EntitySet<T> {
 	boolean any() throws IOException;
 	
 	void remove() throws IOException;
-	void remove(Long id) throws IOException;
+	void remove(UUID id) throws IOException;
 	void remove(T item) throws IOException;
 }

--- a/src/main/java/com/supervisor/sdk/datasource/Record.java
+++ b/src/main/java/com/supervisor/sdk/datasource/Record.java
@@ -2,8 +2,8 @@ package com.supervisor.sdk.datasource;
 
 import com.supervisor.sdk.metadata.FieldMetadata;
 import com.supervisor.sdk.metadata.MethodReferenceUtils;
-
 import java.io.IOException;
+import java.util.UUID;
 
 public interface Record<A1 extends Recordable> extends Recordable {	
 	
@@ -20,7 +20,7 @@ public interface Record<A1 extends Recordable> extends Recordable {
 	
 	<T1 extends Recordable> RecordSet<T1> listOf(Class<T1> clazz) throws IOException;
 	RecordSet<A1> toList() throws IOException;
-	<T1 extends Recordable> Record<T1> of(Class<T1> clazz, Long id);
+	<T1 extends Recordable> Record<T1> of(Class<T1> clazz, UUID id);
 	<T extends Recordable> Record<T> of(MethodReferenceUtils.MethodRefWithoutArg<A1> methodRef) throws IOException;
 	
 	void mustBeUnique(MethodReferenceUtils.MethodRefWithoutArg<A1> methodRef, Object newValue) throws IOException;

--- a/src/main/java/com/supervisor/sdk/datasource/RecordSet.java
+++ b/src/main/java/com/supervisor/sdk/datasource/RecordSet.java
@@ -5,8 +5,8 @@ import com.supervisor.sdk.datasource.conditions.Condition;
 import com.supervisor.sdk.datasource.conditions.Filter;
 import com.supervisor.sdk.metadata.FieldMetadata;
 import com.supervisor.sdk.metadata.MethodReferenceUtils;
-
 import java.io.IOException;
+import java.util.UUID;
 
 public interface RecordSet<A1 extends Recordable> extends EntitySet<Record<A1>> {		
 	
@@ -43,7 +43,7 @@ public interface RecordSet<A1 extends Recordable> extends EntitySet<Record<A1>> 
 	RecordSet<A1> start(Long position) throws IOException;
 	
 	Record<A1> add() throws IOException;
-	Record<A1> addForUser(long uid) throws IOException;
+	Record<A1> addForUser(UUID uid) throws IOException;
 	
 	Object aggregate(String aggScript, String alias) throws IOException;
 	

--- a/src/main/java/com/supervisor/sdk/datasource/Recordable.java
+++ b/src/main/java/com/supervisor/sdk/datasource/Recordable.java
@@ -1,7 +1,6 @@
 package com.supervisor.sdk.datasource;
 
 import com.supervisor.sdk.metadata.Field;
-
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -10,25 +9,22 @@ import java.util.UUID;
 public interface Recordable {
 	
 	@Field(order=0, isKey=true, forceInherit=true)
-	Long id();	
-	
-	@Field(order=1, forceInherit=true)
-	UUID guid() throws IOException;
+	UUID id();
 	
 	@Field(order=101, forceInherit=true)
 	LocalDateTime creationDate() throws IOException;
 	
 	@Field(order=102, forceInherit=true)
-	Long creatorId() throws IOException;
+	UUID creatorId() throws IOException;
 	
 	@Field(order=103, forceInherit=true)
 	LocalDateTime lastModificationDate() throws IOException;
 	
 	@Field(order=104, forceInherit=true)
-	Long lastModifierId() throws IOException;
+	UUID lastModifierId() throws IOException;
 	
 	@Field(order=105, forceInherit=true)
-	Long ownerId() throws IOException;	
+	UUID ownerId() throws IOException;
 	
 	@Field(order=106, forceInherit=true, isMandatory=false)
 	String tag() throws IOException;

--- a/src/main/java/com/supervisor/sdk/datasource/RecordableGenerated.java
+++ b/src/main/java/com/supervisor/sdk/datasource/RecordableGenerated.java
@@ -15,13 +15,8 @@ public abstract class RecordableGenerated implements Recordable {
 	}
 	
 	@Override
-	public Long id() {
-		return 0L;
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		return UUID.randomUUID();
+	public UUID id() {
+		return null;
 	}
 
 	@Override
@@ -30,8 +25,8 @@ public abstract class RecordableGenerated implements Recordable {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
-		return 0L;
+	public UUID creatorId() throws IOException {
+		return null;
 	}
 
 	@Override
@@ -40,13 +35,13 @@ public abstract class RecordableGenerated implements Recordable {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
-		return 0L;
+	public UUID lastModifierId() throws IOException {
+		return null;
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
-		return 0L;
+	public UUID ownerId() throws IOException {
+		return null;
 	}
 
 	@Override

--- a/src/main/java/com/supervisor/sdk/datasource/SqlTxn.java
+++ b/src/main/java/com/supervisor/sdk/datasource/SqlTxn.java
@@ -1,11 +1,14 @@
 package com.supervisor.sdk.datasource;
 
+import com.supervisor.domain.User;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.sdk.utils.logging.Logger;
 import com.supervisor.sdk.utils.logging.MLogger;
 import org.takes.HttpException;
 import org.takes.Request;
 
 import java.net.HttpURLConnection;
+import java.util.UUID;
 
 public final class SqlTxn implements Txn {
 	
@@ -13,19 +16,19 @@ public final class SqlTxn implements Txn {
 	
 	private final Base base;
 	private final Request request;
-	private final long userId;
+	private final UUID userId;
 	
 	public SqlTxn(final Base base) {
-		this(base, 2L);
+		this(base, User.ANONYMOUS_ID);
 	}
 	
 	public SqlTxn(final Base base, final Request request) {
 		this.base = base;
-		this.userId = 0L;
+		this.userId = new OptUUID("0").value();
 		this.request = request;
 	}
 	
-	public SqlTxn(final Base base, final long userId) {
+	public SqlTxn(final Base base, final UUID userId) {
 		this.base = base;
 		this.userId = userId;
 		this.request = null;

--- a/src/main/java/com/supervisor/sdk/pgsql/PgRecord.java
+++ b/src/main/java/com/supervisor/sdk/pgsql/PgRecord.java
@@ -27,17 +27,17 @@ import java.util.UUID;
 
 public class PgRecord<A1 extends Recordable> implements Record<A1> {
 	
-	final Long id;
+	final UUID id;
 	final Map<String, Object> entries;
 	final Class<A1> clazz;
 	final BaseScheme scheme;
 	final Base base;
 	
-	public PgRecord(final Base base, final BaseScheme scheme, final Class<A1> clazz, final Long id) {
+	public PgRecord(final Base base, final BaseScheme scheme, final Class<A1> clazz, final UUID id) {
 		this(base, scheme, clazz, id, new HashMap<String, Object>());
 	}
 	
-	public PgRecord(final Base base, final BaseScheme scheme, final Class<A1> clazz, final Long id, final Map<String, Object> entries) {
+	public PgRecord(final Base base, final BaseScheme scheme, final Class<A1> clazz, final UUID id, final Map<String, Object> entries) {
 		this.id = id;
 		this.entries = entries;
 		this.scheme = scheme;
@@ -46,18 +46,13 @@ public class PgRecord<A1 extends Recordable> implements Record<A1> {
 	}
 	
 	@Override
-	public Long id() {
+	public UUID id() {
 		return id;
 	}
 	
 	@Override
 	public String name() throws IOException {
 		return scheme.nameOf(clazz);
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		return valueOf("guid");
 	}
 	
 	@Override
@@ -73,12 +68,12 @@ public class PgRecord<A1 extends Recordable> implements Record<A1> {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		return valueOf("last_modifier_id");
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		return valueOf("owner_id");
 	}
 
@@ -137,7 +132,7 @@ public class PgRecord<A1 extends Recordable> implements Record<A1> {
 	}
 
 	@Override
-	public <T1 extends Recordable> Record<T1> of(Class<T1> clazz, Long id) {
+	public <T1 extends Recordable> Record<T1> of(Class<T1> clazz, UUID id) {
 		return new PgRecord<>(base, scheme, clazz, id);
 	}
 
@@ -147,7 +142,7 @@ public class PgRecord<A1 extends Recordable> implements Record<A1> {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		return valueOf("creator_id");
 	}
 
@@ -184,7 +179,7 @@ public class PgRecord<A1 extends Recordable> implements Record<A1> {
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T extends Recordable> Record<T> of(MethodReferenceUtils.MethodRefWithoutArg<A1> methodRef) throws IOException {
-		Long newId = valueOf(methodRef);
+		UUID newId = valueOf(methodRef);
 		Method m = MethodReferenceUtils.getReferencedMethod(clazz, methodRef);
 		return of((Class<T>)m.getReturnType(), newId);
 	}

--- a/src/main/java/com/supervisor/sdk/pgsql/PgRecordSet.java
+++ b/src/main/java/com/supervisor/sdk/pgsql/PgRecordSet.java
@@ -87,7 +87,7 @@ public final class PgRecordSet<A1 extends Recordable> implements RecordSet<A1> {
 		
 		List<Record<A1>> items = new ArrayList<>();
 		for (ResultStatement result : results) {
-			items.add(new PgRecord<A1>(base, scheme, clazz, (Long)result.data().get("id")));
+			items.add(new PgRecord<A1>(base, scheme, clazz, (UUID)result.data().get("id")));
 		}
 		
 		return items;
@@ -121,7 +121,7 @@ public final class PgRecordSet<A1 extends Recordable> implements RecordSet<A1> {
 		Statement statement = new PgSimpleSelectStatement(base, Arrays.asList("id"), table, clause, parameters, ordering.script(), 1L, 1L);
 		List<ResultStatement> results = statement.execute();
 		
-		return new PgRecord<>(base, scheme, clazz, (Long)results.get(0).data().get("id"));
+		return new PgRecord<>(base, scheme, clazz, (UUID)results.get(0).data().get("id"));
 	}
 
 	@Override
@@ -135,7 +135,7 @@ public final class PgRecordSet<A1 extends Recordable> implements RecordSet<A1> {
 		Statement statement = new PgSimpleSelectStatement(base, Arrays.asList("id"), table, clause, parameters, ordering.reverse().script(), 1L, 1L);
 		List<ResultStatement> results = statement.execute();
 		
-		return new PgRecord<>(base, scheme, clazz, (Long)results.get(0).data().get("id"));
+		return new PgRecord<>(base, scheme, clazz, (UUID)results.get(0).data().get("id"));
 	}
 
 	@Override
@@ -707,12 +707,12 @@ public final class PgRecordSet<A1 extends Recordable> implements RecordSet<A1> {
 	}
 
 	@Override
-	public Record<A1> get(Long id) throws IOException {
+	public Record<A1> get(UUID id) throws IOException {
 		return where(A1::id, id).first();
 	}
 
 	@Override
-	public Optional<Record<A1>> getOrDefault(Long id) throws IOException {
+	public Optional<Record<A1>> getOrDefault(UUID id) throws IOException {
 		Record<A1> item = null;
 		
 		try {
@@ -725,7 +725,7 @@ public final class PgRecordSet<A1 extends Recordable> implements RecordSet<A1> {
 	}
 
 	@Override
-	public void remove(Long id) throws IOException {
+	public void remove(UUID id) throws IOException {
 		where(A1::id, id).remove();
 	}
 
@@ -735,7 +735,7 @@ public final class PgRecordSet<A1 extends Recordable> implements RecordSet<A1> {
 	}
 
 	@Override
-	public boolean contains(Long id) throws IOException {
+	public boolean contains(UUID id) throws IOException {
 		return where(A1::id, id).any();
 	}
 
@@ -767,14 +767,14 @@ public final class PgRecordSet<A1 extends Recordable> implements RecordSet<A1> {
 	}
 
 	@Override
-	public Record<A1> addForUser(long uid) throws IOException {
+	public Record<A1> addForUser(UUID uid) throws IOException {
 		entries.put("owner_id", uid);
-		Statement statement = new PgInsertStatement(base, scheme.nameOf(clazz), entries, UUID.randomUUID());
+		Statement statement = new PgInsertStatement(base, scheme.nameOf(clazz), entries);
 		List<ResultStatement> results = statement.execute();
 		
 		entries.clear();
 		
-		return new PgRecord<>(base, scheme, clazz, (Long)results.get(0).data().get("id"));
+		return new PgRecord<>(base, scheme, clazz, (UUID)results.get(0).data().get("id"));
 	}
 
 	@Override

--- a/src/main/java/com/supervisor/sdk/pgsql/SetupDataBase.java
+++ b/src/main/java/com/supervisor/sdk/pgsql/SetupDataBase.java
@@ -89,7 +89,7 @@ public abstract class SetupDataBase implements SetupData {
 													.execute()
 													.isEmpty();
 						if(notExists)
-							new PgInsertStatement(base, domainName, row, UUID.randomUUID()).execute();
+							new PgInsertStatement(base, domainName, row).execute();
 					}	
 				}				
 			}

--- a/src/main/java/com/supervisor/sdk/pgsql/statement/PgInsertStatement.java
+++ b/src/main/java/com/supervisor/sdk/pgsql/statement/PgInsertStatement.java
@@ -11,19 +11,18 @@ import java.util.UUID;
 
 public final class PgInsertStatement extends PgStatementUpdatable {
 
-	public PgInsertStatement(final Base base, final String tableName, final Map<String, Object> fieldValues, final UUID guid) {
-		super(base, statement(tableName, fieldValues), parameters(fieldValues, guid, base.currentUserId()));
+	public PgInsertStatement(final Base base, final String tableName, final Map<String, Object> fieldValues) {
+		super(base, statement(tableName, fieldValues), parameters(fieldValues, base.currentUserId()));
 	}
 	
-	private static List<Object> parameters(final Map<String, Object> fieldValues, final UUID guid, final Long userId){
+	private static List<Object> parameters(final Map<String, Object> fieldValues, final UUID userId){
 		List<Object> parameters = new ArrayList<>();
 		parameters.addAll(fieldValues.values());
 		parameters.add(userId);
 		
 		if(!fieldValues.containsKey("owner_id"))
 			parameters.add(userId);
-		
-		parameters.add(guid);
+
 		parameters.add(userId);
 		
 		return parameters;

--- a/src/main/java/com/supervisor/sdk/pgsql/statement/PgSimpleUpdateStatement.java
+++ b/src/main/java/com/supervisor/sdk/pgsql/statement/PgSimpleUpdateStatement.java
@@ -7,14 +7,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.UUID;
 
 public final class PgSimpleUpdateStatement extends PgStatementUpdatable {
 
-	public PgSimpleUpdateStatement(final Base base, final String tableName, final Map<String, Object> fieldValues, final Long id) {
+	public PgSimpleUpdateStatement(final Base base, final String tableName, final Map<String, Object> fieldValues, final UUID id) {
 		super(base, statement(tableName, fieldValues), parameters(fieldValues, id, base.currentUserId()));
 	}
 	
-	private static List<Object> parameters(final Map<String, Object> fieldValues, final Long id, final Long userId){
+	private static List<Object> parameters(final Map<String, Object> fieldValues, final UUID id, final UUID userId){
 		List<Object> parameters = new ArrayList<>();
 		parameters.addAll(fieldValues.values());
 		parameters.add(userId);

--- a/src/main/java/com/supervisor/sdk/takes/TkForm.java
+++ b/src/main/java/com/supervisor/sdk/takes/TkForm.java
@@ -1,6 +1,7 @@
 package com.supervisor.sdk.takes;
 
 import com.supervisor.sdk.datasource.Base;
+import com.supervisor.sdk.utils.OptUUID;
 import org.cactoos.iterable.Sticky;
 import org.takes.Request;
 import org.takes.Response;
@@ -13,6 +14,7 @@ import org.xembly.Directive;
 import org.xembly.Directives;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public abstract class TkForm implements Take {
 
@@ -22,14 +24,14 @@ public abstract class TkForm implements Take {
 		this.base = base;
 	}
 	
-	protected static Long getId(Request req) throws IOException {
-		return Long.parseLong(new RqHref.Smart(req).single("id", "0"));
+	protected static OptUUID getId(Request req) throws IOException {
+		return new OptUUID(new RqHref.Smart(req).single("id", "0"));
 	}
 
 	@Override
 	public Response act(Request req) throws IOException {
 		
-		final Long id = getId(req);																		
+		final OptUUID id = getId(req);
 		XeSource itemToShow;
 		
 		final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
@@ -38,7 +40,7 @@ public abstract class TkForm implements Take {
 		if(showExistingPostData) {
 			Directives dir = new Directives().add("item");
 			
-			if(id > 0)
+			if(id.isPresent())
 				dir.add("id").set(id).up();
 			
 			dir.append(postDataToDirs(form));
@@ -46,7 +48,7 @@ public abstract class TkForm implements Take {
 			dir.up();						
 			itemToShow = postItemDataToShow(id, req, form, dir);
 		}else {
-			if(id > 0) {
+			if(id.isPresent()) {
 				itemToShow = preItemDataToShow(id, req);
 			}else {
 				itemToShow = newItemToShow(req); 
@@ -81,7 +83,7 @@ public abstract class TkForm implements Take {
 		return XeSource.EMPTY;
 	}
 	
-	protected XeSource postItemDataToShow(final Long id, final Request req, final RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(final OptUUID id, final Request req, final RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeSource() {
 			
 			@Override
@@ -93,5 +95,5 @@ public abstract class TkForm implements Take {
 	
 	protected abstract String xslFormPath();
 	protected abstract Iterable<XeSource> contentToShow(final Request req, final XeSource itemToShow) throws IOException;
-	protected abstract XeSource preItemDataToShow(final Long id, final Request req) throws IOException;
+	protected abstract XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException;
 }

--- a/src/main/java/com/supervisor/sdk/takes/XeMIdentity.java
+++ b/src/main/java/com/supervisor/sdk/takes/XeMIdentity.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+
 import org.apache.commons.lang.StringUtils;
 import org.takes.Request;
 import org.takes.facets.auth.Identity;
@@ -69,7 +71,7 @@ public final class XeMIdentity extends XeWrap {
 		if(identity == Identity.ANONYMOUS) {
 			result = XeSource.EMPTY;
 		} else {
-			final Long id = Long.parseLong(identity.properties().get("id"));
+			final UUID id = UUID.fromString(identity.properties().get("id"));
 			final List<ResultStatement> results = base.query(
 				String.join(
 					System.lineSeparator(),

--- a/src/main/java/com/supervisor/sdk/utils/OptUUID.java
+++ b/src/main/java/com/supervisor/sdk/utils/OptUUID.java
@@ -1,0 +1,39 @@
+package com.supervisor.sdk.utils;
+
+import java.util.UUID;
+
+public final class OptUUID {
+
+    private final String value;
+
+    public OptUUID(final UUID value) {
+        this(value.toString());
+    }
+
+    public OptUUID(final String value) {
+        this.value = value;
+    }
+
+    public boolean isEmpty() {
+        return value.equals("") || value.equals("0");
+    }
+
+    public boolean isPresent() {
+        return ! value.isEmpty();
+    }
+
+    public UUID value() {
+        final UUID guid;
+        if (this.isEmpty()) {
+            guid = UUID.fromString("00000000-0000-0000-0000-000000000000");
+        } else {
+            guid = UUID.fromString(this.value);
+        }
+        return guid;
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
+}

--- a/src/main/java/com/supervisor/server/ActivityRealtime.java
+++ b/src/main/java/com/supervisor/server/ActivityRealtime.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.atmosphere.config.service.Get;
@@ -77,23 +78,23 @@ public final class ActivityRealtime {
     
     public final static class ActivityData {
     	
-    	private long id;
+    	private UUID id;
     	private List<IndicatorData> indics;
     	
     	public ActivityData() {
     		
     	}
     	
-    	public ActivityData(long id, List<IndicatorData> indics) {
+    	public ActivityData(UUID id, List<IndicatorData> indics) {
     		this.id = id;
     		this.indics = indics;
     	}
     	
-    	public Long getId() {
+    	public UUID getId() {
             return id;
     	}
 
-        public void setId(long id) {
+        public void setId(UUID id) {
             this.id = id;
         }
         

--- a/src/main/java/com/supervisor/server/Main.java
+++ b/src/main/java/com/supervisor/server/Main.java
@@ -43,6 +43,12 @@ public final class Main {
 	 * We start all things here.
 	 * @param args Arguments.
 	 * @throws Exception If fails
+	 * @todo #58:30min Generate primary key when inserting in database.
+	 *  We changed primary keys type from bigint to uuid. Keys were generated
+	 *  before. So, we need to generate also uuid.
+	 * @todo #58:30min Fix bug when editing a new form.
+	 *  We got an error saying that id's value is present but this value is
+	 *  `00000000-0000-0000-0000-000000000000`.
 	 */
     public static void main(final String... args) throws Exception {
 		final Map<String, String> map = new ConsoleArgs("--", args).asMap();

--- a/src/main/java/com/supervisor/sharing/AggregatedModelUniqueSharing.java
+++ b/src/main/java/com/supervisor/sharing/AggregatedModelUniqueSharing.java
@@ -1,11 +1,13 @@
 package com.supervisor.sharing;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Record;
 import com.supervisor.domain.Activity;
 import com.supervisor.domain.AggregatedModel;
 import com.supervisor.domain.impl.PxAggregatedModel;
+import com.supervisor.sdk.utils.OptUUID;
 
 public final class AggregatedModelUniqueSharing extends DataSharingBase<AggregatedModel, AggregatedModelShared> implements AggregatedModelSharing {
 
@@ -36,9 +38,9 @@ public final class AggregatedModelUniqueSharing extends DataSharingBase<Aggregat
 	@Override
 	protected Record<AggregatedModel> concreteRecord() throws IOException {
 				
-		Long concreteId = 0L;
+		OptUUID concreteId = new OptUUID("0");
 		if(action == WriterAction.TEMPLATING) {			
-			concreteId = source.id();
+			concreteId = new OptUUID(source.id());
 		} else {
 			for (
 					Record<AggregatedModelShared> rec : 
@@ -47,19 +49,19 @@ public final class AggregatedModelUniqueSharing extends DataSharingBase<Aggregat
 					   	  .where(AggregatedModelShared::activity, targetActivity.id())
 					   	  .items()
 			) {
-				final Long id = rec.valueOf(AggregatedModelShared::id);
+				final UUID id = rec.valueOf(AggregatedModelShared::id);
 				final AggregatedModel concrete = new PxAggregatedModel(source.listOf(AggregatedModel.class).get(id));
 				if(concrete.model().activity().id().equals(concreteActor.id())) {
-					concreteId = id;
+					concreteId = new OptUUID(id);
 					break;
 				}
 			}	
 			
-			if(concreteId == 0L)
+			if(concreteId.isEmpty())
 				throw new IllegalArgumentException(String.format("Concrete AggregatedModel not found (Generating activity %s )!", targetActivity.name()));
 		}
 		
-		return source.listOf(AggregatedModel.class).get(concreteId);
+		return source.listOf(AggregatedModel.class).get(concreteId.value());
 	}
 	
 	@Override
@@ -76,7 +78,7 @@ public final class AggregatedModelUniqueSharing extends DataSharingBase<Aggregat
 					   	  .where(AggregatedModelShared::activity, targetActivity.id())
 					   	  .items()
 			) {
-				final Long id = rec.valueOf(AggregatedModelShared::id);
+				final UUID id = rec.valueOf(AggregatedModelShared::id);
 				final AggregatedModel concrete = new PxAggregatedModel(source.listOf(AggregatedModel.class).get(id));
 				if(concrete.model().activity().id().equals(concreteActor.id())) {
 					return true;

--- a/src/main/java/com/supervisor/sharing/DataSharingBase.java
+++ b/src/main/java/com/supervisor/sharing/DataSharingBase.java
@@ -1,6 +1,7 @@
 package com.supervisor.sharing;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Record;
 import com.supervisor.domain.Activity;
@@ -63,7 +64,7 @@ public abstract class DataSharingBase<T extends Sharable, A extends DataShared<T
 	
 	protected Record<T> concreteRecord() throws IOException {
 		
-		final Long concreteId;
+		final UUID concreteId;
 		if(action == WriterAction.TEMPLATING) {			
 			concreteId = source.id();
 		} else {
@@ -79,7 +80,7 @@ public abstract class DataSharingBase<T extends Sharable, A extends DataShared<T
 	
 	protected Record<T> templateRecord() throws IOException {
 		
-		final Long templateId;
+		final UUID templateId;
 		if(action == WriterAction.TEMPLATING) {
 			templateId = source.listOf(dataSharedClazz)
 			          		   .get(source.id())

--- a/src/main/java/com/supervisor/sharing/ListDataFieldSourceUniqueSharing.java
+++ b/src/main/java/com/supervisor/sharing/ListDataFieldSourceUniqueSharing.java
@@ -1,11 +1,13 @@
 package com.supervisor.sharing;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Record;
 import com.supervisor.domain.Activity;
 import com.supervisor.domain.ListDataFieldSource;
 import com.supervisor.domain.impl.PxListDataFieldSource;
+import com.supervisor.sdk.utils.OptUUID;
 
 public final class ListDataFieldSourceUniqueSharing extends DataSharingBase<ListDataFieldSource, ListDataFieldSourceShared> implements ListDataFieldSourceSharing {
 
@@ -37,9 +39,9 @@ public final class ListDataFieldSourceUniqueSharing extends DataSharingBase<List
 	protected Record<ListDataFieldSource> concreteRecord() throws IOException {
 		
 		
-		Long concreteId = 0L;
+		OptUUID concreteId = new OptUUID("0");
 		if(action == WriterAction.TEMPLATING) {			
-			concreteId = source.id();
+			concreteId = new OptUUID(source.id());
 		} else {
 			for (
 					Record<ListDataFieldSourceShared> rec : 
@@ -48,19 +50,19 @@ public final class ListDataFieldSourceUniqueSharing extends DataSharingBase<List
 					   	  .where(ListDataFieldSourceShared::activity, targetActivity.id())
 					   	  .items()
 			) {
-				final Long id = rec.valueOf(ListDataFieldSourceShared::id);
+				final UUID id = rec.valueOf(ListDataFieldSourceShared::id);
 				final ListDataFieldSource concrete = new PxListDataFieldSource(source.listOf(ListDataFieldSource.class).get(id));
 				if(concrete.model().activity().id().equals(concreteListSourceModelActivity.id())) {
-					concreteId = id;
+					concreteId = new OptUUID(id);
 					break;
 				}
 			}	
 			
-			if(concreteId == 0L)
+			if(concreteId.isEmpty())
 				throw new IllegalArgumentException(String.format("Concrete ListDataFieldSource not found (Generating activity %s )!", targetActivity.name()));
 		}
 		
-		return source.listOf(ListDataFieldSource.class).get(concreteId);
+		return source.listOf(ListDataFieldSource.class).get(concreteId.value());
 	}
 	
 	@Override
@@ -76,7 +78,7 @@ public final class ListDataFieldSourceUniqueSharing extends DataSharingBase<List
 					   	  .where(ListDataFieldSourceShared::activity, targetActivity.id())
 					   	  .items()
 			) {
-				final Long id = rec.valueOf(ListDataFieldSourceShared::id);
+				final UUID id = rec.valueOf(ListDataFieldSourceShared::id);
 				final ListDataFieldSource concrete = new PxListDataFieldSource(source.listOf(ListDataFieldSource.class).get(id));
 				if(concrete.model().activity().id().equals(concreteListSourceModelActivity.id())) {
 					return true;

--- a/src/main/java/com/supervisor/takes/DashboardIndicator.java
+++ b/src/main/java/com/supervisor/takes/DashboardIndicator.java
@@ -1,6 +1,7 @@
 package com.supervisor.takes;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import org.takes.Request;
@@ -24,10 +25,10 @@ public final class DashboardIndicator extends IndicatorWrap {
 		final Supervisor module = new PxSupervisor(base, req);
 		Smart params = new RqHref.Smart(req);
 		
-		final Long activityId = Long.parseLong(params.single("activity"));
+		final UUID activityId = UUID.fromString(params.single("activity"));
 		Activity activity = module.activities().get(activityId);
 		
-		final Long id = Long.parseLong(params.single("id"));
+		final UUID id = UUID.fromString(params.single("id"));
 		return activity.indicators().get(id);
 	}
 }

--- a/src/main/java/com/supervisor/takes/RqComputedIndicator.java
+++ b/src/main/java/com/supervisor/takes/RqComputedIndicator.java
@@ -1,6 +1,7 @@
 package com.supervisor.takes;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import org.takes.Request;
@@ -28,7 +29,7 @@ public final class RqComputedIndicator implements ComputedIndicator {
 	public void calculate() throws IOException {
 		final Supervisor module = new PxSupervisor(base, req);
 		Smart params = new RqHref.Smart(req);
-		final Long activityId = Long.parseLong(params.single("activity"));
+		final UUID activityId = UUID.fromString(params.single("activity"));
 		Activity activity = module.activities().get(activityId);
 		
 		origin.calculate(new RqDashboardDate(req).toLocalDate(), activity);

--- a/src/main/java/com/supervisor/takes/RqUser.java
+++ b/src/main/java/com/supervisor/takes/RqUser.java
@@ -21,7 +21,7 @@ public final class RqUser extends UserWrap {
     
 	/**
      * Ctor.
-     * @param bse Base
+     * @param base Base
      * @param req Request
      * @throws IOException 
      * @throws AuthenticationFailedException 
@@ -35,10 +35,10 @@ public final class RqUser extends UserWrap {
         
 		final Identity identity = new RqAuth(request).identity();
         if (identity.equals(Identity.ANONYMOUS)) {
-        	user = new DmUser(base.select(User.class, 2L));
+        	user = new DmUser(base.select(User.class, User.ANONYMOUS_ID));
         }else {
         	Map<String, String> props = identity.properties();
-        	Users users = new PgUsers(new DmUser(base.select(User.class, 1L)));
+        	Users users = new PgUsers(new DmUser(base.select(User.class, User.ADMIN_ID)));
         	
         	try {
         		user = users.signin(props.get("email"), props.get("password"), true);

--- a/src/main/java/com/supervisor/takes/TkAccessEdit.java
+++ b/src/main/java/com/supervisor/takes/TkAccessEdit.java
@@ -4,6 +4,7 @@ import com.supervisor.domain.Access;
 import com.supervisor.domain.Membership;
 import com.supervisor.domain.impl.DmMembership;
 import com.supervisor.domain.impl.PxAccesses;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XeAccess;
 import com.supervisor.xe.XeAccessParam;
 import com.supervisor.xe.XeMembership;
@@ -46,9 +47,9 @@ public final class TkAccessEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(Long id, Request req) throws IOException {
+	protected XeSource preItemDataToShow(OptUUID id, Request req) throws IOException {
 		
-		final Access item = new PxAccesses(base).get(id);
+		final Access item = new PxAccesses(base).get(id.value());
 		return new XeChain(
 				new XeAccess("item", item), 
 				new XeAccessParam(item.parameters())
@@ -56,7 +57,7 @@ public final class TkAccessEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return preItemDataToShow(id, req);
 	}
 }

--- a/src/main/java/com/supervisor/takes/TkAccessSave.java
+++ b/src/main/java/com/supervisor/takes/TkAccessSave.java
@@ -15,6 +15,7 @@ import org.takes.rq.form.RqFormSmart;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkAccessSave extends TkBaseWrap {
@@ -24,7 +25,7 @@ public final class TkAccessSave extends TkBaseWrap {
 				base,
 				req -> {
 					new RqAdminAuth(base, req);
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 					
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));			
 					final String name = form.single("name");
@@ -36,7 +37,7 @@ public final class TkAccessSave extends TkBaseWrap {
 					// sauvegarder les paramètres
 					int nbOfParamsToTreat = getValuesOfRow("param_id", form).size();
 					for (int i = 0; i < nbOfParamsToTreat; i++) {
-						Long paramId = getRowLongValueAt("param_id", form, i);
+						UUID paramId = UUID.fromString(getRowValueAt("param_id", form, i));
 						AccessParam param = item.parameters().get(paramId);
 						
 						String paramName = getRowValueAt("param_name", form, i);

--- a/src/main/java/com/supervisor/takes/TkActivityBaseOnTemplateEdit.java
+++ b/src/main/java/com/supervisor/takes/TkActivityBaseOnTemplateEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -51,7 +53,7 @@ public final class TkActivityBaseOnTemplateEdit extends TkForm {
 	protected XeSource newItemToShow(final Request req) throws IOException {
 		Supervisor module = new PxSupervisor(base, req);		
 		ActivityTemplates templates = module.activityTemplates();
-		Long templateId = Long.parseLong(new RqHref.Smart(req).single("template"));
+		UUID templateId = UUID.fromString(new RqHref.Smart(req).single("template"));
 		
 		ActivityTemplate template = templates.get(templateId);
 		XeSource xeItem = new XeActivityTemplate("item", template); 
@@ -63,12 +65,12 @@ public final class TkActivityBaseOnTemplateEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		return XeSource.EMPTY;
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeDirectives(dir);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkActivityBaseOnTemplateSave.java
+++ b/src/main/java/com/supervisor/takes/TkActivityBaseOnTemplateSave.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -34,7 +35,7 @@ public final class TkActivityBaseOnTemplateSave extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
 					
-					final Long id = Long.parseLong(form.single("id"));
+					final UUID id = UUID.fromString(form.single("id"));
 					String name = form.single("name");
 					final PeriodicityUnit periodicityUnit = PeriodicityUnit.valueOf(form.single("periodicity_unit_id"));
 					final int periodicityNumber = Integer.parseInt(form.single("periodicity_number"));
@@ -50,7 +51,7 @@ public final class TkActivityBaseOnTemplateSave extends TkBaseWrap {
 						String state = getRowValueAt("param_state", form, i);
 						
 						if(state.equals("modified")) {
-							Long modelId = Long.parseLong(getValuesOfRow("param_model_id", form).get(i));
+							UUID modelId = UUID.fromString(getValuesOfRow("param_model_id", form).get(i));
 							String code = getRowValueAt("param_code", form, i);
 							String value = getRowValueAt("param_value", form, i);
 							params.add(new ActivityTemplateParamRequestImpl(modelId, code, value));

--- a/src/main/java/com/supervisor/takes/TkActivityDelete.java
+++ b/src/main/java/com/supervisor/takes/TkActivityDelete.java
@@ -4,8 +4,10 @@ import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
+import org.takes.misc.Opt;
 import org.takes.rq.RqHref;
 
 import com.supervisor.domain.Activities;
@@ -22,11 +24,11 @@ public final class TkActivityDelete extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final Activities myActivities = module.activities();
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));			
-					if(id == 0)
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
+					if(id.isEmpty())
 						throw new IllegalArgumentException("Cet élément n'existe pas !");
 					
-					Activity item = myActivities.get(id);
+					Activity item = myActivities.get(id.value());
 					
 					if(new RqUser(base, req).notOwn(item)) {
 						throw new IllegalArgumentException("Vous ne pouvez pas supprimer une activité partagée !");

--- a/src/main/java/com/supervisor/takes/TkActivityEdit.java
+++ b/src/main/java/com/supervisor/takes/TkActivityEdit.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
 import com.supervisor.sdk.utils.ListOfUniqueRecord;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.form.RqFormSmart;
 import org.takes.rs.xe.XeAppend;
@@ -53,11 +54,11 @@ public final class TkActivityEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(Long id, Request req) throws IOException {
+	protected XeSource preItemDataToShow(OptUUID id, Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		Activities myActivities = module.activities();
-		Activity act = myActivities.get(id);
+		Activity act = myActivities.get(id.value());
 		
 		if(new RqUser(base, req).notOwn(act)) {
 			throw new IllegalArgumentException("Vous ne pouvez pas éditer une activité partagée !");
@@ -78,13 +79,13 @@ public final class TkActivityEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
-		if(id > 0) {
+		if(id.isPresent()) {
 			
 			final Supervisor module = new PxSupervisor(base, req);
 			Activities myActivities = module.activities();
-			Activity act = myActivities.get(id);
+			Activity act = myActivities.get(id.value());
 			
 			if(new RqUser(base, req).notOwn(act)) {
 				throw new IllegalArgumentException("Vous ne pouvez pas éditer une activité partagée !");

--- a/src/main/java/com/supervisor/takes/TkActivityNextPeriod.java
+++ b/src/main/java/com/supervisor/takes/TkActivityNextPeriod.java
@@ -1,6 +1,7 @@
 package com.supervisor.takes;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 import com.supervisor.domain.bi.BiPeriod;
 import com.supervisor.domain.bi.impl.BiPeriodOfPeriodicity;
@@ -27,7 +28,7 @@ public final class TkActivityNextPeriod extends TkBaseWrap {
 					Smart params = new RqHref.Smart(req);					
 					final LocalDate date = new RqDashboardDate(req).toLocalDate();
 					
-					Long activityId = Long.parseLong(params.single("activity"));
+					UUID activityId = UUID.fromString(params.single("activity"));
 					Activity activity = module.activities().get(activityId);
 					final BiPeriod period = new NextBiPeriod(
 						new BiPeriodOfPeriodicity(date, activity.periodicity()),

--- a/src/main/java/com/supervisor/takes/TkActivityOrganize.java
+++ b/src/main/java/com/supervisor/takes/TkActivityOrganize.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import javax.json.JsonArray;
@@ -31,7 +32,7 @@ public final class TkActivityOrganize extends TkBaseWrap {
 					
 					final Request gReq = new RqGreedy(req);
 					
-					Long activityId = Long.parseLong(new RqHref.Smart(gReq).single("activity"));		
+					UUID activityId = UUID.fromString(new RqHref.Smart(gReq).single("activity"));
 					Activity activity = myActivities.get(activityId);
 					
 					if(new RqUser(base, req).notOwn(activity)) {
@@ -42,7 +43,7 @@ public final class TkActivityOrganize extends TkBaseWrap {
 					JsonArray locations = rqJson.payload().asJsonArray();
 					for (JsonObject myLoc : locations.getValuesAs(JsonObject.class)) {
 						
-						Long id = myLoc.getJsonNumber("id").longValue();			
+						UUID id = UUID.fromString(myLoc.getJsonString("id").getString());
 						Indicator indicator = activity.indicators().get(id);	
 						
 						final int sizeX = myLoc.getInt("sizeX");

--- a/src/main/java/com/supervisor/takes/TkActivityPeriodAtDate.java
+++ b/src/main/java/com/supervisor/takes/TkActivityPeriodAtDate.java
@@ -1,6 +1,7 @@
 package com.supervisor.takes;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 import com.supervisor.domain.bi.BiPeriod;
 import com.supervisor.domain.bi.impl.BiPeriodOfPeriodicity;
@@ -26,7 +27,7 @@ public final class TkActivityPeriodAtDate extends TkBaseWrap {
 					Smart params = new RqHref.Smart(req);					
 					final LocalDate date = new RqDashboardDate(req).toLocalDate();
 					
-					Long activityId = Long.parseLong(params.single("activity"));
+					UUID activityId = UUID.fromString(params.single("activity"));
 					Activity activity = module.activities().get(activityId);
 					final BiPeriod period = new BiPeriodOfPeriodicity(date, activity.periodicity());
 					

--- a/src/main/java/com/supervisor/takes/TkActivityPreviousPeriod.java
+++ b/src/main/java/com/supervisor/takes/TkActivityPreviousPeriod.java
@@ -1,6 +1,7 @@
 package com.supervisor.takes;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 import com.supervisor.domain.bi.BiPeriod;
 import com.supervisor.domain.bi.impl.BiPeriodOfPeriodicity;
@@ -27,7 +28,7 @@ public final class TkActivityPreviousPeriod extends TkBaseWrap {
 					Smart params = new RqHref.Smart(req);					
 					final LocalDate date = new RqDashboardDate(req).toLocalDate();
 					
-					Long activityId = Long.parseLong(params.single("activity"));
+					UUID activityId = UUID.fromString(params.single("activity"));
 					Activity activity = module.activities().get(activityId);
 					final BiPeriod period = new PreviousBiPeriod(
 						new BiPeriodOfPeriodicity(date, activity.periodicity()),

--- a/src/main/java/com/supervisor/takes/TkActivityShowDefault.java
+++ b/src/main/java/com/supervisor/takes/TkActivityShowDefault.java
@@ -12,6 +12,8 @@ import com.supervisor.domain.Activity;
 import com.supervisor.domain.Supervisor;
 import com.supervisor.domain.impl.PxSupervisor;
 
+import java.util.UUID;
+
 public final class TkActivityShowDefault extends TkBaseWrap {
 
 	public TkActivityShowDefault(Base base) {
@@ -21,7 +23,7 @@ public final class TkActivityShowDefault extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final Activities myActivities = module.activities();
 					Smart params = new RqHref.Smart(req);			
-					final Long id = Long.parseLong(params.single("id", "0"));
+					final UUID id = UUID.fromString(params.single("id"));
 					
 					Activity act = myActivities.get(id);
 					act.setDefaultShown();

--- a/src/main/java/com/supervisor/takes/TkActivityTemplateDelete.java
+++ b/src/main/java/com/supervisor/takes/TkActivityTemplateDelete.java
@@ -4,6 +4,7 @@ import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqHref;
@@ -22,11 +23,11 @@ public final class TkActivityTemplateDelete extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final ActivityTemplates myActivities = module.activityTemplates();
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));			
-					if(id == 0)
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
+					if(id.isEmpty())
 						throw new IllegalArgumentException("Cet élément n'existe pas !");
 					
-					ActivityTemplate item = myActivities.get(id);
+					ActivityTemplate item = myActivities.get(id.value());
 					
 					if(new RqUser(base, req).notOwn(item)) {
 						throw new IllegalArgumentException("Vous ne pouvez pas supprimer une activité partagée !");

--- a/src/main/java/com/supervisor/takes/TkActivityTemplateEdit.java
+++ b/src/main/java/com/supervisor/takes/TkActivityTemplateEdit.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
 import com.supervisor.sdk.utils.ListOfUniqueRecord;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.form.RqFormSmart;
 import org.takes.rs.xe.XeAppend;
@@ -54,12 +55,12 @@ public final class TkActivityTemplateEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(Long id, Request req) throws IOException {
+	protected XeSource preItemDataToShow(OptUUID id, Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
 		ActivityTemplates myActivities = module.activityTemplates();
-		ActivityTemplate act = myActivities.get(id);
+		ActivityTemplate act = myActivities.get(id.value());
 		
 		if(new RqUser(base, req).notOwn(act)) {
 			throw new IllegalArgumentException("Vous ne pouvez pas éditer une activité partagée !");
@@ -81,12 +82,12 @@ public final class TkActivityTemplateEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
-		if(id > 0) {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+		if(id.isPresent()) {
 			
 			final Supervisor module = new PxSupervisor(base, req);
 			ActivityTemplates myActivities = module.activityTemplates();
-			ActivityTemplate act = myActivities.get(id);
+			ActivityTemplate act = myActivities.get(id.value());
 			
 			if(new RqUser(base, req).notOwn(act)) {
 				throw new IllegalArgumentException("Vous ne pouvez pas éditer une activité partagée !");

--- a/src/main/java/com/supervisor/takes/TkActivityTemplateGenerate.java
+++ b/src/main/java/com/supervisor/takes/TkActivityTemplateGenerate.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -25,7 +26,7 @@ public final class TkActivityTemplateGenerate extends TkBaseWrap {
 					
 					ActivityTemplate itemSaved;
 					
-					final Long originId = Long.parseLong(new RqHref.Smart(req).single("activity"));
+					final UUID originId = UUID.fromString(new RqHref.Smart(req).single("activity"));
 					Activity origin = module.activities().get(originId);
 					itemSaved = myItems.add(origin);
 					return new RsForward(

--- a/src/main/java/com/supervisor/takes/TkActivityTemplateNewDesignerEdit.java
+++ b/src/main/java/com/supervisor/takes/TkActivityTemplateNewDesignerEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -33,7 +35,7 @@ public final class TkActivityTemplateNewDesignerEdit extends TkForm {
 	protected Iterable<XeSource> contentToShow(final Request req, final XeSource itemToShow) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
-		final Long activityId = Long.parseLong(new RqHref.Smart(req).single("activity"));
+		final UUID activityId = UUID.fromString(new RqHref.Smart(req).single("activity"));
 		final ActivityTemplate template = module.activityTemplates().get(activityId);
 		
 		List<XeSource> content = new ArrayList<>();
@@ -45,12 +47,12 @@ public final class TkActivityTemplateNewDesignerEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		return XeSource.EMPTY;
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeActivityTemplate(dir);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkActivityTemplateNewDesignerSave.java
+++ b/src/main/java/com/supervisor/takes/TkActivityTemplateNewDesignerSave.java
@@ -1,6 +1,7 @@
 package com.supervisor.takes;
 
 import java.util.Optional;
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -25,7 +26,7 @@ public final class TkActivityTemplateNewDesignerSave extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
 						
-					final Long activityId = Long.parseLong(new RqHref.Smart(req).single("activity"));
+					final UUID activityId = UUID.fromString(new RqHref.Smart(req).single("activity"));
 					final ActivityTemplate template = module.activityTemplates().get(activityId);
 					
 					final String email = form.single("email");		

--- a/src/main/java/com/supervisor/takes/TkActivityTemplatePublishedAvailable.java
+++ b/src/main/java/com/supervisor/takes/TkActivityTemplatePublishedAvailable.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -20,7 +21,7 @@ public final class TkActivityTemplatePublishedAvailable extends TkBaseWrap {
 				req -> {
 					final Supervisor module = new PxSupervisor(base, req);
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 					ActivityTemplatePublished itemSaved = module.activityTemplatesPublished().get(id);
 					
 					if(new RqUser(base, req).notOwn(itemSaved)) {

--- a/src/main/java/com/supervisor/takes/TkActivityTemplatePublishedDowload.java
+++ b/src/main/java/com/supervisor/takes/TkActivityTemplatePublishedDowload.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -20,7 +21,7 @@ public final class TkActivityTemplatePublishedDowload extends TkBaseWrap {
 				req -> {
 					final Supervisor module = new PxSupervisor(base, req);
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));					
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 					ActivityTemplatePublished template = module.activityTemplatesPublished().get(id);
 					
 					if(!new RqUser(base, req).profile().isUpperOrEqualTo(template.profile()))

--- a/src/main/java/com/supervisor/takes/TkActivityTemplatePublishedEdit.java
+++ b/src/main/java/com/supervisor/takes/TkActivityTemplatePublishedEdit.java
@@ -3,10 +3,12 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.domain.impl.PxProfiles;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -36,7 +38,7 @@ public final class TkActivityTemplatePublishedEdit extends TkForm {
 	@Override
 	protected Iterable<XeSource> contentToShow(final Request req, final XeSource itemToShow) throws IOException {
 		final Supervisor module = new PxSupervisor(base, req);
-		Long templateId = Long.parseLong(new RqHref.Smart(req).single("template", "0"));
+		UUID templateId = UUID.fromString(new RqHref.Smart(req).single("template"));
 		ActivityTemplate template = module.activityTemplates().get(templateId);
 		
 		List<XeSource> content = new ArrayList<>();
@@ -51,15 +53,15 @@ public final class TkActivityTemplatePublishedEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		final Supervisor module = new PxSupervisor(base, req);
-		final ActivityTemplatePublished item = module.activityTemplatesPublished().get(id);
+		final ActivityTemplatePublished item = module.activityTemplatesPublished().get(id.value());
 		
 		return new XeActivityTemplatePublished("item", item);
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeActivityTemplatePublished(dir); 
 	}	
 	

--- a/src/main/java/com/supervisor/takes/TkActivityTemplatePublishedLike.java
+++ b/src/main/java/com/supervisor/takes/TkActivityTemplatePublishedLike.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -21,7 +22,7 @@ public final class TkActivityTemplatePublishedLike extends TkBaseWrap {
 				req -> {
 					final Supervisor module = new PxSupervisor(base, req);
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));					
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 					ActivityTemplatePublished template = module.activityTemplatesPublished().get(id);
 					
 					template.like();

--- a/src/main/java/com/supervisor/takes/TkActivityTemplatePublishedObsolete.java
+++ b/src/main/java/com/supervisor/takes/TkActivityTemplatePublishedObsolete.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -20,7 +21,7 @@ public final class TkActivityTemplatePublishedObsolete extends TkBaseWrap {
 				req -> {
 					final Supervisor module = new PxSupervisor(base, req);
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 					ActivityTemplatePublished itemSaved = module.activityTemplatesPublished().get(id);
 								
 					if(new RqUser(base, req).notOwn(itemSaved)) {

--- a/src/main/java/com/supervisor/takes/TkActivityTemplatePublishedSave.java
+++ b/src/main/java/com/supervisor/takes/TkActivityTemplatePublishedSave.java
@@ -1,10 +1,12 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.domain.impl.PxProfiles;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqGreedy;
@@ -27,8 +29,8 @@ public final class TkActivityTemplatePublishedSave extends TkBaseWrap {
 					
 					final Supervisor module = new PxSupervisor(base, req);
 					
-					final Long templateId = Long.parseLong(form.single("template_id"));
-					final Long profileId = Long.parseLong(form.single("profile_id"));
+					final UUID templateId = UUID.fromString(form.single("template_id"));
+					final UUID profileId = UUID.fromString(form.single("profile_id"));
 					final String icon = form.single("icon");
 								
 					ActivityTemplate template = module.activityTemplates().get(templateId);
@@ -39,9 +41,9 @@ public final class TkActivityTemplatePublishedSave extends TkBaseWrap {
 					Profile profile = new PxProfiles(base).get(profileId);
 					ActivityTemplatePublished itemSaved;
 
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
-					if(id > 0) {			
-						itemSaved = module.activityTemplatesPublished().get(id);		
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
+					if(id.isPresent()) {
+						itemSaved = module.activityTemplatesPublished().get(id.value());
 					}else
 					{			
 						itemSaved = module.activityTemplatesPublished().publish(template, icon);
@@ -52,7 +54,7 @@ public final class TkActivityTemplatePublishedSave extends TkBaseWrap {
 					
 					final String msg;
 					
-					if(id > 0)
+					if(id.isPresent())
 						msg = "La publication a été mise à jour avec succès !";			
 					else
 						msg = String.format("Le modèle %s a été publié avec succès !", itemSaved.name());

--- a/src/main/java/com/supervisor/takes/TkActivityTemplatePublishedVisualized.java
+++ b/src/main/java/com/supervisor/takes/TkActivityTemplatePublishedVisualized.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.form.RqFormSmart;
 import org.takes.rs.xe.XeAppend;
@@ -43,9 +44,9 @@ public final class TkActivityTemplatePublishedVisualized extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		final Supervisor module = new PxSupervisor(base, req);
-		final ActivityTemplatePublished item = module.activityTemplatesPublished().get(id);
+		final ActivityTemplatePublished item = module.activityTemplatesPublished().get(id.value());
 		
 		/* Enregistrer la vue */
 		item.view();
@@ -54,7 +55,7 @@ public final class TkActivityTemplatePublishedVisualized extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return XeSource.EMPTY; 
 	}	
 	

--- a/src/main/java/com/supervisor/takes/TkActivityTemplateReleaseEdit.java
+++ b/src/main/java/com/supervisor/takes/TkActivityTemplateReleaseEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -42,7 +44,7 @@ public final class TkActivityTemplateReleaseEdit extends TkForm {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		ActivityTemplates templates = module.activityTemplates();
-		Long templateId = Long.parseLong(href.single("template"));
+		UUID templateId = UUID.fromString(href.single("template"));
 		ActivityTemplate template = templates.get(templateId);
 		
 		List<XeSource> content = new ArrayList<>();
@@ -56,15 +58,15 @@ public final class TkActivityTemplateReleaseEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(Long id, Request req) throws IOException {
+	protected XeSource preItemDataToShow(OptUUID id, Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		ActivityTemplates templates = module.activityTemplates();
 		
-		Long templateId = Long.parseLong(new RqHref.Smart(req).single("template"));
+		UUID templateId = UUID.fromString(new RqHref.Smart(req).single("template"));
 		ActivityTemplate template = templates.get(templateId);
 		
-		ActivityTemplateRelease release = template.releases().get(id);
+		ActivityTemplateRelease release = template.releases().get(id.value());
 		
 		return new XeChain(
 				new XeActivityTemplateRelease("item", release)
@@ -72,9 +74,9 @@ public final class TkActivityTemplateReleaseEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
-		if(id == 0) {
+		if(id.isEmpty()) {
 			final RqHref.Smart href = new RqHref.Smart(req);
 			
 			return new XeChain(

--- a/src/main/java/com/supervisor/takes/TkActivityTemplateReleaseSave.java
+++ b/src/main/java/com/supervisor/takes/TkActivityTemplateReleaseSave.java
@@ -1,9 +1,11 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqGreedy;
@@ -29,23 +31,22 @@ public final class TkActivityTemplateReleaseSave extends TkBaseWrap {
 					final String version = form.single("version");
 					final String notes = form.single("notes");
 						
-					final Long templateId = Long.parseLong(form.single("release_template_id"));
+					final UUID templateId = UUID.fromString(form.single("release_template_id"));
 					final ActivityTemplate template = module.activityTemplates().get(templateId);
-					
+
 					final ActivityTemplateRelease release;
-					final Long id = Long.parseLong(href.single("id", "0"));
-					if(id > 0) {
-						release = template.releases().get(id);
+					final OptUUID id = new OptUUID(href.single("id", "0"));
+					if(id.isPresent()) {
+						release = template.releases().get(id.value());
 						release.update(version, notes); 
 					}else
 					{
-						final Long activityId = Long.parseLong(form.single("release_activity_src_id"));
-						final Activity activity = module.activities().get(activityId);
+						final Activity activity = module.activities().get(UUID.fromString(form.single("release_activity_src_id")));
 						release = template.releases().add(activity, version, notes);
 					}
 							
 					final String msg;
-					if(id > 0)
+					if(id.isEmpty())
 						msg = String.format("La release %s a été modifiée avec succès !", release.version());
 					else
 						msg = String.format("La release %s a été créée avec succès !", release.version());

--- a/src/main/java/com/supervisor/takes/TkActivityUpdateApply.java
+++ b/src/main/java/com/supervisor/takes/TkActivityUpdateApply.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -23,9 +24,9 @@ public final class TkActivityUpdateApply extends TkBaseWrap {
 					final RqHref.Smart href = new RqHref.Smart(req);	
 					final Supervisor module = new PxSupervisor(base, req);
 											
-					final Long templateId = Long.parseLong(href.single("template"));
-					final Long activityId = Long.parseLong(href.single("activity"));
-					final Long releaseId = Long.parseLong(href.single("release"));
+					final UUID templateId = UUID.fromString(href.single("template"));
+					final UUID activityId = UUID.fromString(href.single("activity"));
+					final UUID releaseId = UUID.fromString(href.single("release"));
 						
 					final ActivityTemplate template = module.activityTemplates().get(templateId);
 					final Activity activity = module.activities().get(activityId);

--- a/src/main/java/com/supervisor/takes/TkActivityUpdateEdit.java
+++ b/src/main/java/com/supervisor/takes/TkActivityUpdateEdit.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rs.xe.XeAppend;
 import org.takes.rs.xe.XeChain;
@@ -44,11 +45,11 @@ public final class TkActivityUpdateEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(Long id, Request req) throws IOException {
+	protected XeSource preItemDataToShow(OptUUID id, Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		Activity activity = module.activities().get(id);
+		Activity activity = module.activities().get(id.value());
 		if(activity.isUpToDate())
 			throw new IllegalArgumentException("L'activité est déjà à jour !");
 		

--- a/src/main/java/com/supervisor/takes/TkAdminChangePasswordEdit.java
+++ b/src/main/java/com/supervisor/takes/TkAdminChangePasswordEdit.java
@@ -2,6 +2,7 @@ package com.supervisor.takes;
 
 import com.supervisor.domain.Membership;
 import com.supervisor.domain.impl.DmMembership;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XeUser;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
@@ -14,6 +15,7 @@ import org.xembly.Directive;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public final class TkAdminChangePasswordEdit extends TkForm {
 
@@ -32,7 +34,7 @@ public final class TkAdminChangePasswordEdit extends TkForm {
 		new RqAdminAuth(base, req);
 		
 		final Membership module = new DmMembership(base, req);
-		final Long userId = Long.parseLong(new RqHref.Smart(req).single("user"));
+		final UUID userId = UUID.fromString(new RqHref.Smart(req).single("user"));
 		List<XeSource> content = new ArrayList<>();
 		content.add(new XeUser(module.users().get(userId)));
 		content.add(itemToShow);
@@ -46,12 +48,12 @@ public final class TkAdminChangePasswordEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(Long id, Request req) throws IOException {
+	protected XeSource preItemDataToShow(OptUUID id, Request req) throws IOException {
 		return XeSource.EMPTY;
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return XeSource.EMPTY;
 	}
 }

--- a/src/main/java/com/supervisor/takes/TkAdminChangePasswordSave.java
+++ b/src/main/java/com/supervisor/takes/TkAdminChangePasswordSave.java
@@ -11,6 +11,7 @@ import org.takes.rq.RqGreedy;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkAdminChangePasswordSave extends TkBaseWrap {
@@ -22,7 +23,7 @@ public final class TkAdminChangePasswordSave extends TkBaseWrap {
 					new RqAdminAuth(base, req);
 					
 					final Membership module = new DmMembership(base, req);
-					Long userId = Long.parseLong(new RqHref.Smart(req).single("user"));
+					UUID userId = UUID.fromString(new RqHref.Smart(req).single("user"));
 					
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
 					

--- a/src/main/java/com/supervisor/takes/TkAggregatedModelDelete.java
+++ b/src/main/java/com/supervisor/takes/TkAggregatedModelDelete.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -21,7 +22,7 @@ public final class TkAggregatedModelDelete extends TkBaseWrap {
 				req -> {
 					final Supervisor module = new PxSupervisor(base, req);
 					final UserAggregatedModels items = module.aggregatedModels();
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 
 					final AggregatedModel item = items.get(id);
 					if(new RqUser(base, req).notOwn(item)) {

--- a/src/main/java/com/supervisor/takes/TkAggregatedModelEdit.java
+++ b/src/main/java/com/supervisor/takes/TkAggregatedModelEdit.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.form.RqFormSmart;
 import org.takes.rs.xe.XeAppend;
@@ -78,11 +79,11 @@ public final class TkAggregatedModelEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		final UserAggregatedModels items = module.aggregatedModels();
-		final AggregatedModel item = items.get(id);
+		final AggregatedModel item = items.get(id.value());
 
 		return new XeChain(
 			new XeAggregatedModel("item", item),
@@ -105,8 +106,8 @@ public final class TkAggregatedModelEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
-		if(id == 0)
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+		if(id.isEmpty())
 			return newItemToShow(req);
 		else
 			return preItemDataToShow(id, req);

--- a/src/main/java/com/supervisor/takes/TkAggregatedModelSave.java
+++ b/src/main/java/com/supervisor/takes/TkAggregatedModelSave.java
@@ -2,6 +2,7 @@ package com.supervisor.takes;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -9,6 +10,7 @@ import com.supervisor.sdk.datasource.comparators.Comparator;
 import com.supervisor.sdk.takes.TkBaseWrap;
 import com.supervisor.sdk.utils.BasicCodeGenerator;
 import com.supervisor.sdk.utils.CodeGenerator;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.collections.IteratorUtils;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
@@ -42,15 +44,15 @@ public final class TkAggregatedModelSave extends TkBaseWrap {
 					
 					AggregatedModel itemSaved = null;
 					
-					final Long activityId = Long.parseLong(form.single("activity_id"));
+					final UUID activityId = UUID.fromString(form.single("activity_id"));
 					final Activity activity = module.activities().get(activityId);
 					final AggregatedModels items = activity.aggregatedModels();
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));		
-					if(id > 0) {
-						final Long dateReferenceId = Long.parseLong(form.single("date_reference_id"));
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
+					if(id.isPresent()) {
+						final UUID dateReferenceId = UUID.fromString(form.single("date_reference_id"));
 						
-						itemSaved = items.get(id);	
+						itemSaved = items.get(id.value());
 						final DataField dateReference = itemSaved.fields().get(dateReferenceId);
 						DataFields fields = itemSaved.model().fields();
 						
@@ -73,7 +75,7 @@ public final class TkAggregatedModelSave extends TkBaseWrap {
 							}
 							
 							if(state.equals("modified")) {
-								Long paramId = getRowLongValueAt("param_id", form, i);
+								UUID paramId = UUID.fromString(getRowValueAt("param_id", form, i));
 								ParamDataField param = itemSaved.params()
 										                     .get(paramId);
 								
@@ -87,7 +89,7 @@ public final class TkAggregatedModelSave extends TkBaseWrap {
 							}
 							
 							if(state.equals("removed")) {
-								Long paramId = getRowLongValueAt("param_id", form, i);
+								UUID paramId = UUID.fromString(getRowValueAt("param_id", form, i));
 								itemSaved.params()
 										 .remove(paramId);
 							}
@@ -105,14 +107,14 @@ public final class TkAggregatedModelSave extends TkBaseWrap {
 							}
 							
 							if(state.equals("modified")) {
-								Long filterId = getRowLongValueAt("filter_id", form, i);
+								UUID filterId = UUID.fromString(getRowValueAt("filter_id", form, i));
 								ModelFilter filter = itemSaved.filters().get(filterId);
 								
 								saveConditionsOf(filter, form, (int)index, fields);
 							}
 							
 							if(state.equals("removed")) {
-								Long filterId = getRowLongValueAt("filter_id", form, i);
+								UUID filterId = UUID.fromString(getRowValueAt("filter_id", form, i));
 								itemSaved.filters().remove(filterId);
 							}
 						}
@@ -134,7 +136,7 @@ public final class TkAggregatedModelSave extends TkBaseWrap {
 															name
 														);
 						
-						final Long modelId = Long.parseLong(form.single("model_id"));			
+						final UUID modelId = UUID.fromString(form.single("model_id"));
 						final DataModel model = module.dataModels().get(modelId);
 						itemSaved = items.add(generator.generate(), model);						
 						itemSaved.update(name, model.fields().get("DATE"));  
@@ -200,7 +202,7 @@ public final class TkAggregatedModelSave extends TkBaseWrap {
 				Comparator comparator = Comparator.valueOf(getRowValueAt("cond_comparator_id", form, i));
 				String value = getRowValueAt("cond_value", form, i);
 				
-				Long id = getRowLongValueAt("cond_id", form, i);
+				UUID id = UUID.fromString(getRowValueAt("cond_id", form, i));
 				ModelFilterCondition cond = filter.conditions()
 							                     .get(id);
 				
@@ -214,7 +216,7 @@ public final class TkAggregatedModelSave extends TkBaseWrap {
 			}
 			
 			if(state.equals("removed")) {
-				Long id = getRowLongValueAt("cond_id", form, i);
+				UUID id = UUID.fromString(getRowValueAt("cond_id", form, i));
 				filter.conditions()
 					  .remove(id);
 			}

--- a/src/main/java/com/supervisor/takes/TkBeginMobileTransaction.java
+++ b/src/main/java/com/supervisor/takes/TkBeginMobileTransaction.java
@@ -18,6 +18,7 @@ import org.takes.rq.RqHref;
 import org.takes.rs.RsJson;
 
 import javax.json.JsonObject;
+import java.util.UUID;
 
 public final class TkBeginMobileTransaction extends TkBaseWrap {
 
@@ -36,8 +37,8 @@ public final class TkBeginMobileTransaction extends TkBaseWrap {
 						JsonObject remplacement = rqJson.payload().asJsonObject();
 						final String number = remplacement.getString("number");
 						
-						Long methodId = Long.parseLong(new RqHref.Smart(gReq).single("method"));
-						Long paymentRequestId = Long.parseLong(new RqHref.Smart(gReq).single("request"));
+						UUID methodId = UUID.fromString(new RqHref.Smart(gReq).single("method"));
+						UUID paymentRequestId = UUID.fromString(new RqHref.Smart(gReq).single("request"));
 						PaymentMethod method = module.paymentMethods().get(methodId);
 						PaymentRequest paymentRequest = user.paymentRequests().get(paymentRequestId);
 						

--- a/src/main/java/com/supervisor/takes/TkChartCamembertSettingEdit.java
+++ b/src/main/java/com/supervisor/takes/TkChartCamembertSettingEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.lang.StringUtils;
 import org.takes.Request;
 import org.takes.rq.RqHref;
@@ -59,14 +61,14 @@ public final class TkChartCamembertSettingEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		final Supervisor module = new PxSupervisor(base, req);
 		
 		final String source = new RqHref.Smart(req).single("source");
-		final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+		final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 		final Activity activity = module.activities().get(activityId);
 		
-		final ChartCamembert indic = (ChartCamembert)activity.indicators().get(id);		
+		final ChartCamembert indic = (ChartCamembert)activity.indicators().get(id.value());
 				
 		return new XeChain(
 				new XeChartCamembertSetting("item", indic),
@@ -77,18 +79,18 @@ public final class TkChartCamembertSettingEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
 		final String source = new RqHref.Smart(req).single("source");
-		final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+		final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 		final Activity activity = module.activities().get(activityId);
 			
 		XeSource xeDataRule = XeSource.EMPTY;
 		XeSource xeParam = XeSource.EMPTY;
-		if(id > 0) {
-			final ChartCamembert indic = (ChartCamembert)activity.indicators().get(id);
+		if(id.isPresent()) {
+			final ChartCamembert indic = (ChartCamembert)activity.indicators().get(id.value());
 			xeDataRule = new XeDataLink(indic.links());
 			xeParam = new XeIndicatorDynamicParam(indic.dynamicParams());
 		}
@@ -104,13 +106,13 @@ public final class TkChartCamembertSettingEdit extends TkForm {
 	@Override
 	protected XeSource newItemToShow(Request req) throws IOException {
 		
-		Long activityId = Long.parseLong(new RqHref.Smart(req).single("activity", "0"));
-		if(activityId == 0)
+		OptUUID activityId = new OptUUID(new RqHref.Smart(req).single("activity", "0"));
+		if(activityId.isEmpty())
 			throw new IllegalArgumentException("Vous devez spécifier l'activité pour lequel vous créer cet indicateur !");
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		Activity activity = module.activities().get(activityId);
+		Activity activity = module.activities().get(activityId.value());
 		
 		return new XeChain(
 				new XeIndicatorType(module.indicatorTypes().indicatorType(IndicatorType.CHART_CAMEMBERT)), 

--- a/src/main/java/com/supervisor/takes/TkChartCamembertSettingSave.java
+++ b/src/main/java/com/supervisor/takes/TkChartCamembertSettingSave.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -11,6 +12,7 @@ import com.supervisor.sdk.takes.TkBaseWrap;
 import com.supervisor.sdk.time.PeriodicityUnit;
 import com.supervisor.sdk.utils.BasicCodeGenerator;
 import com.supervisor.sdk.utils.CodeGenerator;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.lang.StringUtils;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
@@ -43,7 +45,7 @@ public final class TkChartCamembertSettingSave extends TkBaseWrap {
 					final String label = form.single("label");
 					final String subLabel = form.single("sub_label", "");
 					final String description = form.single("description");	
-					final Long activityId = Long.parseLong(form.single("activity_id"));
+					final UUID activityId = UUID.fromString(form.single("activity_id"));
 					Activity activity = myActivities.get(activityId);
 					
 					if(new RqUser(base, req).notOwn(activity)) {
@@ -51,10 +53,10 @@ public final class TkChartCamembertSettingSave extends TkBaseWrap {
 					}
 					
 					ChartCamembert itemSaved;
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));		
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
 
-					if(id > 0) {			
-						itemSaved = (ChartCamembert)activity.indicators().get(id);
+					if(id.isPresent()) {
+						itemSaved = (ChartCamembert)activity.indicators().get(id.value());
 									
 						final String periodicityState = form.single("periodicity_state", "removed");
 						if(periodicityState.equals("added")) {
@@ -89,7 +91,7 @@ public final class TkChartCamembertSettingSave extends TkBaseWrap {
 					
 					final String msg;
 					
-					if(id > 0)
+					if(id.isPresent())
 						msg = String.format("L'indicateur %s a été modifié avec succès !", itemSaved.code());
 					else
 						msg = String.format("L'indicateur %s a été créé avec succès !", itemSaved.code());

--- a/src/main/java/com/supervisor/takes/TkCinetPayOpenTransaction.java
+++ b/src/main/java/com/supervisor/takes/TkCinetPayOpenTransaction.java
@@ -16,6 +16,7 @@ import org.takes.rs.RsWithHeader;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 public final class TkCinetPayOpenTransaction extends TkBaseWrap {
 
@@ -27,7 +28,7 @@ public final class TkCinetPayOpenTransaction extends TkBaseWrap {
 					final Membership module = new DmMembership(base, req);
 					final User user = module.user();
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("request"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("request"));
 					
 					final PaymentRequest payRequest = user.paymentRequests().get(id);
 					final CreditCard method = (CreditCard)module.paymentMethods().where(PaymentMethod::tag, "CINETPAY").first();

--- a/src/main/java/com/supervisor/takes/TkCinetPayTransactionCallback.java
+++ b/src/main/java/com/supervisor/takes/TkCinetPayTransactionCallback.java
@@ -31,7 +31,7 @@ public final class TkCinetPayTransactionCallback extends TkBaseWrap {
 				base,
 				req -> {
 					RecordSet<User> source = base.select(User.class);
-					User user = new DmUser(source.get(1L)); // prendre l'utilisateur Minlessika
+					User user = new DmUser(source.get(User.ADMIN_ID)); // prendre l'utilisateur Minlessika
 					
 					final Membership membership = new DmMembership(base, user);
 					

--- a/src/main/java/com/supervisor/takes/TkConfirmRegistering.java
+++ b/src/main/java/com/supervisor/takes/TkConfirmRegistering.java
@@ -33,7 +33,7 @@ public final class TkConfirmRegistering extends TkBaseWrap {
 											)
 									  );
 					
-					RegistrationRequests myRequests = module.registrationRequests().where(RegistrationRequest::guid, guid);
+					RegistrationRequests myRequests = module.registrationRequests().where(RegistrationRequest::id, guid);
 					
 					if(myRequests.isEmpty())
 						throw new IllegalArgumentException("The link sent is not valid !");

--- a/src/main/java/com/supervisor/takes/TkDataFieldDelete.java
+++ b/src/main/java/com/supervisor/takes/TkDataFieldDelete.java
@@ -1,11 +1,15 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
+import org.checkerframework.checker.guieffect.qual.UI;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
+import org.takes.misc.Opt;
 import org.takes.rq.RqHref;
 
 import com.supervisor.domain.UserScope;
@@ -20,15 +24,15 @@ public final class TkDataFieldDelete extends TkBaseWrap {
 		super(
 				base, 
 				req -> {
-					Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
-					Long tableId = Long.parseLong(new RqHref.Smart(req).single("table", "0"));
-					Long tableModelId = Long.parseLong(new RqHref.Smart(req).single("table_model", "0"));
+					UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
+					OptUUID tableId = new OptUUID(new RqHref.Smart(req).single("table", "0"));
+					OptUUID tableModelId = new OptUUID(new RqHref.Smart(req).single("table_model", "0"));
 					
 					final Supervisor module = new PxSupervisor(base, req);
 					DataSheetModel model = module.dataSheetModels().get(modelId);
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
 
-					EditableDataField item = (EditableDataField)model.fields().get(id);
+					EditableDataField item = (EditableDataField)model.fields().get(id.value());
 					
 					if(item.userScope() == UserScope.SYSTEM)
 						throw new IllegalArgumentException("Vous ne pouvez pas supprimer un champ système !");
@@ -36,7 +40,7 @@ public final class TkDataFieldDelete extends TkBaseWrap {
 					String name = item.name();
 					model.fields().remove(item);
 								
-					if(tableId > 0) {
+					if(tableId.isPresent()) {
 						return new RsForward(
 							new RsFlash(
 				                String.format("Le champ %s a été supprimé avec succès !", name),

--- a/src/main/java/com/supervisor/takes/TkDataFieldEdit.java
+++ b/src/main/java/com/supervisor/takes/TkDataFieldEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -38,8 +40,8 @@ public final class TkDataFieldEdit extends TkForm {
 	@Override
 	protected Iterable<XeSource> contentToShow(final Request req, final XeSource itemToShow) throws IOException {
 		
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
-		Long tableId = Long.parseLong(new RqHref.Smart(req).single("table", "0"));
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
+		OptUUID tableId = new OptUUID(new RqHref.Smart(req).single("table", "0"));
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		DataSheetModel model = module.dataSheetModels().get(modelId);
@@ -50,8 +52,8 @@ public final class TkDataFieldEdit extends TkForm {
 		content.add(new XeDataFieldStyle());
 		content.add(new XeDataSheetModel("model", model));
 		
-		if(tableId > 0)
-			content.add(new XeTableDataField("table", model.fields().tables().get(tableId)));
+		if(tableId.isPresent())
+			content.add(new XeTableDataField("table", model.fields().tables().get(tableId.value())));
 		
 		content.add(new XeSupervisor(module));
 		content.add(itemToShow);
@@ -60,16 +62,16 @@ public final class TkDataFieldEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		final Supervisor module = new PxSupervisor(base, req);
 		final DataSheetModel model = module.dataSheetModels().get(modelId);
-		final SimpleDataField item = (SimpleDataField)model.fields().get(id);
+		final SimpleDataField item = (SimpleDataField)model.fields().get(id.value());
 		return new XeDataField("item", item);
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeDataField(dir);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkDataFieldTableEdit.java
+++ b/src/main/java/com/supervisor/takes/TkDataFieldTableEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -40,7 +42,7 @@ public final class TkDataFieldTableEdit extends TkForm {
 	@Override
 	protected Iterable<XeSource> contentToShow(final Request req, final XeSource itemToShow) throws IOException {
 		
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		final Supervisor module = new PxSupervisor(base, req);
 		DataSheetModel model = module.dataSheetModels().get(modelId);
 
@@ -56,11 +58,11 @@ public final class TkDataFieldTableEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		final Supervisor module = new PxSupervisor(base, req);
 		DataSheetModel model = module.dataSheetModels().get(modelId);
-		final TableDataField item = (TableDataField)model.fields().get(id);
+		final TableDataField item = (TableDataField)model.fields().get(id.value());
 		return new XeChain(
 				new XeTableDataField("item", item),
 				new XeEditableDataField(item.columns())
@@ -68,9 +70,9 @@ public final class TkDataFieldTableEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
-		if(id > 0) {
+		if(id.isPresent()) {
 		    return new XeChain(
 				new XeDataField(dir),
 				preItemDataToShow(id, req)

--- a/src/main/java/com/supervisor/takes/TkDataFieldTableSave.java
+++ b/src/main/java/com/supervisor/takes/TkDataFieldTableSave.java
@@ -1,11 +1,13 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
 import com.supervisor.sdk.utils.BasicCodeGenerator;
 import com.supervisor.sdk.utils.CodeGenerator;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Response;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
@@ -29,16 +31,16 @@ public final class TkDataFieldTableSave extends TkBaseWrap {
 					
 					final String name = form.single("name");		
 					final int order = Integer.parseInt(form.single("order"));
-					final Long modelId = Long.parseLong(form.single("model_id"));
+					final UUID modelId = UUID.fromString(form.single("model_id"));
 					final String description = form.single("description");
 						
 					DataSheetModel model = module.dataSheetModels().get(modelId);
 					TableDataField itemSaved;
 					Response response;
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
-					if(id > 0) {
-						itemSaved = model.fields().tables().get(id); 
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
+					if(id.isPresent()) {
+						itemSaved = model.fields().tables().get(id.value());
 						itemSaved.update(itemSaved.code(), name, description);		
 						itemSaved.makeMandatory(true);
 						itemSaved.order(order);

--- a/src/main/java/com/supervisor/takes/TkDataLinkDelete.java
+++ b/src/main/java/com/supervisor/takes/TkDataLinkDelete.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -21,11 +22,11 @@ public final class TkDataLinkDelete extends TkBaseWrap {
 				base, 
 				req ->{
 					final Supervisor module = new PxSupervisor(base, req);
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
-					final Long indicId = Long.parseLong(new RqHref.Smart(req).single("indic"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
+					final UUID indicId = UUID.fromString(new RqHref.Smart(req).single("indic"));
 					final String source = new RqHref.Smart(req).single("source");
 					
-					final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+					final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 					final Activity activity = module.activities().get(activityId);
 					Indicator indic = activity.indicators().get(indicId);
 

--- a/src/main/java/com/supervisor/takes/TkDataLinkEdit.java
+++ b/src/main/java/com/supervisor/takes/TkDataLinkEdit.java
@@ -4,9 +4,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.lang.StringUtils;
 import org.takes.Request;
 import org.takes.rq.RqHref;
@@ -65,10 +67,10 @@ public final class TkDataLinkEdit extends TkForm {
 			   );
 		}
 		
-		final Long indicId = Long.parseLong(new RqHref.Smart(req).single("indic"));
+		final UUID indicId = UUID.fromString(new RqHref.Smart(req).single("indic"));
 
 		final String source = new RqHref.Smart(req).single("source");
-		final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+		final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 		final Activity activity = module.activities().get(activityId);
 		final Indicator indic = activity.indicators().get(indicId);
 		
@@ -84,10 +86,10 @@ public final class TkDataLinkEdit extends TkForm {
 	protected Iterable<XeSource> contentToShow(final Request req, final XeSource itemToShow) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
-		final Long indicId = Long.parseLong(new RqHref.Smart(req).single("indic"));
+		final UUID indicId = UUID.fromString(new RqHref.Smart(req).single("indic"));
 
 		final String source = new RqHref.Smart(req).single("source");
-		final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+		final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 		final Activity activity = module.activities().get(activityId);
 		final Indicator indic = activity.indicators().get(indicId);
 
@@ -105,16 +107,16 @@ public final class TkDataLinkEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
-		final Long indicId = Long.parseLong(new RqHref.Smart(req).single("indic"));
+		final UUID indicId = UUID.fromString(new RqHref.Smart(req).single("indic"));
 
 		final String source = new RqHref.Smart(req).single("source");
-		final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+		final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 		final Activity activity = module.activities().get(activityId);
 		Indicator indic = activity.indicators().get(indicId);		
-		DataLink item = indic.links().get(id);
+		DataLink item = indic.links().get(id.value());
 		DataModel model = item.model();
 		
 		return new XeChain(
@@ -128,8 +130,8 @@ public final class TkDataLinkEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
-		if(id == 0)
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+		if(id.isEmpty())
 			return newItemToShow(req);
 		else
 			return preItemDataToShow(id, req);

--- a/src/main/java/com/supervisor/takes/TkDataSheetDelete.java
+++ b/src/main/java/com/supervisor/takes/TkDataSheetDelete.java
@@ -4,8 +4,10 @@ import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
+import org.takes.misc.Opt;
 import org.takes.rq.RqHref;
 
 import com.supervisor.domain.DataSheet;
@@ -22,9 +24,9 @@ public final class TkDataSheetDelete extends TkBaseWrap {
 				req ->{
 					final Supervisor module = new PxSupervisor(base, req);
 					DataSheets myDataSheets = module.dataSheets();
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
 
-					DataSheet item = myDataSheets.get(id);
+					DataSheet item = myDataSheets.get(id.value());
 					if(new RqUser(base, req).notOwn(item)) {
 						throw new IllegalArgumentException("Vous ne pouvez pas supprimer la feuille d'un modèle partagé !");
 					}

--- a/src/main/java/com/supervisor/takes/TkDataSheetEdit.java
+++ b/src/main/java/com/supervisor/takes/TkDataSheetEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -62,7 +64,7 @@ public final class TkDataSheetEdit extends TkForm {
 
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model", "0"));
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		DataSheetModel model = module.dataSheetModels().get(modelId);
 		
 		XeSource xeSheetModel = new XeDataSheetModel(model);
@@ -105,11 +107,11 @@ public final class TkDataSheetEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		DataSheets myItems = module.dataSheets();
-		DataSheet item = myItems.get(id);	
+		DataSheet item = myItems.get(id.value());
 				
 		XeSource xeRows = XeSource.EMPTY;
 		XeSource xeColumns = XeSource.EMPTY;
@@ -149,9 +151,9 @@ public final class TkDataSheetEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(final Long id, final Request req, final RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(final OptUUID id, final Request req, final RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
-		if(id == 0) {
+		if(id.isEmpty()) {
 			return newItemToShow(req);
 		}else {
 			return preItemDataToShow(id, req);

--- a/src/main/java/com/supervisor/takes/TkDataSheetModelDelete.java
+++ b/src/main/java/com/supervisor/takes/TkDataSheetModelDelete.java
@@ -4,6 +4,7 @@ import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqHref;
@@ -21,9 +22,9 @@ public final class TkDataSheetModelDelete extends TkBaseWrap {
 				(req)->{
 					final Supervisor module = new PxSupervisor(base, req);
 					DataSheetModels myDataFields = module.dataSheetModels();
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
 
-					DataSheetModel item = myDataFields.get(id);
+					DataSheetModel item = myDataFields.get(id.value());
 					if(new RqUser(base, req).notOwn(item)) {
 						throw new IllegalArgumentException("Vous ne pouvez pas supprimer un modèle partagé !");
 					}

--- a/src/main/java/com/supervisor/takes/TkDataSheetModelEdit.java
+++ b/src/main/java/com/supervisor/takes/TkDataSheetModelEdit.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.form.RqFormSmart;
 import org.takes.rs.xe.XeAppend;
@@ -53,10 +54,10 @@ public final class TkDataSheetModelEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		final Supervisor module = new PxSupervisor(base, req);
 		DataSheetModels myItems = module.dataSheetModels(); 
-		DataSheetModel item = myItems.get(id);		
+		DataSheetModel item = myItems.get(id.value());
 		return new XeChain(
 				new XeEditableDataField(item.fields().editables()),
 				new XeDataSheetModel("item", item)				
@@ -64,13 +65,13 @@ public final class TkDataSheetModelEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
 		XeSource xeSource = new XeDataSheetModel(dir);
-		if(id > 0) {
+		if(id.isPresent()) {
 			final Supervisor module = new PxSupervisor(base, req);
 			DataSheetModels myItems = module.dataSheetModels(); 
-			DataSheetModel item = myItems.get(id);
+			DataSheetModel item = myItems.get(id.value());
 			
 			xeSource = new XeChain(
 							new XeEditableDataField(item.fields().editables()),

--- a/src/main/java/com/supervisor/takes/TkDataSheetModelSave.java
+++ b/src/main/java/com/supervisor/takes/TkDataSheetModelSave.java
@@ -1,14 +1,17 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
 import com.supervisor.sdk.utils.BasicCodeGenerator;
 import com.supervisor.sdk.utils.CodeGenerator;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Response;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
+import org.takes.misc.Opt;
 import org.takes.rq.RqGreedy;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -30,17 +33,17 @@ public final class TkDataSheetModelSave extends TkBaseWrap {
 					final String name = form.single("name");
 					final boolean canMergeAtSameDate = Boolean.parseBoolean(form.single("can_merge_at_same_date"));
 					final String description = form.single("description");
-					final Long activityId = Long.parseLong(form.single("activity_id"));
+					final UUID activityId = UUID.fromString(form.single("activity_id"));
 					
 					final Activity activity = module.activities().get(activityId);
 					
 					DataSheetModel itemSaved;
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
 					Response response;
 					
-					if(id > 0) {
-						itemSaved = activity.forms().get(id);
+					if(id.isPresent()) {
+						itemSaved = activity.forms().get(id.value());
 						
 						if(new RqUser(base, req).notOwn(itemSaved)) {
 							throw new IllegalArgumentException("Vous ne pouvez pas modifier un modèle partagé !");

--- a/src/main/java/com/supervisor/takes/TkDynamicTable2ColSettingEdit.java
+++ b/src/main/java/com/supervisor/takes/TkDynamicTable2ColSettingEdit.java
@@ -3,11 +3,14 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.lang.StringUtils;
 import org.takes.Request;
+import org.takes.misc.Opt;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
 import org.takes.rs.xe.XeAppend;
@@ -59,13 +62,13 @@ public final class TkDynamicTable2ColSettingEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		final String source = new RqHref.Smart(req).single("source");
-		final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+		final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 		final Activity activity = module.activities().get(activityId);
-		final DynamicTable2Col indic = (DynamicTable2Col)activity.indicators().get(id);
+		final DynamicTable2Col indic = (DynamicTable2Col)activity.indicators().get(id.value());
 						
 		return new XeChain(
 				new XeDynamicTable2ColSetting("item", indic),
@@ -76,18 +79,18 @@ public final class TkDynamicTable2ColSettingEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
 		String source = new RqHref.Smart(req).single("source");
-		final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+		final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 		final Activity activity = module.activities().get(activityId);
 			
 		XeSource xeDataRule = XeSource.EMPTY;
 		XeSource xeParam = XeSource.EMPTY;
-		if(id > 0) {
-			final DynamicTable2Col indic = (DynamicTable2Col)activity.indicators().get(id);
+		if(id.isPresent()) {
+			final DynamicTable2Col indic = (DynamicTable2Col)activity.indicators().get(id.value());
 			xeDataRule = new XeDataLink(indic.links());
 			xeParam = new XeIndicatorDynamicParam(indic.dynamicParams());
 		}
@@ -103,13 +106,13 @@ public final class TkDynamicTable2ColSettingEdit extends TkForm {
 	@Override
 	protected XeSource newItemToShow(Request req) throws IOException {
 		
-		Long activityId = Long.parseLong(new RqHref.Smart(req).single("activity", "0"));
-		if(activityId == 0)
+		OptUUID activityId = new OptUUID(new RqHref.Smart(req).single("activity", "0"));
+		if(activityId.isEmpty())
 			throw new IllegalArgumentException("Vous devez spécifier l'activité pour lequel vous créer cet indicateur !");
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		Activity activity = module.activities().get(activityId);
+		Activity activity = module.activities().get(activityId.value());
 		
 		return new XeChain(
 				new XeIndicatorType(module.indicatorTypes().indicatorType(IndicatorType.DYNAMIC_TABLE_2_COL)), 

--- a/src/main/java/com/supervisor/takes/TkDynamicTable2ColSettingSave.java
+++ b/src/main/java/com/supervisor/takes/TkDynamicTable2ColSettingSave.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -11,6 +12,7 @@ import com.supervisor.sdk.takes.TkBaseWrap;
 import com.supervisor.sdk.time.PeriodicityUnit;
 import com.supervisor.sdk.utils.BasicCodeGenerator;
 import com.supervisor.sdk.utils.CodeGenerator;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.lang.StringUtils;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
@@ -47,7 +49,7 @@ public final class TkDynamicTable2ColSettingSave extends TkBaseWrap {
 					final String unitySymbol = form.single("unity_symbol", "");
 					final SymbolPosition symbolPosition = SymbolPosition.valueOf(form.single("symbol_position", "RIGHT"));
 					final boolean manageEvolutionPercent = Boolean.parseBoolean(form.single("manage_evolution_percent"));		
-					final Long activityId = Long.parseLong(form.single("activity_id"));
+					final UUID activityId = UUID.fromString(form.single("activity_id"));
 					final Activity activity = myActivities.get(activityId);
 					
 					if(new RqUser(base, req).notOwn(activity)) {
@@ -55,10 +57,10 @@ public final class TkDynamicTable2ColSettingSave extends TkBaseWrap {
 					}
 					
 					DynamicTable2Col itemSaved;
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));		
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
 
-					if(id > 0) {			
-						itemSaved = (DynamicTable2Col)activity.indicators().get(id);
+					if(id.isPresent()) {
+						itemSaved = (DynamicTable2Col)activity.indicators().get(id.value());
 									
 						if(new RqUser(base, req).notOwn(itemSaved)) {
 							throw new IllegalArgumentException("Vous ne pouvez pas modifier l'indicateur d'une activité partagée !");
@@ -106,7 +108,7 @@ public final class TkDynamicTable2ColSettingSave extends TkBaseWrap {
 					
 					final String msg;
 					
-					if(id > 0)
+					if(id.isPresent())
 						msg = String.format("L'indicateur %s a été modifié avec succès !", itemSaved.code());
 					else
 						msg = String.format("L'indicateur %s a été créé avec succès !", itemSaved.code());

--- a/src/main/java/com/supervisor/takes/TkExpressionArgEdit.java
+++ b/src/main/java/com/supervisor/takes/TkExpressionArgEdit.java
@@ -3,10 +3,12 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.datasource.comparators.Matchers;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.RqHref.Smart;
@@ -59,11 +61,11 @@ public final class TkExpressionArgEdit extends TkForm {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model")); 
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		AggregatedModel model = module.aggregatedModels()
 									 .get(modelId);
 		
-		Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		FormularDataField formular = model.formulars().get(formularId);
 		
 		List<XeSource> content = new ArrayList<>();
@@ -84,22 +86,22 @@ public final class TkExpressionArgEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
 		final Smart href = new RqHref.Smart(req);
 		
-		Long modelId = Long.parseLong(href.single("model"));
+		UUID modelId = UUID.fromString(href.single("model"));
 		AggregatedModel model = module.aggregatedModels().get(modelId); 
 		
-		Long formularId = Long.parseLong(href.single("formular"));
+		UUID formularId = UUID.fromString(href.single("formular"));
 		FormularDataField formular = model.formulars().get(formularId);
 		
-		Long expressionId = Long.parseLong(href.single("expression"));
+		UUID expressionId = UUID.fromString(href.single("expression"));
 				
 		FormularExpression expression = formular.expressions().get(expressionId);
-		final ExpressionArg item = expression.arguments().get(id);
+		final ExpressionArg item = expression.arguments().get(id.value());
 		
 		String typeId = href.single("type");
 		
@@ -147,7 +149,7 @@ public final class TkExpressionArgEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeSource() {
 		            @Override
 		            public Iterable<Directive> toXembly() throws IOException {

--- a/src/main/java/com/supervisor/takes/TkExpressionArgSave.java
+++ b/src/main/java/com/supervisor/takes/TkExpressionArgSave.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -29,18 +30,18 @@ public final class TkExpressionArgSave extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));				
 					
-					final Long modelId = Long.parseLong(form.single("model_id"));
+					final UUID modelId = UUID.fromString(form.single("model_id"));
 					AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(form.single("formular_id"));
+					final UUID formularId = UUID.fromString(form.single("formular_id"));
 					FormularDataField formular = model.formulars().get(formularId); 
 					
-					final Long expressionId = Long.parseLong(form.single("expression_id"));
+					final UUID expressionId = UUID.fromString(form.single("expression_id"));
 					FormularExpression expression = formular.expressions().get(expressionId); 
 					
 					ExpressionArgType type = ExpressionArgType.valueOf(form.single("type_id"));
 					
-					final Long id = Long.parseLong(form.single("id"));
+					final UUID id = UUID.fromString(form.single("id"));
 					final ExpressionArg item = expression.arguments().get(id);		
 					
 					switch (type) {
@@ -50,22 +51,22 @@ public final class TkExpressionArgSave extends TkBaseWrap {
 							item.update(value, valueType); 
 							break;
 						case DATA_FIELD :
-							final Long fieldId = Long.parseLong(form.single("field_id"));
+							final UUID fieldId = UUID.fromString(form.single("field_id"));
 							EditableDataField field = model.model().fields().editables().get(fieldId);
 							item.update(field); 
 							break;
 						case PARAMETER :
-							final Long paramId = Long.parseLong(form.single("param_id"));
+							final UUID paramId = UUID.fromString(form.single("param_id"));
 							ParamDataField param = model.params().get(paramId);
 							item.update(param); 
 							break;
 						case FORMULAR :
-							final Long targetFormularId = Long.parseLong(form.single("target_formular_id"));
+							final UUID targetFormularId = UUID.fromString(form.single("target_formular_id"));
 							FormularDataField targetFormular = model.formulars().get(targetFormularId);
 							item.update(targetFormular); 
 							break;
 						case EXPRESSION :
-							final Long targetExprId = Long.parseLong(form.single("target_expr_id"));
+							final UUID targetExprId = UUID.fromString(form.single("target_expr_id"));
 							FormularExpression targetExpr = formular.expressions().get(targetExprId);
 							item.update(targetExpr); 
 							break;

--- a/src/main/java/com/supervisor/takes/TkFeedbackEdit.java
+++ b/src/main/java/com/supervisor/takes/TkFeedbackEdit.java
@@ -2,6 +2,7 @@ package com.supervisor.takes;
 
 import com.supervisor.domain.Membership;
 import com.supervisor.domain.impl.DmMembership;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XeMembership;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
@@ -44,12 +45,12 @@ public final class TkFeedbackEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		return XeSource.EMPTY;
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeDirectives(dir);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkFloozTransactionCallback.java
+++ b/src/main/java/com/supervisor/takes/TkFloozTransactionCallback.java
@@ -21,7 +21,7 @@ public final class TkFloozTransactionCallback extends TkBaseWrap {
 				base,
 				req -> {
 					RecordSet<User> source = base.select(User.class);
-					User user = new DmUser(source.get(1L)); // prendre l'utilisateur Minlessika
+					User user = new DmUser(source.get(User.ADMIN_ID)); // prendre l'utilisateur Minlessika
 					
 					final Membership module = new DmMembership(base, user);
 					

--- a/src/main/java/com/supervisor/takes/TkFormularCaseExpressionEdit.java
+++ b/src/main/java/com/supervisor/takes/TkFormularCaseExpressionEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -45,11 +47,11 @@ public final class TkFormularCaseExpressionEdit extends TkForm {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model")); 
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		AggregatedModel model = module.aggregatedModels()
 									 .get(modelId);
 		
-		Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		FormularDataField formular = model.formulars().get(formularId);
 		
 		List<XeSource> content = new ArrayList<>();
@@ -66,17 +68,17 @@ public final class TkFormularCaseExpressionEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		AggregatedModel model = module.aggregatedModels().get(modelId); 
 		
-		Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		FormularDataField formular = model.formulars().get(formularId);
 		
-		FormularCaseExpression item = (FormularCaseExpression)formular.expressions().get(id);
+		FormularCaseExpression item = (FormularCaseExpression)formular.expressions().get(id.value());
 
 		return new XeChain(
 				new XeFormularCaseExpression("item", item),
@@ -85,9 +87,9 @@ public final class TkFormularCaseExpressionEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
-		if(id == 0)
+		if(id.isEmpty())
 			return newItemToShow(req);
 		else
 			return preItemDataToShow(id, req);

--- a/src/main/java/com/supervisor/takes/TkFormularCaseExpressionSave.java
+++ b/src/main/java/com/supervisor/takes/TkFormularCaseExpressionSave.java
@@ -1,11 +1,14 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
+import org.takes.misc.Opt;
 import org.takes.rq.RqGreedy;
 import org.takes.rq.form.RqFormSmart;
 
@@ -24,16 +27,16 @@ public final class TkFormularCaseExpressionSave extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));		
 					
-					final Long modelId = Long.parseLong(form.single("model_id"));
+					final UUID modelId = UUID.fromString(form.single("model_id"));
 					AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(form.single("formular_id"));
+					final UUID formularId = UUID.fromString(form.single("formular_id"));
 					FormularDataField formular = model.formulars().get(formularId); 
 					
 					final FormularCaseExpression itemSaved;
 					
-					final Long id = Long.parseLong(form.single("id", "0"));
-					if(id > 0) {						
+					final OptUUID id = new OptUUID(form.single("id", "0"));
+					if(id.isPresent()) {
 						return new RsForward(
 								new RsFlash(
 					                "L'expression a été modifiée avec succès !",

--- a/src/main/java/com/supervisor/takes/TkFormularDelete.java
+++ b/src/main/java/com/supervisor/takes/TkFormularDelete.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -24,10 +25,10 @@ public final class TkFormularDelete extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 
 					final Smart href = new RqHref.Smart(req);
-					final Long modelId = Long.parseLong(href.single("model"));
+					final UUID modelId = UUID.fromString(href.single("model"));
 					AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long id = Long.parseLong(href.single("id"));
+					final UUID id = UUID.fromString(href.single("id"));
 					final FormularDataField item = model.formulars().get(id);
 					final String name = item.name();
 					model.formulars().remove(item);

--- a/src/main/java/com/supervisor/takes/TkFormularEdit.java
+++ b/src/main/java/com/supervisor/takes/TkFormularEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -39,7 +41,7 @@ public final class TkFormularEdit extends TkForm {
 	@Override
 	protected XeSource newItemToShow(final Request req) throws IOException {
 		final Supervisor module = new PxSupervisor(base, req);
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model")); 
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		AggregatedModel model = module.aggregatedModels()
 									 .get(modelId);
 		
@@ -65,11 +67,11 @@ public final class TkFormularEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		final Supervisor module = new PxSupervisor(base, req);
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		AggregatedModel model = module.aggregatedModels().get(modelId); 
-		FormularDataField item = model.formulars().get(id);
+		FormularDataField item = model.formulars().get(id.value());
 
 		return new XeChain(
 				new XeAggregatedModel(model),
@@ -79,8 +81,8 @@ public final class TkFormularEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
-		if(id == 0)
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+		if(id.isEmpty())
 			return newItemToShow(req);
 		else
 			return preItemDataToShow(id, req);

--- a/src/main/java/com/supervisor/takes/TkFormularExpressionDelete.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExpressionDelete.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -25,13 +26,13 @@ public final class TkFormularExpressionDelete extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 
 					final Smart href = new RqHref.Smart(req);
-					final Long modelId = Long.parseLong(href.single("model"));
+					final UUID modelId = UUID.fromString(href.single("model"));
 					AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(href.single("formular"));
+					final UUID formularId = UUID.fromString(href.single("formular"));
 					FormularDataField formular = model.formulars().get(formularId);
 					
-					final Long id = Long.parseLong(href.single("id"));
+					final UUID id = UUID.fromString(href.single("id"));
 					
 					final FormularExpression item = formular.expressions().get(id);
 					final String name = item.name();

--- a/src/main/java/com/supervisor/takes/TkFormularExpressionOrganize.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExpressionOrganize.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import javax.json.JsonArray;
@@ -31,8 +32,8 @@ public final class TkFormularExpressionOrganize extends TkBaseWrap {
 					
 					final Request gReq = new RqGreedy(req);
 					
-					Long modelId = Long.parseLong(new RqHref.Smart(gReq).single("model"));
-					Long formularId = Long.parseLong(new RqHref.Smart(gReq).single("formular"));		
+					UUID modelId = UUID.fromString(new RqHref.Smart(gReq).single("model"));
+					UUID formularId = UUID.fromString(new RqHref.Smart(gReq).single("formular"));
 					AggregatedModel model = module.aggregatedModels().get(modelId);
 					FormularDataField formular = model.formulars().get(formularId);
 						
@@ -40,7 +41,7 @@ public final class TkFormularExpressionOrganize extends TkBaseWrap {
 					JsonArray locations = rqJson.payload().asJsonArray();
 					for (JsonObject myLoc : locations.getValuesAs(JsonObject.class)) {
 						
-						Long id = myLoc.getJsonNumber("id").longValue();			
+						UUID id = UUID.fromString(myLoc.getJsonString("id").getString());
 						FormularExpression expr = formular.expressions().get(id);	
 						
 						final int no = myLoc.getInt("no");

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToChildExpressionEdit.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToChildExpressionEdit.java
@@ -3,10 +3,12 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.datasource.comparators.Matchers;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -51,12 +53,12 @@ public final class TkFormularExtendedToChildExpressionEdit extends TkForm {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 
-		final Long modelId = Long.parseLong(new RqHref.Smart(req).single("model")); 
+		final UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		final AggregatedModel amodel = module.aggregatedModels()
 									  		.get(modelId);
 		final DataSheetModel model = amodel.coreModel();
 		
-		final Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		final UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		final FormularDataField formular = amodel.formulars().get(formularId);
 		
 		XeSource xeChildren = XeSource.EMPTY;
@@ -94,17 +96,17 @@ public final class TkFormularExtendedToChildExpressionEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		final Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
+		final UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		final AggregatedModel model = module.aggregatedModels().get(modelId); 
 		
-		final Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		final UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		final FormularDataField formular = model.formulars().get(formularId);
 		
-		final FormularExtendedToChildExpression item = (FormularExtendedToChildExpression)formular.expressions().get(id);
+		final FormularExtendedToChildExpression item = (FormularExtendedToChildExpression)formular.expressions().get(id.value());
 
 		return new XeChain(
 			new XeFormularExtendedToChildExpression("item", item)
@@ -112,9 +114,9 @@ public final class TkFormularExtendedToChildExpressionEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
-		if(id == 0)
+		if(id.isEmpty())
 			return newItemToShow(req);
 		else
 			return preItemDataToShow(id, req);

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToChildExpressionSave.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToChildExpressionSave.java
@@ -1,9 +1,11 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqGreedy;
@@ -28,23 +30,23 @@ public final class TkFormularExtendedToChildExpressionSave extends TkBaseWrap {
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));		
 					
 					final AggregateFunc aggregate = AggregateFunc.valueOf(form.single("aggregate_id"));
-					final Long modelId = Long.parseLong(form.single("model_id"));
+					final UUID modelId = UUID.fromString(form.single("model_id"));
 					final AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long childModelId = Long.parseLong(form.single("child_model_id"));
+					final UUID childModelId = UUID.fromString(form.single("child_model_id"));
 					final DataSheetModel childModel = module.dataSheetModels().get(childModelId);
 					
-					final Long formularId = Long.parseLong(form.single("formular_id"));
+					final UUID formularId = UUID.fromString(form.single("formular_id"));
 					FormularDataField formular = model.formulars().get(formularId); 
 					
-					final Long childId = Long.parseLong(form.single("child_id"));
+					final UUID childId = UUID.fromString(form.single("child_id"));
 					final EditableDataField child = childModel.fields().editables().get(childId); 
 					
 					final FormularExtendedToChildExpression itemSaved;
 					
-					final Long id = Long.parseLong(form.single("id", "0"));
-					if(id > 0) {	
-						itemSaved = (FormularExtendedToChildExpression)formular.expressions().get(id);		
+					final OptUUID id = new OptUUID(form.single("id", "0"));
+					if(id.isPresent()) {
+						itemSaved = (FormularExtendedToChildExpression)formular.expressions().get(id.value());
 					} else {
 						itemSaved = formular.expressions().addChildExtension();
 					}

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToModelExpressionAggregateEdit.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToModelExpressionAggregateEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -44,11 +46,11 @@ public final class TkFormularExtendedToModelExpressionAggregateEdit extends TkFo
 		
 		final Supervisor module = new PxSupervisor(base, req);
 
-		final Long modelId = Long.parseLong(new RqHref.Smart(req).single("model")); 
+		final UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		final AggregatedModel amodel = module.aggregatedModels()
 									  		 .get(modelId);
 		
-		final Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		final UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		final FormularDataField formular = amodel.formulars().get(formularId);
 		
 		final List<XeSource> content = new ArrayList<>();
@@ -65,17 +67,17 @@ public final class TkFormularExtendedToModelExpressionAggregateEdit extends TkFo
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		final Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
+		final UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		final AggregatedModel model = module.aggregatedModels().get(modelId); 
 		
-		final Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		final UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		final FormularDataField formular = model.formulars().get(formularId);
 		
-		final FormularExtendedToModelExpression item = (FormularExtendedToModelExpression)formular.expressions().get(id);
+		final FormularExtendedToModelExpression item = (FormularExtendedToModelExpression)formular.expressions().get(id.value());
 
 		return new XeChain(
 			new XeFormularExtendedToModelExpression("item", item)
@@ -83,7 +85,7 @@ public final class TkFormularExtendedToModelExpressionAggregateEdit extends TkFo
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {		
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return preItemDataToShow(id, req);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToModelExpressionAggregateSave.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToModelExpressionAggregateSave.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -27,15 +28,15 @@ public final class TkFormularExtendedToModelExpressionAggregateSave extends TkBa
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));		
 					
 					final AggregateFunc aggregate = AggregateFunc.valueOf(form.single("aggregate_id"));
-					final Long modelId = Long.parseLong(form.single("model_id"));
+					final UUID modelId = UUID.fromString(form.single("model_id"));
 					final AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(form.single("formular_id"));
+					final UUID formularId = UUID.fromString(form.single("formular_id"));
 					FormularDataField formular = model.formulars().get(formularId);  
 					
 					final FormularExtendedToModelExpression itemSaved;
 					
-					final Long id = Long.parseLong(form.single("id"));
+					final UUID id = UUID.fromString(form.single("id"));
 					itemSaved = (FormularExtendedToModelExpression)formular.expressions().get(id);
 					
 					itemSaved.update(aggregate); 

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToModelExpressionEdit.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToModelExpressionEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -45,11 +47,11 @@ public final class TkFormularExtendedToModelExpressionEdit extends TkForm {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model")); 
+		final UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		AggregatedModel model = module.aggregatedModels()
 									 .get(modelId);
 		
-		Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		final UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		FormularDataField formular = model.formulars().get(formularId);
 		
 		List<XeSource> content = new ArrayList<>();
@@ -66,17 +68,17 @@ public final class TkFormularExtendedToModelExpressionEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		AggregatedModel model = module.aggregatedModels().get(modelId); 
 		
-		Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		FormularDataField formular = model.formulars().get(formularId);
 		
-		final FormularExtendedToModelExpression item = (FormularExtendedToModelExpression)formular.expressions().get(id);
+		final FormularExtendedToModelExpression item = (FormularExtendedToModelExpression)formular.expressions().get(id.value());
 
 		return new XeChain(
 			new XeFormularExtendedToModelExpression("item", item),
@@ -85,9 +87,9 @@ public final class TkFormularExtendedToModelExpressionEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
-		if(id == 0)
+		if(id.isEmpty())
 			return newItemToShow(req);
 		else
 			return preItemDataToShow(id, req);

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToModelExpressionNew.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToModelExpressionNew.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -22,10 +23,10 @@ public final class TkFormularExtendedToModelExpressionNew extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final RqHref.Smart href = new RqHref.Smart(req);		
 					
-					final Long modelId = Long.parseLong(href.single("model"));
+					final UUID modelId = UUID.fromString(href.single("model"));
 					AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(href.single("formular"));
+					final UUID formularId = UUID.fromString(href.single("formular"));
 					FormularDataField formular = model.formulars().get(formularId); 
 					
 					final FormularExtendedToModelExpression itemSaved = formular.expressions().addModelExtension();

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToModelSourceActivate.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToModelSourceActivate.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -26,18 +27,18 @@ public final class TkFormularExtendedToModelSourceActivate extends TkBaseWrap {
 					final Smart href = new RqHref.Smart(req);
 					
 					
-					final Long modelId = Long.parseLong(href.single("model"));
+					final UUID modelId = UUID.fromString(href.single("model"));
 					final AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(href.single("formular"));
+					final UUID formularId = UUID.fromString(href.single("formular"));
 					FormularDataField formular = model.formulars().get(formularId); 
 					
-					final Long exprId = Long.parseLong(href.single("expr"));
+					final UUID exprId = UUID.fromString(href.single("expr"));
 					final FormularExtendedToModelExpression expr = (FormularExtendedToModelExpression)formular.expressions().get(exprId);
 					
 					final boolean active = Boolean.parseBoolean(href.single("active"));										
 					
-					final Long id = Long.parseLong(href.single("id"));
+					final UUID id = UUID.fromString(href.single("id"));
 					final FormularExtendedToModelSource item = expr.sources().get(id);
 					item.activate(active); 
 	

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToModelSourceDelete.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToModelSourceDelete.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -27,16 +28,16 @@ public final class TkFormularExtendedToModelSourceDelete extends TkBaseWrap {
 
 					final Smart href = new RqHref.Smart(req);
 					
-					final Long modelId = Long.parseLong(href.single("model"));
+					final UUID modelId = UUID.fromString(href.single("model"));
 					final AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(href.single("formular"));
+					final UUID formularId = UUID.fromString(href.single("formular"));
 					FormularDataField formular = model.formulars().get(formularId); 
 					
-					final Long exprId = Long.parseLong(href.single("expr"));
+					final UUID exprId = UUID.fromString(href.single("expr"));
 					final FormularExtendedToModelExpression expr = (FormularExtendedToModelExpression)formular.expressions().get(exprId);
 					
-					final Long id = Long.parseLong(href.single("id"));
+					final UUID id = UUID.fromString(href.single("id"));
 					
 					final FormularExtendedToModelSource item = expr.sources().get(id);
 					expr.sources().remove(item);

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToModelSourceEdit.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToModelSourceEdit.java
@@ -3,11 +3,13 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.datasource.comparators.Matchers;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -54,14 +56,14 @@ public final class TkFormularExtendedToModelSourceEdit extends TkForm {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 
-		final Long modelId = Long.parseLong(new RqHref.Smart(req).single("model")); 
+		final UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		final AggregatedModel amodel = module.aggregatedModels()
 									  		.get(modelId);		
 		
-		final Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		final UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		final FormularDataField formular = amodel.formulars().get(formularId);
 		
-		final Long exprId = Long.parseLong(new RqHref.Smart(req).single("expr"));
+		final UUID exprId = UUID.fromString(new RqHref.Smart(req).single("expr"));
 		final FormularExpression expr = formular.expressions().get(exprId);
 		
 		final XeSource xeModels;
@@ -116,19 +118,19 @@ public final class TkFormularExtendedToModelSourceEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		final Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
+		final UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		final AggregatedModel model = module.aggregatedModels().get(modelId); 
 		
-		final Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		final UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		final FormularDataField formular = model.formulars().get(formularId);
 		
-		final Long exprId = Long.parseLong(new RqHref.Smart(req).single("expr"));
+		final UUID exprId = UUID.fromString(new RqHref.Smart(req).single("expr"));
 		final FormularExtendedToModelExpression expr = (FormularExtendedToModelExpression)formular.expressions().get(exprId);
-		final FormularExtendedToModelSource item = expr.sources().get(id);
+		final FormularExtendedToModelSource item = expr.sources().get(id.value());
 		
 		return new XeChain(
 			new XeFormularExtendedToModelSource("item", item)
@@ -136,9 +138,9 @@ public final class TkFormularExtendedToModelSourceEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
-		if(id == 0)
+		if(id.isEmpty())
 			return newItemToShow(req);
 		else
 			return preItemDataToShow(id, req);

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToModelSourceSave.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToModelSourceSave.java
@@ -1,10 +1,12 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.datasource.comparators.Comparator;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqGreedy;
@@ -30,34 +32,34 @@ public final class TkFormularExtendedToModelSourceSave extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));		
 					
-					final Long modelId = Long.parseLong(form.single("model_id"));
+					final UUID modelId = UUID.fromString(form.single("model_id"));
 					final AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long modelToExtendId = Long.parseLong(form.single("model_to_extend_id"));
+					final UUID modelToExtendId = UUID.fromString(form.single("model_to_extend_id"));
 					final DataSheetModel modelToExtend = (DataSheetModel)module.dataModels().get(modelToExtendId); 
 					
-					final Long formularId = Long.parseLong(form.single("formular_id"));
+					final UUID formularId = UUID.fromString(form.single("formular_id"));
 					FormularDataField formular = model.formulars().get(formularId); 
 					
-					final Long referenceId = Long.parseLong(form.single("reference_id"));
+					final UUID referenceId = UUID.fromString(form.single("reference_id"));
 					final DataField reference = model.fields().get(referenceId); 
 					
-					final Long exprId = Long.parseLong(form.single("expr_id"));
+					final UUID exprId = UUID.fromString(form.single("expr_id"));
 					final FormularExtendedToModelExpression expr = (FormularExtendedToModelExpression)formular.expressions().get(exprId);
 					
-					final Long modelFieldId = Long.parseLong(form.single("model_field_id"));
+					final UUID modelFieldId = UUID.fromString(form.single("model_field_id"));
 					final EditableDataField modelField = modelToExtend.editableFields().get(modelFieldId);
 					
-					final Long fieldToExtendId = Long.parseLong(form.single("field_to_extend_id"));
+					final UUID fieldToExtendId = UUID.fromString(form.single("field_to_extend_id"));
 					final EditableDataField fieldToExtend = modelToExtend.editableFields().get(fieldToExtendId);
 					
 					final Comparator comparator = Comparator.valueOf(form.single("comparator_id"));
 									
 					final FormularExtendedToModelSource itemSaved;
 					
-					final Long id = Long.parseLong(form.single("id", "0"));
-					if(id > 0) {	
-						itemSaved = expr.sources().get(id);
+					final OptUUID id = new OptUUID(form.single("id", "0"));
+					if(id.isPresent()) {
+						itemSaved = expr.sources().get(id.value());
 						itemSaved.update(modelField, comparator, reference, fieldToExtend);
 					} else {
 						itemSaved = expr.sources().add(modelToExtend, modelField, comparator, reference, fieldToExtend);

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToParentExpressionEdit.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToParentExpressionEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -40,11 +42,11 @@ public final class TkFormularExtendedToParentExpressionEdit extends TkForm {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 
-		final Long modelId = Long.parseLong(new RqHref.Smart(req).single("model")); 
+		final UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		final AggregatedModel amodel = module.aggregatedModels()
 									  		.get(modelId);
 		
-		final Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		final UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		final FormularDataField formular = amodel.formulars().get(formularId);
 		
 		final List<XeSource> content = new ArrayList<>();
@@ -64,7 +66,7 @@ public final class TkFormularExtendedToParentExpressionEdit extends TkForm {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		final Long modelId = Long.parseLong(new RqHref.Smart(req).single("model")); 
+		final UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		final AggregatedModel amodel = module.aggregatedModels()
 									  		.get(modelId);
 		final DataSheetModel model = amodel.coreModel();
@@ -73,17 +75,17 @@ public final class TkFormularExtendedToParentExpressionEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		final Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
+		final UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		final AggregatedModel model = module.aggregatedModels().get(modelId); 
 		
-		final Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		final UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		final FormularDataField formular = model.formulars().get(formularId);
 		
-		final FormularExtendedToParentExpression item = (FormularExtendedToParentExpression)formular.expressions().get(id);
+		final FormularExtendedToParentExpression item = (FormularExtendedToParentExpression)formular.expressions().get(id.value());
 
 		return new XeChain(
 			new XeFormularExtendedToParentExpression("item", item),
@@ -92,9 +94,9 @@ public final class TkFormularExtendedToParentExpressionEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
-		if(id == 0)
+		if(id.isEmpty())
 			return newItemToShow(req);
 		else
 			return preItemDataToShow(id, req);

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToParentExpressionSave.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToParentExpressionSave.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -25,13 +26,13 @@ public final class TkFormularExtendedToParentExpressionSave extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));		
 					
-					final Long modelId = Long.parseLong(form.single("model_id"));
+					final UUID modelId = UUID.fromString(form.single("model_id"));
 					final AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(form.single("formular_id"));
+					final UUID formularId = UUID.fromString(form.single("formular_id"));
 					FormularDataField formular = model.formulars().get(formularId); 
 					
-					final Long referenceId = Long.parseLong(form.single("reference_id"));
+					final UUID referenceId = UUID.fromString(form.single("reference_id"));
 					final ListDataField reference = model.fields().lists().get(referenceId); 
 					
 					final FormularExtendedToParentExpression itemSaved;

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToParentSourceDelete.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToParentSourceDelete.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -27,16 +28,16 @@ public final class TkFormularExtendedToParentSourceDelete extends TkBaseWrap {
 
 					final Smart href = new RqHref.Smart(req);
 					
-					final Long modelId = Long.parseLong(href.single("model"));
+					final UUID modelId = UUID.fromString(href.single("model"));
 					final AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(href.single("formular"));
+					final UUID formularId = UUID.fromString(href.single("formular"));
 					FormularDataField formular = model.formulars().get(formularId); 
 					
-					final Long exprId = Long.parseLong(href.single("expr"));
+					final UUID exprId = UUID.fromString(href.single("expr"));
 					final FormularExtendedToParentExpression expr = (FormularExtendedToParentExpression)formular.expressions().get(exprId);
 					
-					final Long id = Long.parseLong(href.single("id"));
+					final UUID id = UUID.fromString(href.single("id"));
 					
 					final FormularExtendedToParentSource item = expr.sources().get(id);
 					expr.sources().remove(item);

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToParentSourceEdit.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToParentSourceEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -48,18 +50,18 @@ public final class TkFormularExtendedToParentSourceEdit extends TkForm {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 
-		final Long modelId = Long.parseLong(new RqHref.Smart(req).single("model")); 
+		final UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		final AggregatedModel amodel = module.aggregatedModels()
 									  		.get(modelId);
 		final DataSheetModel model = amodel.coreModel();
 		
-		final Long referenceId = Long.parseLong(new RqHref.Smart(req).single("reference"));
+		final UUID referenceId = UUID.fromString(new RqHref.Smart(req).single("reference"));
 		final ListDataField reference = model.fields().lists().get(referenceId);
 		
-		final Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		final UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		final FormularDataField formular = amodel.formulars().get(formularId);
 		
-		final Long exprId = Long.parseLong(new RqHref.Smart(req).single("expr"));
+		final UUID exprId = UUID.fromString(new RqHref.Smart(req).single("expr"));
 		final FormularExpression expr = formular.expressions().get(exprId);
 		
 		final XeSource xeParent;
@@ -105,19 +107,19 @@ public final class TkFormularExtendedToParentSourceEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		final Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
+		final UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		final AggregatedModel model = module.aggregatedModels().get(modelId); 
 		
-		final Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		final UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		final FormularDataField formular = model.formulars().get(formularId);
 		
-		final Long exprId = Long.parseLong(new RqHref.Smart(req).single("expr"));
+		final UUID exprId = UUID.fromString(new RqHref.Smart(req).single("expr"));
 		final FormularExtendedToParentExpression expr = (FormularExtendedToParentExpression)formular.expressions().get(exprId);
-		final FormularExtendedToParentSource item = expr.sources().get(id);
+		final FormularExtendedToParentSource item = expr.sources().get(id.value());
 		
 		return new XeChain(
 			new XeFormularExtendedToParentSource("item", item)
@@ -125,9 +127,9 @@ public final class TkFormularExtendedToParentSourceEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
-		if(id == 0)
+		if(id.isEmpty())
 			return newItemToShow(req);
 		else
 			return preItemDataToShow(id, req);

--- a/src/main/java/com/supervisor/takes/TkFormularExtendedToParentSourceSave.java
+++ b/src/main/java/com/supervisor/takes/TkFormularExtendedToParentSourceSave.java
@@ -1,9 +1,11 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqGreedy;
@@ -29,32 +31,32 @@ public final class TkFormularExtendedToParentSourceSave extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));		
 					
-					final Long modelId = Long.parseLong(form.single("model_id"));
+					final UUID modelId = UUID.fromString(form.single("model_id"));
 					final AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(form.single("formular_id"));
+					final UUID formularId = UUID.fromString(form.single("formular_id"));
 					FormularDataField formular = model.formulars().get(formularId); 
 					
-					final Long referenceId = Long.parseLong(form.single("reference_id"));
+					final UUID referenceId = UUID.fromString(form.single("reference_id"));
 					final ListDataField reference = model.fields().lists().get(referenceId); 
 					
-					final Long exprId = Long.parseLong(form.single("expr_id"));
+					final UUID exprId = UUID.fromString(form.single("expr_id"));
 					final FormularExtendedToParentExpression expr = (FormularExtendedToParentExpression)formular.expressions().get(exprId);
 					
-					final Long fieldId = Long.parseLong(form.single("parent_id"));
+					final UUID fieldId = UUID.fromString(form.single("parent_id"));
 					
 					final DataModel parentModel;
 					final EditableDataField field;
 					final FormularExtendedToParentSource itemSaved;
 					
-					final Long id = Long.parseLong(form.single("id", "0"));
-					if(id > 0) {	
-						itemSaved = expr.sources().get(id);
+					final OptUUID id = new OptUUID(form.single("id", "0"));
+					if(id.isPresent()) {
+						itemSaved = expr.sources().get(id.value());
 						parentModel = itemSaved.listSource().model();
 						field = parentModel.fields().editables().get(fieldId);
 						itemSaved.update(field);
 					} else {
-						final Long parentModelId = Long.parseLong(form.single("parent_model_id"));
+						final UUID parentModelId = UUID.fromString(form.single("parent_model_id"));
 						parentModel = model.coreModel().parents().get(parentModelId); 
 						field = parentModel.fields().editables().get(fieldId);
 						final ListDataFieldSource src = reference.sources().whichBasedOn(parentModel);

--- a/src/main/java/com/supervisor/takes/TkFormularSave.java
+++ b/src/main/java/com/supervisor/takes/TkFormularSave.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -7,6 +8,7 @@ import com.supervisor.sdk.datasource.comparators.Comparator;
 import com.supervisor.sdk.takes.TkBaseWrap;
 import com.supervisor.sdk.utils.BasicCodeGenerator;
 import com.supervisor.sdk.utils.CodeGenerator;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqGreedy;
@@ -28,16 +30,16 @@ public final class TkFormularSave extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));		
 					
-					final Long modelId = Long.parseLong(form.single("model_id"));
+					final UUID modelId = UUID.fromString(form.single("model_id"));
 					final String name = form.single("name");
 					final DataFieldType type = DataFieldType.valueOf(form.single("type_id"));
 					
 					AggregatedModel model = module.aggregatedModels().get(modelId); 
 					final FormularDataField itemSaved;
 					
-					final Long id = Long.parseLong(form.single("id", "0"));
-					if(id > 0) {
-						itemSaved = model.formulars().get(id);	
+					final OptUUID id = new OptUUID(form.single("id", "0"));
+					if(id.isPresent()) {
+						itemSaved = model.formulars().get(id.value());
 						itemSaved.update(name, itemSaved.code(), type);
 						
 						String state = form.single("formular_condition_state", "");

--- a/src/main/java/com/supervisor/takes/TkFormularSimpleExpressionEdit.java
+++ b/src/main/java/com/supervisor/takes/TkFormularSimpleExpressionEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -44,11 +46,11 @@ public final class TkFormularSimpleExpressionEdit extends TkForm {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model")); 
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		AggregatedModel model = module.aggregatedModels()
 									 .get(modelId);
 		
-		Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		FormularDataField formular = model.formulars().get(formularId);
 		
 		List<XeSource> content = new ArrayList<>();
@@ -65,17 +67,17 @@ public final class TkFormularSimpleExpressionEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		AggregatedModel model = module.aggregatedModels().get(modelId); 
 		
-		Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		FormularDataField formular = model.formulars().get(formularId);
-		
-		FormularSimpleExpression item = (FormularSimpleExpression)formular.expressions().get(id);
+
+		FormularSimpleExpression item = (FormularSimpleExpression)formular.expressions().get(id.value());
 
 		return new XeChain(
 				new XeFormularSimpleExpression("item", item)
@@ -83,9 +85,9 @@ public final class TkFormularSimpleExpressionEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
-		if(id == 0)
+		if(id.isEmpty())
 			return newItemToShow(req);
 		else
 			return preItemDataToShow(id, req);

--- a/src/main/java/com/supervisor/takes/TkFormularSimpleExpressionSave.java
+++ b/src/main/java/com/supervisor/takes/TkFormularSimpleExpressionSave.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -27,10 +28,10 @@ public final class TkFormularSimpleExpressionSave extends TkBaseWrap {
 					
 					final FormularFunc func = FormularFunc.valueOf(form.single("func_id"));
 					
-					final Long modelId = Long.parseLong(form.single("model_id"));
+					final UUID modelId = UUID.fromString(form.single("model_id"));
 					AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(form.single("formular_id"));
+					final UUID formularId = UUID.fromString(form.single("formular_id"));
 					FormularDataField formular = model.formulars().get(formularId); 
 					
 					final FormularSimpleExpression itemSaved;

--- a/src/main/java/com/supervisor/takes/TkFormularSimpleExpressionTransformFunction.java
+++ b/src/main/java/com/supervisor/takes/TkFormularSimpleExpressionTransformFunction.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -28,13 +29,13 @@ public final class TkFormularSimpleExpressionTransformFunction extends TkBaseWra
 					
 					final FormularFunc func = FormularFunc.valueOf(href.single("func"));
 					
-					final Long modelId = Long.parseLong(href.single("model"));
+					final UUID modelId = UUID.fromString(href.single("model"));
 					AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(href.single("formular"));
+					final UUID formularId = UUID.fromString(href.single("formular"));
 					FormularDataField formular = model.formulars().get(formularId); 
 					
-					final Long id = Long.parseLong(href.single("id"));
+					final UUID id = UUID.fromString(href.single("id"));
 					final FormularSimpleExpression item = (FormularSimpleExpression)formular.expressions().get(id);
 					
 					item.update(func);

--- a/src/main/java/com/supervisor/takes/TkGaugeSettingEdit.java
+++ b/src/main/java/com/supervisor/takes/TkGaugeSettingEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.lang.StringUtils;
 import org.takes.Request;
 import org.takes.rq.RqHref;
@@ -62,13 +64,13 @@ public final class TkGaugeSettingEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		String source = new RqHref.Smart(req).single("source");
-		final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+		final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 		final Activity activity = module.activities().get(activityId);
-		final Gauge indic = (Gauge)activity.indicators().get(id);
+		final Gauge indic = (Gauge)activity.indicators().get(id.value());
 		
 		return new XeChain(
 				new XeGaugeSetting("item", indic),
@@ -80,19 +82,19 @@ public final class TkGaugeSettingEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
 		String source = new RqHref.Smart(req).single("source");
-		final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+		final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 		final Activity activity = module.activities().get(activityId);
 
 		XeSource xeDataRule = XeSource.EMPTY;
 	    XeSource xeGaugeZone = XeSource.EMPTY;
 	    XeSource xeParam = XeSource.EMPTY;
-		if(id > 0) {
-			final Gauge indic = (Gauge)activity.indicators().get(id);
+		if(id.isPresent()) {
+			final Gauge indic = (Gauge)activity.indicators().get(id.value());
 			xeDataRule = new XeDataLink(indic.links());
 			xeGaugeZone = new XeGaugeZone(indic.zones());
 			xeParam = new XeIndicatorDynamicParam(indic.dynamicParams());
@@ -110,13 +112,13 @@ public final class TkGaugeSettingEdit extends TkForm {
 	@Override
 	protected XeSource newItemToShow(Request req) throws IOException {
 		
-		Long activityId = Long.parseLong(new RqHref.Smart(req).single("activity", "0"));
-		if(activityId == 0)
+		OptUUID activityId = new OptUUID(new RqHref.Smart(req).single("activity", "0"));
+		if(activityId.isEmpty())
 			throw new IllegalArgumentException("Vous devez spécifier l'activité pour lequel vous créer cet indicateur !");
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		Activity activity = module.activities().get(activityId);
+		Activity activity = module.activities().get(activityId.value());
 		
 		return new XeChain(
 				new XeIndicatorType(module.indicatorTypes().indicatorType(IndicatorType.GAUGE)), 

--- a/src/main/java/com/supervisor/takes/TkGaugeSettingSave.java
+++ b/src/main/java/com/supervisor/takes/TkGaugeSettingSave.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.colors.Color;
@@ -13,6 +14,7 @@ import com.supervisor.sdk.takes.TkBaseWrap;
 import com.supervisor.sdk.time.PeriodicityUnit;
 import com.supervisor.sdk.utils.BasicCodeGenerator;
 import com.supervisor.sdk.utils.CodeGenerator;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.collections.IteratorUtils;
 import org.apache.commons.lang.StringUtils;
 import org.takes.facets.flash.RsFlash;
@@ -53,7 +55,7 @@ public final class TkGaugeSettingSave extends TkBaseWrap {
 					final SymbolPosition symbolPosition = SymbolPosition.valueOf(form.single("symbol_position", "RIGHT"));
 					final GaugeType gaugeType = GaugeType.valueOf(form.single("gauge_type_id"));		
 					
-					final Long activityId = Long.parseLong(form.single("activity_id"));
+					final UUID activityId = UUID.fromString(form.single("activity_id"));
 					final Activity activity = myActivities.get(activityId);
 					
 					if(new RqUser(base, req).notOwn(activity)) {
@@ -62,9 +64,9 @@ public final class TkGaugeSettingSave extends TkBaseWrap {
 					
 					Gauge itemSaved;
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
-					if(id > 0) {			
-						itemSaved = (Gauge)activity.indicators().get(id);
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
+					if(id.isPresent()) {
+						itemSaved = (Gauge)activity.indicators().get(id.value());
 									
 						final String periodicityState = form.single("periodicity_state", "removed");
 						if(periodicityState.equals("added")) {
@@ -106,7 +108,7 @@ public final class TkGaugeSettingSave extends TkBaseWrap {
 						
 						if(editState.equals("modified")) {
 							
-							Long zoneId = Long.parseLong(getValuesOfRow("zone_id", form).get(i));
+							UUID zoneId = UUID.fromString(getValuesOfRow("zone_id", form).get(i));
 							Color color = Color.valueOf(getValuesOfRow("zone_color_id", form).get(i));
 							Double zoneMin = Double.parseDouble(getValuesOfRow("zone_min", form).get(i));
 							Double zoneMax = Double.parseDouble(getValuesOfRow("zone_max", form).get(i));
@@ -117,7 +119,7 @@ public final class TkGaugeSettingSave extends TkBaseWrap {
 						}
 						
 						if(editState.equals("removed")) {
-							Long zoneId = Long.parseLong(getValuesOfRow("zone_id", form).get(i));
+							UUID zoneId = UUID.fromString(getValuesOfRow("zone_id", form).get(i));
 							
 							itemSaved.zones()
 							         .remove(zoneId);
@@ -138,7 +140,7 @@ public final class TkGaugeSettingSave extends TkBaseWrap {
 					
 					final String msg;
 					
-					if(id > 0)
+					if(id.isPresent())
 						msg = String.format("L'indicateur %s a été modifié avec succès !", itemSaved.code());
 					else
 						msg = String.format("L'indicateur %s a été créé avec succès !", itemSaved.code());

--- a/src/main/java/com/supervisor/takes/TkGoalNumberSettingEdit.java
+++ b/src/main/java/com/supervisor/takes/TkGoalNumberSettingEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.lang.StringUtils;
 import org.takes.Request;
 import org.takes.rq.RqHref;
@@ -59,15 +61,15 @@ public final class TkGoalNumberSettingEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);		
 		
 		String source = new RqHref.Smart(req).single("source");
-		final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+		final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 		final Activity activity = module.activities().get(activityId);
 		
-		final GoalNumber indic = (GoalNumber)activity.indicators().get(id);
+		final GoalNumber indic = (GoalNumber)activity.indicators().get(id.value());
 		
 		return new XeChain(
 				new XeGoalNumberSetting("item", indic),
@@ -78,18 +80,18 @@ public final class TkGoalNumberSettingEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
 		String source = new RqHref.Smart(req).single("source");
-		final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+		final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 		final Activity activity = module.activities().get(activityId);
 		
 		XeSource xeDataRule = XeSource.EMPTY;
 		XeSource xeParam = XeSource.EMPTY;
-		if(id > 0) {
-			final GoalNumber indic = (GoalNumber)activity.indicators().get(id);
+		if(id.isPresent()) {
+			final GoalNumber indic = (GoalNumber)activity.indicators().get(id.value());
 			xeDataRule = new XeDataLink(indic.links());
 			xeParam = new XeIndicatorDynamicParam(indic.dynamicParams());
 		}
@@ -105,13 +107,13 @@ public final class TkGoalNumberSettingEdit extends TkForm {
 	@Override
 	protected XeSource newItemToShow(Request req) throws IOException {
 		
-		Long activityId = Long.parseLong(new RqHref.Smart(req).single("activity", "0"));
-		if(activityId == 0)
+		OptUUID activityId = new OptUUID(new RqHref.Smart(req).single("activity", "0"));
+		if(activityId.isEmpty())
 			throw new IllegalArgumentException("Vous devez spécifier l'activité pour lequel vous créer cet indicateur !");
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		Activity activity = module.activities().get(activityId);
+		Activity activity = module.activities().get(activityId.value());
 		return new XeChain(
 				new XeIndicatorType(module.indicatorTypes().indicatorType(IndicatorType.GOAL_NUMBER)), 
 				new XeActivity(activity)

--- a/src/main/java/com/supervisor/takes/TkGoalNumberSettingSave.java
+++ b/src/main/java/com/supervisor/takes/TkGoalNumberSettingSave.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.colors.Color;
@@ -12,6 +13,7 @@ import com.supervisor.sdk.takes.TkBaseWrap;
 import com.supervisor.sdk.time.PeriodicityUnit;
 import com.supervisor.sdk.utils.BasicCodeGenerator;
 import com.supervisor.sdk.utils.CodeGenerator;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.lang.StringUtils;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
@@ -45,7 +47,7 @@ public final class TkGoalNumberSettingSave extends TkBaseWrap {
 					final String unitySymbol = form.single("unity_symbol", "");
 					final SymbolPosition symbolPosition = SymbolPosition.valueOf(form.single("symbol_position", "RIGHT"));
 					final Color color = Color.valueOf(form.single("color_id"));
-					final Long activityId = Long.parseLong(form.single("activity_id"));
+					final UUID activityId = UUID.fromString(form.single("activity_id"));
 					final Activity activity = myActivities.get(activityId);
 					
 					if(new RqUser(base, req).notOwn(activity)) {
@@ -54,9 +56,9 @@ public final class TkGoalNumberSettingSave extends TkBaseWrap {
 					
 					GoalNumber itemSaved;
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
-					if(id > 0) {			
-						itemSaved = (GoalNumber)activity.indicators().get(id);
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
+					if(id.isPresent()) {
+						itemSaved = (GoalNumber)activity.indicators().get(id.value());
 						
 						final String periodicityState = form.single("periodicity_state", "removed");
 						if(periodicityState.equals("added")) {
@@ -91,7 +93,7 @@ public final class TkGoalNumberSettingSave extends TkBaseWrap {
 					
 					final String msg;
 					
-					if(id > 0)
+					if(id.isPresent())
 						msg = String.format("L'indicateur %s a été modifié avec succès !", itemSaved.code());
 					else
 						msg = String.format("L'indicateur %s a été créé avec succès !", itemSaved.code());

--- a/src/main/java/com/supervisor/takes/TkHome.java
+++ b/src/main/java/com/supervisor/takes/TkHome.java
@@ -7,6 +7,7 @@ import com.supervisor.domain.impl.UserOf;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.RsPage;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.cactoos.iterable.Sticky;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqHref;
@@ -38,12 +39,12 @@ public final class TkHome extends TkBaseWrap {
 					}else {
 						Smart params = new RqHref.Smart(req);
 						
-						final Long id = Long.parseLong(params.single("activity", "0"));
+						final OptUUID id = new OptUUID(params.single("activity", "0"));
 						final Activity act;
 						
-						if(id > 0) {
+						if(id.isPresent()) {
 							// prendre l'activité sélectionné par l'utilisateur
-							act = myActivities.get(id);								
+							act = myActivities.get(id.value());
 						}else {
 							// afficher une activité par défaut
 							Activities ownActivities = myActivities.ownActivities();

--- a/src/main/java/com/supervisor/takes/TkHub2OpenTransaction.java
+++ b/src/main/java/com/supervisor/takes/TkHub2OpenTransaction.java
@@ -23,6 +23,7 @@ import java.io.DataOutputStream;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 public final class TkHub2OpenTransaction extends TkBaseWrap {
 
@@ -34,7 +35,7 @@ public final class TkHub2OpenTransaction extends TkBaseWrap {
 					final Membership module = new DmMembership(base, req);
 					final User user = module.user();
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("request"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("request"));
 					
 					PaymentRequest payRequest = user.paymentRequests().get(id);
 					PaymentMethod method = module.paymentMethods().where(PaymentMethod::tag, "HUB2").first();

--- a/src/main/java/com/supervisor/takes/TkHub2TransactionCallback.java
+++ b/src/main/java/com/supervisor/takes/TkHub2TransactionCallback.java
@@ -30,7 +30,7 @@ public final class TkHub2TransactionCallback extends TkBaseWrap {
 				req -> {
 					
 					RecordSet<User> source = base.select(User.class);
-					User user = new DmUser(source.get(1L)); // prendre l'utilisateur Minlessika
+					User user = new DmUser(source.get(User.ADMIN_ID)); // prendre l'utilisateur Minlessika
 					
 					final Membership module = new DmMembership(base, user);
 					

--- a/src/main/java/com/supervisor/takes/TkImportDataSheetEdit.java
+++ b/src/main/java/com/supervisor/takes/TkImportDataSheetEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -50,7 +52,7 @@ public final class TkImportDataSheetEdit extends TkForm {
 	protected XeSource newItemToShow(final Request req) throws IOException {
 		Supervisor module = new PxSupervisor(base, req);		
 		DataSheetModels models = module.dataSheetModels();
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		
 		DataSheetModel model = models.get(modelId);
 		XeSource xeItem = new XeDataSheetModel("item", model); 
@@ -61,12 +63,12 @@ public final class TkImportDataSheetEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		return XeSource.EMPTY;
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return newItemToShow(req);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkImportDataSheetSave.java
+++ b/src/main/java/com/supervisor/takes/TkImportDataSheetSave.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -22,8 +23,8 @@ public final class TkImportDataSheetSave extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
 					
-					final Long id = Long.parseLong(form.single("id"));
-					final Long sourceId = Long.parseLong(form.single("source_id"));
+					final UUID id = UUID.fromString(form.single("id"));
+					final UUID sourceId = UUID.fromString(form.single("source_id"));
 					
 					final DataSheetModel source = module.dataSheetModels().get(sourceId);
 					final DataSheetModel target = module.dataSheetModels().get(id);

--- a/src/main/java/com/supervisor/takes/TkIndicator.java
+++ b/src/main/java/com/supervisor/takes/TkIndicator.java
@@ -16,6 +16,8 @@ import com.supervisor.indicator.Indicators;
 import com.supervisor.xe.XeIndicator;
 import com.supervisor.xe.XeSupervisor;
 
+import java.util.UUID;
+
 public final class TkIndicator extends TkBaseWrap {
 
 	public TkIndicator(final Base base) {
@@ -23,7 +25,7 @@ public final class TkIndicator extends TkBaseWrap {
 				base, 
 				req -> {
 					final Supervisor module = new PxSupervisor(base, req);
-					final Long activityId = Long.parseLong(new RqHref.Smart(req).single("activity"));
+					final UUID activityId = UUID.fromString(new RqHref.Smart(req).single("activity"));
 					final Activity activity = module.activities().get(activityId);
 					Indicators myItems = activity.indicators().where(Indicator::isTemplate, false);
 					

--- a/src/main/java/com/supervisor/takes/TkIndicatorDelete.java
+++ b/src/main/java/com/supervisor/takes/TkIndicatorDelete.java
@@ -1,12 +1,15 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.lang.StringUtils;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
+import org.takes.misc.Opt;
 import org.takes.rq.RqHref;
 
 import com.supervisor.domain.Activity;
@@ -25,13 +28,13 @@ public final class TkIndicatorDelete extends TkBaseWrap {
 				req -> {
 					final Supervisor module = new PxSupervisor(base, req);
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));			
-					if(id == 0)
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
+					if(id.isEmpty())
 						throw new IllegalArgumentException("Cet élément n'existe pas !");
 					
-					final Long activityId = Long.parseLong(StringUtils.replace(new RqHref.Smart(req).single("source"), "activity", ""));
+					final UUID activityId = UUID.fromString(StringUtils.replace(new RqHref.Smart(req).single("source"), "activity", ""));
 					final Activity activity = module.activities().get(activityId);
-					Indicator indicator = activity.indicators().get(id);
+					Indicator indicator = activity.indicators().get(id.value());
 
 					if(new RqUser(base, req).notOwn(indicator)) {
 						throw new IllegalArgumentException("Vous ne pouvez pas supprimer l'indicateur d'une activité partagée !");

--- a/src/main/java/com/supervisor/takes/TkIndicatorDynamicParamEdit.java
+++ b/src/main/java/com/supervisor/takes/TkIndicatorDynamicParamEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.lang.StringUtils;
 import org.takes.Request;
 import org.takes.rq.RqHref;
@@ -50,17 +52,17 @@ public final class TkIndicatorDynamicParamEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final String source = new RqHref.Smart(req).single("source");
 		final String shortName = new RqHref.Smart(req).single("short_name");
-		final Long indicId = Long.parseLong(new RqHref.Smart(req).single("indic"));
+		final UUID indicId = UUID.fromString(new RqHref.Smart(req).single("indic"));
 		
 		final Supervisor module = new PxSupervisor(base, req);
-		final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+		final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 		final Activity activity = module.activities().get(activityId);
 		Indicator indic = activity.indicators().get(indicId);
-		IndicatorDynamicParam item = indic.dynamicParams().get(id);
+		IndicatorDynamicParam item = indic.dynamicParams().get(id.value());
 				
 		return new XeChain( 
 			new XeAppend("short_name", shortName),
@@ -70,7 +72,7 @@ public final class TkIndicatorDynamicParamEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeIndicatorDynamicParam(dir);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkIndicatorDynamicParamSave.java
+++ b/src/main/java/com/supervisor/takes/TkIndicatorDynamicParamSave.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -31,13 +32,13 @@ public final class TkIndicatorDynamicParamSave extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
 						
-					final Long indicatorId = Long.parseLong(form.single("indicator_id"));		
+					final UUID indicatorId = UUID.fromString(form.single("indicator_id"));
 					final String source = new RqHref.Smart(req).single("source");
-					final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+					final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 					final Activity activity = module.activities().get(activityId);
 					Indicator indicator = activity.indicators().get(indicatorId);		
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 					IndicatorDynamicParam itemSaved = indicator.dynamicParams().get(id);
 					
 					switch (itemSaved.type()) {

--- a/src/main/java/com/supervisor/takes/TkIndicatorType.java
+++ b/src/main/java/com/supervisor/takes/TkIndicatorType.java
@@ -3,6 +3,7 @@ package com.supervisor.takes;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.RsPage;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.cactoos.iterable.Sticky;
 import org.takes.rq.RqHref;
 import org.takes.rs.xe.XeAppend;
@@ -23,12 +24,12 @@ public final class TkIndicatorType extends TkBaseWrap {
 				req -> {
 					final Supervisor module = new PxSupervisor(base, req);
 					
-					Long activityId = Long.parseLong(new RqHref.Smart(req).single("activity", "0"));
-					if(activityId == 0)
+					OptUUID activityId = new OptUUID(new RqHref.Smart(req).single("activity", "0"));
+					if(activityId.isEmpty())
 						throw new IllegalArgumentException("Vous devez spécifier l'activité pour lequel vous créer cet indicateur !");
 					
 					Activity activity = module.activities()
-							                  .get(activityId);
+							                  .get(activityId.value());
 					
 					XeSource xeActivity = new XeActivity(activity);
 					XeSource xeSupervisor = new XeSupervisor(module);

--- a/src/main/java/com/supervisor/takes/TkInteraction.java
+++ b/src/main/java/com/supervisor/takes/TkInteraction.java
@@ -15,6 +15,8 @@ import com.supervisor.xe.XeActivity;
 import com.supervisor.xe.XeInteraction;
 import com.supervisor.xe.XeSupervisor;
 
+import java.util.UUID;
+
 public final class TkInteraction extends TkBaseWrap {
 
 	public TkInteraction(final Base base) {
@@ -26,7 +28,7 @@ public final class TkInteraction extends TkBaseWrap {
 					
 					final Supervisor module = new PxSupervisor(base, req);
 					
-					final Long activityId = Long.parseLong(new RqHref.Smart(req).single("activity"));
+					final UUID activityId = UUID.fromString(new RqHref.Smart(req).single("activity"));
 					final Activities activities = module.activities();
 					final Activity activity = activities.get(activityId);
 					

--- a/src/main/java/com/supervisor/takes/TkInteractionActivate.java
+++ b/src/main/java/com/supervisor/takes/TkInteractionActivate.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -27,8 +28,8 @@ public final class TkInteractionActivate extends TkBaseWrap {
 					final Activities myActivities = module.activities();
 					
 					final Smart href = new RqHref.Smart(req);
-					final Long receiverId = Long.parseLong(href.single("receiver"));
-					final Long actorId = Long.parseLong(href.single("actor"));
+					final UUID receiverId = UUID.fromString(href.single("receiver"));
+					final UUID actorId = UUID.fromString(href.single("actor"));
 					final boolean activate = Boolean.parseBoolean(href.single("activate"));
 					
 					final Activity actor = myActivities.get(actorId);

--- a/src/main/java/com/supervisor/takes/TkListDataFieldEdit.java
+++ b/src/main/java/com/supervisor/takes/TkListDataFieldEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -42,9 +44,9 @@ public final class TkListDataFieldEdit extends TkForm {
 	@Override
 	protected Iterable<XeSource> contentToShow(final Request req, final XeSource itemToShow) throws IOException {
 		
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single(MODEL));
-		Long tableModelId = Long.parseLong(new RqHref.Smart(req).single("table_model", "0"));
-		Long tableId = Long.parseLong(new RqHref.Smart(req).single("table", "0"));
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single(MODEL));
+		OptUUID tableModelId = new OptUUID(new RqHref.Smart(req).single("table_model", "0"));
+		OptUUID tableId = new OptUUID(new RqHref.Smart(req).single("table", "0"));
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		final DataSheetModel model = module.dataSheetModels().get(modelId);
@@ -54,9 +56,9 @@ public final class TkListDataFieldEdit extends TkForm {
 		content.add(new XeOrderDirection());
 		content.add(new XeDataSheetModel(MODEL, model));
 		
-		if(tableId > 0) {
-			final DataSheetModel tableModel = module.dataSheetModels().get(tableModelId);
-			content.add(new XeDataField("table", tableModel.fields().get(tableId)));
+		if(tableId.isPresent()) {
+			final DataSheetModel tableModel = module.dataSheetModels().get(tableModelId.value());
+			content.add(new XeDataField("table", tableModel.fields().get(tableId.value())));
 			content.add(new XeAppend("table_model_id", tableModelId.toString()));
 		}			
 		
@@ -67,12 +69,12 @@ public final class TkListDataFieldEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
-		final Long modelId = Long.parseLong(new RqHref.Smart(req).single(MODEL));
+		final UUID modelId = UUID.fromString(new RqHref.Smart(req).single(MODEL));
 		final Supervisor module = new PxSupervisor(base, req);
 		final DataSheetModel model = module.dataSheetModels().get(modelId);
-		final ListDataField item = (ListDataField)model.fields().get(id);
+		final ListDataField item = (ListDataField)model.fields().get(id.value());
 		
 		return new XeChain(
 			new XeListDataField("item", item), 
@@ -81,7 +83,7 @@ public final class TkListDataFieldEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeListDataField(dir);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkListDataFieldSave.java
+++ b/src/main/java/com/supervisor/takes/TkListDataFieldSave.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -7,8 +8,10 @@ import com.supervisor.sdk.datasource.OrderDirection;
 import com.supervisor.sdk.takes.TkBaseWrap;
 import com.supervisor.sdk.utils.BasicCodeGenerator;
 import com.supervisor.sdk.utils.CodeGenerator;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
+import org.takes.misc.Opt;
 import org.takes.rq.RqGreedy;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -36,28 +39,28 @@ public final class TkListDataFieldSave extends TkBaseWrap {
 					final boolean mustEditOnce = Boolean.parseBoolean(form.single("must_edit_once"));
 					final int limit = Integer.parseInt(form.single("limit"));
 					
-					final Long modelId = Long.parseLong(form.single("model_id"));
+					final UUID modelId = UUID.fromString(form.single("model_id"));
 					final DataSheetModel model = module.dataSheetModels().get(modelId);
 					
 					final OrderDirection orderDirection = OrderDirection.valueOf(form.single("order_direction_id"));
 					
-					final long tableId = Long.parseLong(form.single("table_id", "0"));
-					final long tableModelId = Long.parseLong(form.single("table_model_id", "0"));
+					final OptUUID tableId = new OptUUID(form.single("table_id", "0"));
+					final OptUUID tableModelId = new OptUUID(form.single("table_model_id", "0"));
 					
 					final DataFieldType type = DataFieldType.valueOf(form.single("type_id"));
 					final String description = form.single("description");
 													
 					final ListDataField itemSaved;
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
-					if(id > 0) {
-						itemSaved = model.fields().lists().get(id); 
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
+					if(id.isPresent()) {
+						itemSaved = model.fields().lists().get(id.value());
 						itemSaved.update(itemSaved.code(), name, type, description);			
 					} else {						
 						final CodeGenerator generator;
-						if(tableId > 0) {
-							final DataSheetModel tableModel = module.dataSheetModels().get(tableModelId);
-							TableDataField table = (TableDataField)tableModel.fields().get(tableId);
+						if(tableId.isPresent()) {
+							final DataSheetModel tableModel = module.dataSheetModels().get(tableModelId.value());
+							TableDataField table = (TableDataField)tableModel.fields().get(tableId.value());
 							
 							generator = new BasicCodeGenerator(
 											table.structure().fields(), 
@@ -84,12 +87,12 @@ public final class TkListDataFieldSave extends TkBaseWrap {
 					
 					final String msg;
 					
-					if(id > 0)
+					if(id.isPresent())
 						msg = String.format("Le champ %s a été modifié avec succès !", itemSaved.name());
 					else
 						msg = String.format("Le champ %s a été créé avec succès !", itemSaved.name());
 					
-					if(tableId > 0) {
+					if(tableId.isPresent()) {
 						return new RsForward(
 								new RsFlash(
 					                msg,

--- a/src/main/java/com/supervisor/takes/TkListDataFieldSourceActivate.java
+++ b/src/main/java/com/supervisor/takes/TkListDataFieldSourceActivate.java
@@ -1,9 +1,11 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqHref;
@@ -21,11 +23,11 @@ public final class TkListDataFieldSourceActivate extends TkBaseWrap {
 				req -> {
 					final Supervisor module = new PxSupervisor(base, req);
 					
-					final Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
-					final Long fieldId = Long.parseLong(new RqHref.Smart(req).single("field"));
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
-					final Long tableId = Long.parseLong(new RqHref.Smart(req).single("table", "0"));
-					final Long tableModelId = Long.parseLong(new RqHref.Smart(req).single("table_model", "0"));
+					final UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
+					final UUID fieldId = UUID.fromString(new RqHref.Smart(req).single("field"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
+					final OptUUID tableId = new OptUUID(new RqHref.Smart(req).single("table", "0"));
+					final OptUUID tableModelId = new OptUUID(new RqHref.Smart(req).single("table_model", "0"));
 					final boolean active = Boolean.parseBoolean(new RqHref.Smart(req).single("active"));
 					
 					final DataSheetModel model = module.dataSheetModels().get(modelId);
@@ -41,7 +43,7 @@ public final class TkListDataFieldSourceActivate extends TkBaseWrap {
 					else
 						msg = "La source de données a été désactivée avec succès !";
 					
-					if(tableId > 0) {
+					if(tableId.isPresent()) {
 						return new RsForward(
 								new RsFlash(
 					                msg,

--- a/src/main/java/com/supervisor/takes/TkListDataFieldSourceDelete.java
+++ b/src/main/java/com/supervisor/takes/TkListDataFieldSourceDelete.java
@@ -1,9 +1,11 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqHref;
@@ -21,10 +23,10 @@ public final class TkListDataFieldSourceDelete extends TkBaseWrap {
 				req -> {
 					final Supervisor module = new PxSupervisor(base, req);
 					
-					final Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
-					final Long fieldId = Long.parseLong(new RqHref.Smart(req).single("field"));
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
-					final Long tableId = Long.parseLong(new RqHref.Smart(req).single("table", "0"));
+					final UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
+					final UUID fieldId = UUID.fromString(new RqHref.Smart(req).single("field"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
+					final OptUUID tableId = new OptUUID(new RqHref.Smart(req).single("table", "0"));
 					
 					final DataSheetModel model = module.dataSheetModels().get(modelId);
 					final ListDataField field = (ListDataField)model.fields().get(fieldId); 
@@ -34,7 +36,7 @@ public final class TkListDataFieldSourceDelete extends TkBaseWrap {
 					
 					final String msg = "La source de données a été supprimée avec succès !";
 
-					if(tableId > 0) {
+					if(tableId.isPresent()) {
 						return new RsForward(
 								new RsFlash(
 					                msg,

--- a/src/main/java/com/supervisor/takes/TkListDataFieldSourceEdit.java
+++ b/src/main/java/com/supervisor/takes/TkListDataFieldSourceEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -45,10 +47,10 @@ public final class TkListDataFieldSourceEdit extends TkForm {
 	@Override
 	protected Iterable<XeSource> contentToShow(final Request req, final XeSource itemToShow) throws IOException {
 		
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single(MODEL));
-		Long fieldId = Long.parseLong(new RqHref.Smart(req).single("field"));
-		Long tableId = Long.parseLong(new RqHref.Smart(req).single("table", "0"));
-		Long tableModelId = Long.parseLong(new RqHref.Smart(req).single("table_model", "0"));
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single(MODEL));
+		UUID fieldId = UUID.fromString(new RqHref.Smart(req).single("field"));
+		OptUUID tableId = new OptUUID(new RqHref.Smart(req).single("table", "0"));
+		OptUUID tableModelId = new OptUUID(new RqHref.Smart(req).single("table_model", "0"));
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		final DataSheetModel model = module.dataSheetModels().get(modelId);
@@ -69,9 +71,9 @@ public final class TkListDataFieldSourceEdit extends TkForm {
 		content.add(xeModelFields);
 		content.add(new XeDataSheetModel(MODEL, model));
 		
-		if(tableId > 0) {		
-			final DataSheetModel tableModel = module.dataSheetModels().get(tableModelId);
-			final TableDataField table = (TableDataField)tableModel.fields().get(tableId);
+		if(tableId.isPresent()) {
+			final DataSheetModel tableModel = module.dataSheetModels().get(tableModelId.value());
+			final TableDataField table = (TableDataField)tableModel.fields().get(tableId.value());
 			content.add(new XeDataField("table", table));
 		}			
 		
@@ -87,20 +89,20 @@ public final class TkListDataFieldSourceEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
-		final Long modelId = Long.parseLong(new RqHref.Smart(req).single(MODEL));
-		Long fieldId = Long.parseLong(new RqHref.Smart(req).single("field"));
+		final UUID modelId = UUID.fromString(new RqHref.Smart(req).single(MODEL));
+		UUID fieldId = UUID.fromString(new RqHref.Smart(req).single("field"));
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		final DataSheetModel model = module.dataSheetModels().get(modelId);
 		final ListDataField list = (ListDataField)model.fields().get(fieldId);
-		final ListDataFieldSource item = list.sources().get(id);
+		final ListDataFieldSource item = list.sources().get(id.value());
 		return new XeListDataFieldSource("item", item);
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeListDataFieldSource(dir);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkListDataFieldSourceSave.java
+++ b/src/main/java/com/supervisor/takes/TkListDataFieldSourceSave.java
@@ -1,9 +1,11 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqGreedy;
@@ -27,29 +29,29 @@ public final class TkListDataFieldSourceSave extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
 					
-					final Long modelId = Long.parseLong(form.single("model_id"));
+					final UUID modelId = UUID.fromString(form.single("model_id"));
 					final DataSheetModel model = module.dataSheetModels().get(modelId);
 					
-					final Long fieldId = Long.parseLong(form.single("field_id"));
+					final UUID fieldId = UUID.fromString(form.single("field_id"));
 					final ListDataField field = (ListDataField)model.fields().get(fieldId); 
 					
-					final Long listModelId = Long.parseLong(form.single("list_model_id"));
+					final UUID listModelId = UUID.fromString(form.single("list_model_id"));
 					final DataModel listModel = module.dataModels().get(listModelId);
 					
-					final Long fieldToDisplayId = Long.parseLong(form.single("field_to_display_id"));
+					final UUID fieldToDisplayId = UUID.fromString(form.single("field_to_display_id"));
 					final DataField fieldToDisplay = listModel.fields().get(fieldToDisplayId);
 					
-					final Long orderFieldId = Long.parseLong(form.single("order_field_id"));
+					final UUID orderFieldId = UUID.fromString(form.single("order_field_id"));
 					final DataField orderField = listModel.fields().get(orderFieldId);
 					
-					final Long tableId = Long.parseLong(form.single("table_id", "0"));
-					final Long tableModelId = Long.parseLong(form.single("table_model_id", "0"));
+					final OptUUID tableId = new OptUUID(form.single("table_id", "0"));
+					final OptUUID tableModelId = new OptUUID(form.single("table_model_id", "0"));
 													
 					final ListDataFieldSource itemSaved;
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
-					if(id > 0) {
-						itemSaved = field.sources().get(id); 
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
+					if(id.isPresent()) {
+						itemSaved = field.sources().get(id.value());
 						itemSaved.update(listModel, fieldToDisplay, orderField);	 	
 					} else {			
 						itemSaved = field.sources().add(listModel, fieldToDisplay, orderField);
@@ -57,12 +59,12 @@ public final class TkListDataFieldSourceSave extends TkBaseWrap {
 					
 					final String msg;
 					
-					if(id > 0)
+					if(id.isPresent())
 						msg = "La source de données a été modifiée avec succès !";
 					else
 						msg = "La source de données a été créée avec succès !";
 					
-					if(tableId > 0) {
+					if(tableId.isPresent()) {
 						return new RsForward(
 								new RsFlash(
 					                msg,

--- a/src/main/java/com/supervisor/takes/TkListDataFieldValueSearchable.java
+++ b/src/main/java/com/supervisor/takes/TkListDataFieldValueSearchable.java
@@ -13,6 +13,8 @@ import com.supervisor.domain.bi.BiResult;
 import com.supervisor.domain.impl.PxSupervisor;
 import com.supervisor.xe.XeListDataFieldValueJson;
 
+import java.util.UUID;
+
 public final class TkListDataFieldValueSearchable extends TkBaseWrap {
 
 	public TkListDataFieldValueSearchable(final Base base) {
@@ -22,8 +24,8 @@ public final class TkListDataFieldValueSearchable extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					Smart params = new RqHref.Smart(req);
 		
-					final Long fieldId = Long.parseLong(params.single("field"));
-					final Long modelId = Long.parseLong(params.single("model"));
+					final UUID fieldId = UUID.fromString(params.single("field"));
+					final UUID modelId = UUID.fromString(params.single("model"));
 					final String filter = params.single("filter", "");
 					final Long page = Long.parseLong(params.single("page"));
 					final int itemsPerPage = Integer.parseInt(params.single("itemsPerPage"));

--- a/src/main/java/com/supervisor/takes/TkMobileMoneyPaymentEdit.java
+++ b/src/main/java/com/supervisor/takes/TkMobileMoneyPaymentEdit.java
@@ -9,6 +9,7 @@ import com.supervisor.billing.PaymentType;
 import com.supervisor.domain.Membership;
 import com.supervisor.domain.User;
 import com.supervisor.domain.impl.DmMembership;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XeMembership;
 import com.supervisor.xe.XeMobilePaymentReceipt;
 import com.supervisor.xe.XePaymentMethod;
@@ -25,6 +26,7 @@ import org.xembly.Directive;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public final class TkMobileMoneyPaymentEdit extends TkForm {
 
@@ -43,11 +45,11 @@ public final class TkMobileMoneyPaymentEdit extends TkForm {
 		final Membership module = new DmMembership(base, req);
 		final User user = module.user();
 		
-		Long requestId = Long.parseLong(new RqHref.Smart(req).single("request"));
+		UUID requestId = UUID.fromString(new RqHref.Smart(req).single("request"));
 		PaymentRequest request = user.paymentRequests().get(requestId);
 		XeSource xePaymentRequest = new XePaymentRequest("request", request);
 		
-		Long methodId = Long.parseLong(new RqHref.Smart(req).single("method"));
+		UUID methodId = UUID.fromString(new RqHref.Smart(req).single("method"));
 		PaymentMethod method = module.paymentMethods()
 			                         .where(PaymentMethod::type, PaymentType.MOBILE_MONEY)
 			                         .get(methodId);
@@ -81,12 +83,12 @@ public final class TkMobileMoneyPaymentEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		return XeSource.EMPTY;
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeDirectives(dir);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkMobileMoneyPaymentFinalize.java
+++ b/src/main/java/com/supervisor/takes/TkMobileMoneyPaymentFinalize.java
@@ -15,6 +15,7 @@ import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqGreedy;
 import org.takes.rq.form.RqFormSmart;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkMobileMoneyPaymentFinalize extends TkBaseWrap {
@@ -29,10 +30,10 @@ public final class TkMobileMoneyPaymentFinalize extends TkBaseWrap {
 					
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
 					
-					final Long requestId = Long.parseLong(form.single("request_id"));
+					final UUID requestId = UUID.fromString(form.single("request_id"));
 					PaymentRequest paymentRequest = user.paymentRequests().get(requestId);
 					
-					final Long methodId = Long.parseLong(form.single("method_id"));
+					final UUID methodId = UUID.fromString(form.single("method_id"));
 					PaymentMethod method = module.paymentMethods().get(methodId);
 					
 					final MobileMoney mobileMoney = (MobileMoney)method;

--- a/src/main/java/com/supervisor/takes/TkMomoTransactionCallback.java
+++ b/src/main/java/com/supervisor/takes/TkMomoTransactionCallback.java
@@ -21,7 +21,7 @@ public final class TkMomoTransactionCallback extends TkBaseWrap {
 				base,
 				req -> {
 					RecordSet<User> source = base.select(User.class);
-					User user = new DmUser(source.get(1L)); // prendre l'utilisateur Minlessika
+					User user = new DmUser(source.get(User.ADMIN_ID)); // prendre l'utilisateur Minlessika
 					
 					final Membership membership = new DmMembership(base, user);
 					

--- a/src/main/java/com/supervisor/takes/TkNotifyActivity.java
+++ b/src/main/java/com/supervisor/takes/TkNotifyActivity.java
@@ -13,6 +13,8 @@ import com.supervisor.domain.DataSheetModel;
 import com.supervisor.domain.Supervisor;
 import com.supervisor.domain.impl.PxSupervisor;
 
+import java.util.UUID;
+
 public final class TkNotifyActivity extends TkBaseWrap {
 
 	public TkNotifyActivity(final Base base) {
@@ -21,7 +23,7 @@ public final class TkNotifyActivity extends TkBaseWrap {
 				req -> {
 					
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));	
-					final Long ownerId = Long.parseLong(form.single("owner_id"));
+					final UUID ownerId = UUID.fromString(form.single("owner_id"));
 					final Iterable<String> modelIds = form.param("model_id");
 					
 					final RecordSet<User> source = base.select(User.class);
@@ -30,7 +32,7 @@ public final class TkNotifyActivity extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, owner);
 					
 					for (String modelId : modelIds) {
-						final DataSheetModel model = module.dataSheetModels().get(Long.parseLong(modelId));
+						final DataSheetModel model = module.dataSheetModels().get(UUID.fromString(modelId));
 						module.activityNotification().publish(model);
 					}					
 					

--- a/src/main/java/com/supervisor/takes/TkNumberOrientedSettingEdit.java
+++ b/src/main/java/com/supervisor/takes/TkNumberOrientedSettingEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.lang.StringUtils;
 import org.takes.Request;
 import org.takes.rq.RqHref;
@@ -57,14 +59,14 @@ public final class TkNumberOrientedSettingEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);		
 
 		final String source = new RqHref.Smart(req).single("source");
-		final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+		final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 		final Activity activity = module.activities().get(activityId);
-		final NumberOriented indic = (NumberOriented)activity.indicators().get(id);
+		final NumberOriented indic = (NumberOriented)activity.indicators().get(id.value());
 		
 		return new XeChain(
 				new XeNumberOrientedSetting("item", indic),
@@ -75,18 +77,18 @@ public final class TkNumberOrientedSettingEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
 		String source = new RqHref.Smart(req).single("source");
-		final Long activityId = Long.parseLong(StringUtils.remove(source, "activity"));
+		final UUID activityId = UUID.fromString(StringUtils.remove(source, "activity"));
 		final Activity activity = module.activities().get(activityId);
 	
 		XeSource xeDataRule = XeSource.EMPTY;
 		XeSource xeParam = XeSource.EMPTY;
-		if(id > 0) {
-			final NumberOriented indic = (NumberOriented)activity.indicators().get(id);
+		if(id.isPresent()) {
+			final NumberOriented indic = (NumberOriented)activity.indicators().get(id.value());
 			xeDataRule = new XeDataLink(indic.links());
 			xeParam = new XeIndicatorDynamicParam(indic.dynamicParams());
 		}
@@ -102,12 +104,12 @@ public final class TkNumberOrientedSettingEdit extends TkForm {
 	@Override
 	protected XeSource newItemToShow(Request req) throws IOException {
 		
-		Long activityId = Long.parseLong(new RqHref.Smart(req).single("activity", "0"));
-		if(activityId == 0)
+		OptUUID activityId = new OptUUID(new RqHref.Smart(req).single("activity", "0"));
+		if(activityId.isEmpty())
 			throw new IllegalArgumentException("Vous devez spécifier l'activité pour lequel vous créer cet indicateur !");
 		
 		final Supervisor module = new PxSupervisor(base, req);		
-		Activity activity = module.activities().get(activityId);
+		Activity activity = module.activities().get(activityId.value());
 		
 		return new XeChain(
 				new XeIndicatorType(module.indicatorTypes().indicatorType(IndicatorType.NUMBER_ORIENTED)), 

--- a/src/main/java/com/supervisor/takes/TkNumberOrientedSettingSave.java
+++ b/src/main/java/com/supervisor/takes/TkNumberOrientedSettingSave.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -11,9 +12,11 @@ import com.supervisor.sdk.takes.TkBaseWrap;
 import com.supervisor.sdk.time.PeriodicityUnit;
 import com.supervisor.sdk.utils.BasicCodeGenerator;
 import com.supervisor.sdk.utils.CodeGenerator;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.lang.StringUtils;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
+import org.takes.misc.Opt;
 import org.takes.rq.RqGreedy;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -45,7 +48,7 @@ public final class TkNumberOrientedSettingSave extends TkBaseWrap {
 					final String unitySymbol = form.single("unity_symbol", "");
 					final SymbolPosition symbolPosition = SymbolPosition.valueOf(form.single("symbol_position", "RIGHT"));
 					final boolean manageEvolutionPercent = Boolean.parseBoolean(form.single("manage_evolution_percent"));		
-					final Long activityId = Long.parseLong(form.single("activity_id"));
+					final UUID activityId = UUID.fromString(form.single("activity_id"));
 					final Activity activity = myActivities.get(activityId);
 					
 					if(new RqUser(base, req).notOwn(activity)) {
@@ -54,9 +57,9 @@ public final class TkNumberOrientedSettingSave extends TkBaseWrap {
 					
 					NumberOriented itemSaved;
 
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
-					if(id > 0) {			
-						itemSaved = (NumberOriented)activity.indicators().get(id);
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
+					if(id.isPresent()) {
+						itemSaved = (NumberOriented)activity.indicators().get(id.value());
 									
 						final String periodicityState = form.single("periodicity_state", "removed");
 						if(periodicityState.equals("added")) {
@@ -92,7 +95,7 @@ public final class TkNumberOrientedSettingSave extends TkBaseWrap {
 					
 					final String msg;
 					
-					if(id > 0)
+					if(id.isPresent())
 						msg = String.format("L'indicateur %s a été modifié avec succès !", itemSaved.code());
 					else
 						msg = String.format("L'indicateur %s a été créé avec succès !", itemSaved.code());

--- a/src/main/java/com/supervisor/takes/TkOmOpenTransaction.java
+++ b/src/main/java/com/supervisor/takes/TkOmOpenTransaction.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 public final class TkOmOpenTransaction extends TkBaseWrap {
 
@@ -28,7 +29,7 @@ public final class TkOmOpenTransaction extends TkBaseWrap {
 					final Membership module = new DmMembership(base, req);
 					final User user = module.user();
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("request"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("request"));
 					
 					final PaymentRequest paymentRequest = user.paymentRequests().get(id);
 					final MobileMoney method = (MobileMoney)module.paymentMethods().where(PaymentMethod::tag, "OM").first();

--- a/src/main/java/com/supervisor/takes/TkOmTransactionCallback.java
+++ b/src/main/java/com/supervisor/takes/TkOmTransactionCallback.java
@@ -24,7 +24,7 @@ public final class TkOmTransactionCallback extends TkBaseWrap {
 				base,
 				req -> {
 					RecordSet<User> source = base.select(User.class);
-					User user = new DmUser(source.get(1L)); // prendre l'utilisateur Minlessika
+					User user = new DmUser(source.get(User.ADMIN_ID)); // prendre l'utilisateur Minlessika
 					
 					final Membership membership = new DmMembership(base, user);
 					

--- a/src/main/java/com/supervisor/takes/TkPasswordEdit.java
+++ b/src/main/java/com/supervisor/takes/TkPasswordEdit.java
@@ -2,6 +2,7 @@ package com.supervisor.takes;
 
 import com.supervisor.domain.Membership;
 import com.supervisor.domain.impl.DmMembership;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XeMembership;
 import com.supervisor.xe.XeUserProfile;
 import com.supervisor.sdk.datasource.Base;
@@ -44,12 +45,12 @@ public final class TkPasswordEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		return XeSource.EMPTY;
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeUserProfile(dir);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkPasswordForgotten.java
+++ b/src/main/java/com/supervisor/takes/TkPasswordForgotten.java
@@ -3,6 +3,7 @@ package com.supervisor.takes;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
 import com.supervisor.sdk.takes.XeRecaptcha;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rs.xe.XeSource;
 
@@ -31,7 +32,7 @@ public final class TkPasswordForgotten extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(Long id, Request req) throws IOException {
+	protected XeSource preItemDataToShow(OptUUID id, Request req) throws IOException {
 		return XeSource.EMPTY;
 	}
 }

--- a/src/main/java/com/supervisor/takes/TkPasswordForgottenChanged.java
+++ b/src/main/java/com/supervisor/takes/TkPasswordForgottenChanged.java
@@ -8,6 +8,7 @@ import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
 import com.supervisor.sdk.takes.XeRecaptcha;
 import com.supervisor.sdk.translation.I18n;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.facets.auth.Identity;
 import org.takes.facets.auth.codecs.Codec;
@@ -49,7 +50,7 @@ public final class TkPasswordForgottenChanged extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(Long id, Request req) throws IOException {
+	protected XeSource preItemDataToShow(OptUUID id, Request req) throws IOException {
 		return XeSource.EMPTY;
 	}
 	

--- a/src/main/java/com/supervisor/takes/TkPayTestBuy.java
+++ b/src/main/java/com/supervisor/takes/TkPayTestBuy.java
@@ -15,6 +15,7 @@ import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqHref;
 
 import java.util.HashMap;
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkPayTestBuy extends TkBaseWrap {
@@ -26,7 +27,7 @@ public final class TkPayTestBuy extends TkBaseWrap {
 					final Membership module = new DmMembership(base, req);
 					final User user = module.user();
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("request"));					
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("request"));
 					final PaymentRequest payRequest = user.paymentRequests().get(id);
 					final PaymentMethod method = module.paymentMethods().where(PaymentMethod::tag, "PAY_TEST").first();
 					

--- a/src/main/java/com/supervisor/takes/TkPaymentMethodEdit.java
+++ b/src/main/java/com/supervisor/takes/TkPaymentMethodEdit.java
@@ -3,6 +3,7 @@ package com.supervisor.takes;
 import com.supervisor.billing.PaymentMethod;
 import com.supervisor.domain.Membership;
 import com.supervisor.domain.impl.DmMembership;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XePaymentMethod;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
@@ -40,9 +41,9 @@ public final class TkPaymentMethodEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		final Membership module = new DmMembership(base, req);
-		final PaymentMethod method = module.paymentMethods().get(id);
+		final PaymentMethod method = module.paymentMethods().get(id.value());
 		
 		XeSource xeMethod = new XePaymentMethod("item", method);		
 		return new XeChain(
@@ -51,7 +52,7 @@ public final class TkPaymentMethodEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XePaymentMethod(dir);
 	}
 }

--- a/src/main/java/com/supervisor/takes/TkPaymentMethodSave.java
+++ b/src/main/java/com/supervisor/takes/TkPaymentMethodSave.java
@@ -13,6 +13,7 @@ import org.takes.rq.RqGreedy;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkPaymentMethodSave extends TkBaseWrap {
@@ -26,7 +27,7 @@ public final class TkPaymentMethodSave extends TkBaseWrap {
 					final Membership module = new DmMembership(base, req);
 					final PaymentMethods methods = module.paymentMethods();
 					
-					Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 					
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
 					

--- a/src/main/java/com/supervisor/takes/TkPaymentRequestCancel.java
+++ b/src/main/java/com/supervisor/takes/TkPaymentRequestCancel.java
@@ -10,6 +10,7 @@ import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqHref;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkPaymentRequestCancel extends TkBaseWrap {
@@ -21,7 +22,7 @@ public final class TkPaymentRequestCancel extends TkBaseWrap {
 					
 					final Membership module = new DmMembership(base, req);
 					final User user = module.user();
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 
 					PaymentRequest item = user.paymentRequests().get(id);
 					item.cancel();

--- a/src/main/java/com/supervisor/takes/TkPaymentRequestEdit.java
+++ b/src/main/java/com/supervisor/takes/TkPaymentRequestEdit.java
@@ -5,6 +5,7 @@ import com.supervisor.billing.PaymentRequest;
 import com.supervisor.domain.Membership;
 import com.supervisor.domain.User;
 import com.supervisor.domain.impl.DmMembership;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XeMembership;
 import com.supervisor.xe.XePaymentMethod;
 import com.supervisor.xe.XePaymentRequest;
@@ -50,12 +51,12 @@ public final class TkPaymentRequestEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Membership module = new DmMembership(base, req);
 		final User user = module.user();
 		
-		PaymentRequest item = user.paymentRequests().get(id);
+		PaymentRequest item = user.paymentRequests().get(id.value());
 		return new XeChain(
 				new XePaymentRequest("item", item),
 				new XePaymentMethod(
@@ -68,7 +69,7 @@ public final class TkPaymentRequestEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeDirectives(dir);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkPlanDelete.java
+++ b/src/main/java/com/supervisor/takes/TkPlanDelete.java
@@ -10,6 +10,7 @@ import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqHref;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkPlanDelete extends TkBaseWrap {
@@ -23,7 +24,7 @@ public final class TkPlanDelete extends TkBaseWrap {
 					
 					final Membership module = new DmMembership(base, req);			
 					final Plans plans = module.plans();
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 
 					Plan item = plans.get(id);
 					String name = item.name();

--- a/src/main/java/com/supervisor/takes/TkPlanEdit.java
+++ b/src/main/java/com/supervisor/takes/TkPlanEdit.java
@@ -4,6 +4,7 @@ import com.supervisor.domain.Membership;
 import com.supervisor.domain.Plan;
 import com.supervisor.domain.impl.DmMembership;
 import com.supervisor.domain.impl.PxProfiles;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XePlan;
 import com.supervisor.xe.XePlanFeature;
 import com.supervisor.xe.XeProfile;
@@ -49,9 +50,9 @@ public final class TkPlanEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		final Membership module = new DmMembership(base, req);
-		final Plan plan = module.plans().get(id);
+		final Plan plan = module.plans().get(id.value());
 		
 		XeSource xePlan = new XePlan("item", plan);
 		XeSource xeFeatures = new XePlanFeature(plan.features().items());
@@ -62,7 +63,7 @@ public final class TkPlanEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XePlanFeature(dir);
 	}
 }

--- a/src/main/java/com/supervisor/takes/TkPlanFeatureDelete.java
+++ b/src/main/java/com/supervisor/takes/TkPlanFeatureDelete.java
@@ -11,6 +11,7 @@ import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqHref;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkPlanFeatureDelete extends TkBaseWrap {
@@ -25,8 +26,8 @@ public final class TkPlanFeatureDelete extends TkBaseWrap {
 					final Membership module = new DmMembership(base, req);			
 					final Plans plans = module.plans();
 					
-					final Long planId = Long.parseLong(new RqHref.Smart(req).single("plan"));
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					final UUID planId = UUID.fromString(new RqHref.Smart(req).single("plan"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 
 					Plan plan = plans.get(planId);
 					PlanFeature item = plan.features().get(id);

--- a/src/main/java/com/supervisor/takes/TkPlanFeatureEdit.java
+++ b/src/main/java/com/supervisor/takes/TkPlanFeatureEdit.java
@@ -4,11 +4,13 @@ import com.supervisor.domain.Membership;
 import com.supervisor.domain.Plan;
 import com.supervisor.domain.PlanFeature;
 import com.supervisor.domain.impl.DmMembership;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XePlan;
 import com.supervisor.xe.XePlanFeature;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
 import org.takes.Request;
+import org.takes.misc.Opt;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
 import org.takes.rs.xe.XeChain;
@@ -18,6 +20,7 @@ import org.xembly.Directive;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public final class TkPlanFeatureEdit extends TkForm {
 
@@ -37,7 +40,7 @@ public final class TkPlanFeatureEdit extends TkForm {
 		new RqAdminAuth(base, req);
 		
 		final Membership module = new DmMembership(base, req);
-		final Long planId = Long.parseLong(new RqHref.Smart(req).single("plan"));
+		final UUID planId = UUID.fromString(new RqHref.Smart(req).single("plan"));
 		final Plan plan = module.plans().get(planId);
 		
 		List<XeSource> content = new ArrayList<>();
@@ -53,11 +56,11 @@ public final class TkPlanFeatureEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		final Membership module = new DmMembership(base, req);
-		final Long planId = Long.parseLong(new RqHref.Smart(req).single("plan"));
+		final UUID planId = UUID.fromString(new RqHref.Smart(req).single("plan"));
 		final Plan plan = module.plans().get(planId);
-		final PlanFeature item = plan.features().get(id);
+		final PlanFeature item = plan.features().get(id.value());
 		
 		XeSource xePlanFeature = new XePlanFeature("item", item);
 		return new XeChain(
@@ -66,7 +69,7 @@ public final class TkPlanFeatureEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XePlanFeature(dir);
 	}
 }

--- a/src/main/java/com/supervisor/takes/TkPlanFeatureSave.java
+++ b/src/main/java/com/supervisor/takes/TkPlanFeatureSave.java
@@ -7,12 +7,14 @@ import com.supervisor.domain.Plans;
 import com.supervisor.domain.impl.DmMembership;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqGreedy;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkPlanFeatureSave extends TkBaseWrap {
@@ -28,10 +30,10 @@ public final class TkPlanFeatureSave extends TkBaseWrap {
 					
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
 					
-					Long planId = Long.parseLong(form.single("plan_id"));
+					UUID planId = UUID.fromString(form.single("plan_id"));
 					final PlanFeatures features = plans.get(planId).features();
 					
-					Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));		
+					OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
 					
 					final String name = form.single("name");
 					final String description = form.single("description");
@@ -41,8 +43,8 @@ public final class TkPlanFeatureSave extends TkBaseWrap {
 					
 					final PlanFeature item;
 					final String msg;
-					if(id > 0) {	
-						item = features.get(id);			
+					if(id.isPresent()) {
+						item = features.get(id.value());
 						msg = String.format("La fonctionnalité %s a été modifiée avec succès !", item.name());
 					}else {
 						item = features.add(name);

--- a/src/main/java/com/supervisor/takes/TkPlanSave.java
+++ b/src/main/java/com/supervisor/takes/TkPlanSave.java
@@ -8,12 +8,14 @@ import com.supervisor.domain.impl.DmMembership;
 import com.supervisor.domain.impl.PxProfiles;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqGreedy;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkPlanSave extends TkBaseWrap {
@@ -27,7 +29,7 @@ public final class TkPlanSave extends TkBaseWrap {
 					final Membership module = new DmMembership(base, req);
 					final Plans plans = module.plans();
 					
-					Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
+					OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
 					
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
 					
@@ -39,12 +41,12 @@ public final class TkPlanSave extends TkBaseWrap {
 					
 					final Plan item;
 					final String msg;
-					if(id > 0) {	
-						item = plans.get(id);			
+					if(id.isPresent()) {
+						item = plans.get(id.value());
 						msg = String.format("Le plan %s a été modifié avec succès !", item.name());
 					}else {
 						final String reference = form.single("reference");
-						final Long profileId = Long.parseLong(form.single("profile_id"));
+						final UUID profileId = UUID.fromString(form.single("profile_id"));
 						final Profile profile = new PxProfiles(base).get(profileId);
 						
 						item = plans.add(reference, profile, price);

--- a/src/main/java/com/supervisor/takes/TkPlanSubscriptionOrder.java
+++ b/src/main/java/com/supervisor/takes/TkPlanSubscriptionOrder.java
@@ -2,6 +2,7 @@ package com.supervisor.takes;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
@@ -29,7 +30,7 @@ public final class TkPlanSubscriptionOrder extends TkBaseWrap {
 					final User user = new RqUser(base, req);
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
 					
-					final Long planId = Long.parseLong(form.single("plan_id"));
+					final UUID planId = UUID.fromString(form.single("plan_id"));
 					final int delay = Integer.parseInt(form.single("delay"));		
 							
 					Plan plan = membership.plans().get(planId);

--- a/src/main/java/com/supervisor/takes/TkPricingSubscriptionDelayEdit.java
+++ b/src/main/java/com/supervisor/takes/TkPricingSubscriptionDelayEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -36,7 +38,7 @@ public final class TkPricingSubscriptionDelayEdit extends TkForm {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		Long planId = Long.parseLong(new RqHref.Smart(req).single("plan"));
+		UUID planId = UUID.fromString(new RqHref.Smart(req).single("plan"));
 		Plan plan = module.membership().plans().get(planId);
 		XeSource xePlan = new XePlan(plan);
 		
@@ -58,12 +60,12 @@ public final class TkPricingSubscriptionDelayEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		return XeSource.EMPTY;
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeDirectives(dir);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkProfileAccessAdd.java
+++ b/src/main/java/com/supervisor/takes/TkProfileAccessAdd.java
@@ -14,6 +14,7 @@ import org.takes.rq.form.RqFormSmart;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkProfileAccessAdd extends TkBaseWrap {
@@ -24,7 +25,7 @@ public final class TkProfileAccessAdd extends TkBaseWrap {
 				req -> {
 					new RqAdminAuth(base, req);
 					
-					final Long profileId = Long.parseLong(new RqHref.Smart(req).single("profile"));
+					final UUID profileId = UUID.fromString(new RqHref.Smart(req).single("profile"));
 					final Profile profile = new PxAllProfiles(base).get(profileId);
 					
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));			
@@ -36,7 +37,7 @@ public final class TkProfileAccessAdd extends TkBaseWrap {
 						if(!isChecked)
 							continue;
 						
-						Long accessId = getRowLongValueAt("access_id", form, i);
+						UUID accessId = UUID.fromString(getRowValueAt("access_id", form, i));
 						Access access = profile.exceptedAccesses().get(accessId);
 						
 						profile.accesses().add(access);

--- a/src/main/java/com/supervisor/takes/TkProfileAccessDelete.java
+++ b/src/main/java/com/supervisor/takes/TkProfileAccessDelete.java
@@ -9,6 +9,7 @@ import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqHref;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkProfileAccessDelete extends TkBaseWrap {
@@ -20,10 +21,10 @@ public final class TkProfileAccessDelete extends TkBaseWrap {
 					
 					new RqAdminAuth(base, req);
 										
-					final Long profileId = Long.parseLong(new RqHref.Smart(req).single("profile"));
+					final UUID profileId = UUID.fromString(new RqHref.Smart(req).single("profile"));
 					final Profile profile = new PxAllProfiles(base).get(profileId);
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 
 					ProfileAccess item = profile.accesses().get(id);
 					String name = item.name();

--- a/src/main/java/com/supervisor/takes/TkProfileAccessEdit.java
+++ b/src/main/java/com/supervisor/takes/TkProfileAccessEdit.java
@@ -3,6 +3,7 @@ package com.supervisor.takes;
 import com.supervisor.domain.Profile;
 import com.supervisor.domain.ProfileAccess;
 import com.supervisor.domain.impl.PxAllProfiles;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XeProfileAccess;
 import com.supervisor.xe.XeProfileAccessParam;
 import com.supervisor.sdk.datasource.Base;
@@ -17,6 +18,7 @@ import org.xembly.Directive;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public final class TkProfileAccessEdit extends TkForm {
 
@@ -41,11 +43,11 @@ public final class TkProfileAccessEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(Long id, Request req) throws IOException {
+	protected XeSource preItemDataToShow(OptUUID id, Request req) throws IOException {
 
-		final Long profileId = Long.parseLong(new RqHref.Smart(req).single("profile"));
+		final UUID profileId = UUID.fromString(new RqHref.Smart(req).single("profile"));
 		final Profile profile = new PxAllProfiles(base).get(profileId);
-		final ProfileAccess item = profile.accesses().get(id);
+		final ProfileAccess item = profile.accesses().get(id.value());
 		
 		return new XeChain(
 				new XeProfileAccess("item", item), 
@@ -54,7 +56,7 @@ public final class TkProfileAccessEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return preItemDataToShow(id, req);
 	}
 }

--- a/src/main/java/com/supervisor/takes/TkProfileAccessNotAdded.java
+++ b/src/main/java/com/supervisor/takes/TkProfileAccessNotAdded.java
@@ -2,6 +2,7 @@ package com.supervisor.takes;
 
 import com.supervisor.domain.Profile;
 import com.supervisor.domain.impl.PxAllProfiles;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XeAccess;
 import com.supervisor.xe.XeProfile;
 import com.supervisor.sdk.datasource.Base;
@@ -16,6 +17,7 @@ import org.xembly.Directive;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public final class TkProfileAccessNotAdded extends TkForm {
 
@@ -42,7 +44,7 @@ public final class TkProfileAccessNotAdded extends TkForm {
 	@Override
 	protected XeSource newItemToShow(Request req) throws IOException {
 
-		Long profileId = Long.parseLong(new RqHref.Smart(req).single("profile"));
+		UUID profileId = UUID.fromString(new RqHref.Smart(req).single("profile"));
 		final Profile item = new PxAllProfiles(base).get(profileId);
 		
 		return new XeChain(
@@ -52,12 +54,12 @@ public final class TkProfileAccessNotAdded extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(Long id, Request req) throws IOException {
+	protected XeSource preItemDataToShow(OptUUID id, Request req) throws IOException {
 		return XeSource.EMPTY;
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return preItemDataToShow(id, req);
 	}
 }

--- a/src/main/java/com/supervisor/takes/TkProfileAccessSave.java
+++ b/src/main/java/com/supervisor/takes/TkProfileAccessSave.java
@@ -15,6 +15,7 @@ import org.takes.rq.form.RqFormSmart;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkProfileAccessSave extends TkBaseWrap {
@@ -25,10 +26,10 @@ public final class TkProfileAccessSave extends TkBaseWrap {
 				req -> {
 					new RqAdminAuth(base, req);
 					
-					final Long profileId = Long.parseLong(new RqHref.Smart(req).single("profile"));
+					final UUID profileId = UUID.fromString(new RqHref.Smart(req).single("profile"));
 					final Profile profile = new PxAllProfiles(base).get(profileId);
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 					final ProfileAccess item = profile.accesses().get(id);
 					
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));			
@@ -36,7 +37,7 @@ public final class TkProfileAccessSave extends TkBaseWrap {
 					// sauvegarder les valeurs des paramètres
 					int nbOfParamsToTreat = getValuesOfRow("param_id", form).size();
 					for (int i = 0; i < nbOfParamsToTreat; i++) {
-						Long paramId = getRowLongValueAt("param_id", form, i);
+						UUID paramId = UUID.fromString(getRowValueAt("param_id", form, i));
 						ProfileAccessParam param = item.parameterValues().get(paramId);
 						
 						String paramValue = getRowValueAt("param_value", form, i);

--- a/src/main/java/com/supervisor/takes/TkProfileDelete.java
+++ b/src/main/java/com/supervisor/takes/TkProfileDelete.java
@@ -9,6 +9,7 @@ import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqHref;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkProfileDelete extends TkBaseWrap {
@@ -21,7 +22,7 @@ public final class TkProfileDelete extends TkBaseWrap {
 					new RqAdminAuth(base, req);
 												
 					final AllProfiles profiles = new PxAllProfiles(base);
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 
 					Profile item = profiles.get(id);
 					String name = item.name();

--- a/src/main/java/com/supervisor/takes/TkProfileEdit.java
+++ b/src/main/java/com/supervisor/takes/TkProfileEdit.java
@@ -4,6 +4,7 @@ import com.supervisor.domain.Profile;
 import com.supervisor.domain.Profiles;
 import com.supervisor.domain.impl.PxAllProfiles;
 import com.supervisor.domain.impl.PxProfiles;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XeModule;
 import com.supervisor.xe.XeProfile;
 import com.supervisor.xe.XeProfileAccess;
@@ -48,9 +49,9 @@ public final class TkProfileEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(Long id, Request req) throws IOException {
+	protected XeSource preItemDataToShow(OptUUID id, Request req) throws IOException {
 		
-		final Profile item = new PxAllProfiles(base).get(id);
+		final Profile item = new PxAllProfiles(base).get(id.value());
 		final Profiles profiles = new PxProfiles(base);
 		return new XeChain(
 				new XeProfile("item", item), 
@@ -60,7 +61,7 @@ public final class TkProfileEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return preItemDataToShow(id, req);
 	}
 }

--- a/src/main/java/com/supervisor/takes/TkProfileSave.java
+++ b/src/main/java/com/supervisor/takes/TkProfileSave.java
@@ -5,8 +5,10 @@ import com.supervisor.domain.Profiles;
 import com.supervisor.domain.impl.PxProfiles;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
+import org.takes.misc.Opt;
 import org.takes.rq.RqGreedy;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -21,7 +23,7 @@ public final class TkProfileSave extends TkBaseWrap {
 				req -> {
 					new RqAdminAuth(base, req);
 					
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
+					final OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
 					
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));			
 					final String name = form.single("name");
@@ -30,14 +32,14 @@ public final class TkProfileSave extends TkBaseWrap {
 					
 					final Profile item;
 					
-					if(id > 0) {
-						item = profiles.get(id);	
+					if(id.isPresent()) {
+						item = profiles.get(id.value());
 						item.update(item.code(), name);
 						
 						Profile parent = Profile.EMPTY;
-						final Long parentId = Long.parseLong(form.single("parent_id"));
-						if(parentId > 0)
-							parent = profiles.get(parentId);
+						final OptUUID parentId = new OptUUID(form.single("parent_id"));
+						if(parentId.isPresent())
+							parent = profiles.get(parentId.value());
 						
 						item.changeParent(parent);
 						

--- a/src/main/java/com/supervisor/takes/TkPurchaseOrderCancel.java
+++ b/src/main/java/com/supervisor/takes/TkPurchaseOrderCancel.java
@@ -10,6 +10,7 @@ import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqHref;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkPurchaseOrderCancel extends TkBaseWrap {
@@ -21,7 +22,7 @@ public final class TkPurchaseOrderCancel extends TkBaseWrap {
 					
 					final Membership module = new DmMembership(base, req);			
 					final PurchaseOrders orders = module.purchaseOrders();
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 
 					PurchaseOrder item = orders.get(id);
 					item.cancel();

--- a/src/main/java/com/supervisor/takes/TkPurchaseOrderEdit.java
+++ b/src/main/java/com/supervisor/takes/TkPurchaseOrderEdit.java
@@ -3,6 +3,7 @@ package com.supervisor.takes;
 import com.supervisor.billing.PurchaseOrder;
 import com.supervisor.domain.Membership;
 import com.supervisor.domain.impl.DmMembership;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XeMembership;
 import com.supervisor.xe.XeOrderLine;
 import com.supervisor.xe.XeOrderTax;
@@ -49,11 +50,11 @@ public final class TkPurchaseOrderEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Membership module = new DmMembership(base, req);
 		
-		PurchaseOrder item = module.purchaseOrders().get(id);
+		PurchaseOrder item = module.purchaseOrders().get(id.value());
 		return new XeChain(
 				new XePurchaseOrder("item", item),
 				new XeOrderLine(item.lines()),
@@ -62,7 +63,7 @@ public final class TkPurchaseOrderEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeDirectives(dir);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkRegister.java
+++ b/src/main/java/com/supervisor/takes/TkRegister.java
@@ -63,7 +63,7 @@ public final class TkRegister extends TkWrap {
 					.request(name, email, password, confirmedPassword, preferredLanguage);
 				final String baseUri = new BaseUri(req).toString();
 				final String key = new String(
-					Base64.getEncoder().encode(request.guid().toString().getBytes()),
+					Base64.getEncoder().encode(request.id().toString().getBytes()),
 					StandardCharsets.UTF_8
 				);
 				final String link = String.format("%s/register/confirm?key=%s", baseUri, key);

--- a/src/main/java/com/supervisor/takes/TkSharing.java
+++ b/src/main/java/com/supervisor/takes/TkSharing.java
@@ -19,6 +19,8 @@ import com.supervisor.xe.XeResource;
 import com.supervisor.xe.XeSharedResource;
 import com.supervisor.xe.XeSupervisor;
 
+import java.util.UUID;
+
 public final class TkSharing extends TkBaseWrap {
 
 	public TkSharing(final Base base) {
@@ -31,7 +33,7 @@ public final class TkSharing extends TkBaseWrap {
 					Smart params = new RqHref.Smart(req);
 					
 					ResourceType type = ResourceType.valueOf(params.single("type"));
-					Long resourceId = Long.parseLong(params.single("resource"));					
+					UUID resourceId = UUID.fromString(params.single("resource"));
 					Resource resource = module.resources().resource(type, resourceId);
 					
 					if(new RqUser(base, req).notOwn(resource)) {

--- a/src/main/java/com/supervisor/takes/TkSharingDelete.java
+++ b/src/main/java/com/supervisor/takes/TkSharingDelete.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -23,12 +24,12 @@ public final class TkSharingDelete extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					Smart params = new RqHref.Smart(req);
 					
-					Long id = Long.parseLong(params.single("id"));
+					UUID id = UUID.fromString(params.single("id"));
 									
 					SharedResource resource = module.sharing().get(id);
 					String name = resource.subscriber().name();
 					ResourceType type = resource.type();
-					Long resourceId = resource.resourceId();					
+					UUID resourceId = resource.resourceId();
 					
 					module.sharing().remove(resource);
 								

--- a/src/main/java/com/supervisor/takes/TkSharingEdit.java
+++ b/src/main/java/com/supervisor/takes/TkSharingEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.collections.IteratorUtils;
 import org.takes.Request;
 import org.takes.rq.RqHref;
@@ -40,7 +42,7 @@ public final class TkSharingEdit extends TkForm {
 		Smart params = new RqHref.Smart(req);
 		
 		ResourceType type = ResourceType.valueOf(params.single("type"));
-		Long resourceId = Long.parseLong(params.single("resource"));
+		UUID resourceId = UUID.fromString(params.single("resource"));
 		Resource resource = module.resources().resource(type, resourceId);
 		
 		if(new RqUser(base, req).notOwn(resource)) {
@@ -59,13 +61,13 @@ public final class TkSharingEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		return XeSource.EMPTY;
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeSubscriber((List<String>)IteratorUtils.toList(form.param("item_email").iterator()));
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkSharingSave.java
+++ b/src/main/java/com/supervisor/takes/TkSharingSave.java
@@ -2,6 +2,7 @@ package com.supervisor.takes;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -32,7 +33,7 @@ public final class TkSharingSave extends TkBaseWrap {
 					Smart params = new RqHref.Smart(req);
 					
 					ResourceType type = ResourceType.valueOf(params.single("type"));
-					Long resourceId = Long.parseLong(params.single("resource"));		
+					UUID resourceId = UUID.fromString(params.single("resource"));
 					Resource resource = module.resources().resource(type, resourceId);
 					
 					if(new RqUser(base, req).notOwn(resource)) {

--- a/src/main/java/com/supervisor/takes/TkSimpleDataFieldEdit.java
+++ b/src/main/java/com/supervisor/takes/TkSimpleDataFieldEdit.java
@@ -3,10 +3,13 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
+import org.takes.misc.Opt;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
 import org.takes.rs.xe.XeAppend;
@@ -39,9 +42,9 @@ public final class TkSimpleDataFieldEdit extends TkForm {
 	@Override
 	protected Iterable<XeSource> contentToShow(final Request req, final XeSource itemToShow) throws IOException {
 		
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single(MODEL));
-		Long tableModelId = Long.parseLong(new RqHref.Smart(req).single("table_model", "0"));
-		Long tableId = Long.parseLong(new RqHref.Smart(req).single("table", "0"));
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single(MODEL));
+		OptUUID tableModelId = new OptUUID(new RqHref.Smart(req).single("table_model", "0"));
+		OptUUID tableId = new OptUUID(new RqHref.Smart(req).single("table", "0"));
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		DataSheetModel model = module.dataSheetModels().get(modelId);
@@ -51,9 +54,9 @@ public final class TkSimpleDataFieldEdit extends TkForm {
 		content.add(new XeDataFieldType());
 		content.add(new XeDataSheetModel(MODEL, model));
 		
-		if(tableId > 0) {
-			final DataSheetModel tableModel = module.dataSheetModels().get(tableModelId);
-			content.add(new XeDataField("table", tableModel.fields().get(tableId)));
+		if(tableId.isPresent()) {
+			final DataSheetModel tableModel = module.dataSheetModels().get(tableModelId.value());
+			content.add(new XeDataField("table", tableModel.fields().get(tableId.value())));
 			content.add(new XeAppend("table_model_id", tableModelId.toString()));
 		}	
 		
@@ -64,16 +67,16 @@ public final class TkSimpleDataFieldEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single(MODEL));
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single(MODEL));
 		final Supervisor module = new PxSupervisor(base, req);
 		DataSheetModel model = module.dataSheetModels().get(modelId);
-		SimpleDataField item = model.fields().simples().get(id);
+		SimpleDataField item = model.fields().simples().get(id.value());
 		return new XeSimpleDataField("item", item);
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeSimpleDataField(dir);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkTaxEdit.java
+++ b/src/main/java/com/supervisor/takes/TkTaxEdit.java
@@ -3,10 +3,12 @@ package com.supervisor.takes;
 import com.supervisor.billing.Tax;
 import com.supervisor.domain.Membership;
 import com.supervisor.domain.impl.DmMembership;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XeTax;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
 import org.takes.Request;
+import org.takes.misc.Opt;
 import org.takes.rq.form.RqFormSmart;
 import org.takes.rs.xe.XeChain;
 import org.takes.rs.xe.XeSource;
@@ -40,9 +42,9 @@ public final class TkTaxEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		final Membership module = new DmMembership(base, req);
-		final Tax tax = module.taxes().get(id);
+		final Tax tax = module.taxes().get(id.value());
 		
 		XeSource xeTax = new XeTax("item", tax);		
 		return new XeChain(
@@ -51,7 +53,7 @@ public final class TkTaxEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeTax(dir);
 	}
 }

--- a/src/main/java/com/supervisor/takes/TkTaxSave.java
+++ b/src/main/java/com/supervisor/takes/TkTaxSave.java
@@ -12,6 +12,7 @@ import org.takes.rq.RqGreedy;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkTaxSave extends TkBaseWrap {
@@ -25,7 +26,7 @@ public final class TkTaxSave extends TkBaseWrap {
 					final Membership module = new DmMembership(base, req);
 					final Taxes taxes = module.taxes();
 					
-					Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 					
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
 					

--- a/src/main/java/com/supervisor/takes/TkUserActivate.java
+++ b/src/main/java/com/supervisor/takes/TkUserActivate.java
@@ -10,6 +10,7 @@ import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqHref;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkUserActivate extends TkBaseWrap {
@@ -23,7 +24,7 @@ public final class TkUserActivate extends TkBaseWrap {
 					
 					final Membership module = new DmMembership(base, req);			
 					final Users users = module.users();
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 					final Boolean active = Boolean.parseBoolean(new RqHref.Smart(req).single("active"));
 					
 					User item = users.get(id);

--- a/src/main/java/com/supervisor/takes/TkUserDelete.java
+++ b/src/main/java/com/supervisor/takes/TkUserDelete.java
@@ -10,6 +10,7 @@ import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
 import org.takes.rq.RqHref;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkUserDelete extends TkBaseWrap {
@@ -23,7 +24,7 @@ public final class TkUserDelete extends TkBaseWrap {
 					
 					final Membership module = new DmMembership(base, req);			
 					final Users users = module.users();
-					final Long id = Long.parseLong(new RqHref.Smart(req).single("id"));
+					final UUID id = UUID.fromString(new RqHref.Smart(req).single("id"));
 
 					User item = users.get(id);
 					String name = item.name();

--- a/src/main/java/com/supervisor/takes/TkUserEdit.java
+++ b/src/main/java/com/supervisor/takes/TkUserEdit.java
@@ -5,6 +5,7 @@ import com.supervisor.domain.Membership;
 import com.supervisor.domain.User;
 import com.supervisor.domain.impl.DmMembership;
 import com.supervisor.domain.impl.PxAllProfiles;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XeCountry;
 import com.supervisor.xe.XeCurrency;
 import com.supervisor.xe.XeLanguage;
@@ -67,15 +68,15 @@ public final class TkUserEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		final Membership module = new DmMembership(base, req);
-		final User user = module.users().get(id);
+		final User user = module.users().get(id.value());
 		
 		return new XeUserProfile("item", user);
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeUser(dir);
 	}
 }

--- a/src/main/java/com/supervisor/takes/TkUserProfileEdit.java
+++ b/src/main/java/com/supervisor/takes/TkUserProfileEdit.java
@@ -4,6 +4,7 @@ import com.supervisor.domain.Currency;
 import com.supervisor.domain.Membership;
 import com.supervisor.domain.User;
 import com.supervisor.domain.impl.DmMembership;
+import com.supervisor.sdk.utils.OptUUID;
 import com.supervisor.xe.XeCountry;
 import com.supervisor.xe.XeCurrency;
 import com.supervisor.xe.XeLanguage;
@@ -68,12 +69,12 @@ public final class TkUserProfileEdit extends TkForm {
 	}
 	
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		return XeSource.EMPTY;
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		return new XeUserProfile(dir);
 	}	
 }

--- a/src/main/java/com/supervisor/takes/TkUserProfileSave.java
+++ b/src/main/java/com/supervisor/takes/TkUserProfileSave.java
@@ -17,6 +17,7 @@ import org.takes.rq.RqGreedy;
 import org.takes.rq.form.RqFormSmart;
 
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkUserProfileSave extends TkBaseWrap {
@@ -33,9 +34,9 @@ public final class TkUserProfileSave extends TkBaseWrap {
 					final String photo = form.single("photo");
 					final TimeZone timeZone = TimeZone.getTimeZone(form.single("time_zone_id"));
 					final String email = user.address().email();
-					final Language preferredLanguage = module.languages().get(Long.parseLong(form.single("preferred_language_id")));
-					final Currency preferredCurrency = module.currencies().get(Long.parseLong(form.single("preferred_currency_id")));
-					final Country country = module.countries().get(Long.parseLong(form.single("country_id")));		
+					final Language preferredLanguage = module.languages().get(UUID.fromString(form.single("preferred_language_id")));
+					final Currency preferredCurrency = module.currencies().get(UUID.fromString(form.single("preferred_currency_id")));
+					final Country country = module.countries().get(UUID.fromString(form.single("country_id")));
 					final String addressLine1 = form.single("address_line1");
 					final String addressLine2 = form.single("address_line2", StringUtils.EMPTY);
 					final String phone1 = form.single("phone1");

--- a/src/main/java/com/supervisor/takes/TkUserSave.java
+++ b/src/main/java/com/supervisor/takes/TkUserSave.java
@@ -10,6 +10,7 @@ import com.supervisor.domain.User;
 import com.supervisor.domain.impl.DmMembership;
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkBaseWrap;
+import com.supervisor.sdk.utils.OptUUID;
 import org.apache.commons.lang.StringUtils;
 import org.takes.facets.flash.RsFlash;
 import org.takes.facets.forward.RsForward;
@@ -18,6 +19,7 @@ import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
 
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.logging.Level;
 
 public final class TkUserSave extends TkBaseWrap {
@@ -29,7 +31,7 @@ public final class TkUserSave extends TkBaseWrap {
 					new RqAdminAuth(base, req);
 					
 					final Membership module = new DmMembership(base, req);
-					Long id = Long.parseLong(new RqHref.Smart(req).single("id", "0"));
+					OptUUID id = new OptUUID(new RqHref.Smart(req).single("id", "0"));
 					
 					final RqFormSmart form = new RqFormSmart(new RqGreedy(req));
 					
@@ -38,9 +40,9 @@ public final class TkUserSave extends TkBaseWrap {
 					final String email = form.single("email");
 					final Boolean isCompany = Boolean.parseBoolean(form.single("is_company"));
 					final TimeZone timeZone = TimeZone.getTimeZone(form.single("time_zone_id"));
-					final Language preferredLanguage = module.languages().get(Long.parseLong(form.single("preferred_language_id")));
-					final Currency preferredCurrency = module.currencies().get(Long.parseLong(form.single("preferred_currency_id")));
-					final Country country = module.countries().get(Long.parseLong(form.single("country_id")));		
+					final Language preferredLanguage = module.languages().get(UUID.fromString(form.single("preferred_language_id")));
+					final Currency preferredCurrency = module.currencies().get(UUID.fromString(form.single("preferred_currency_id")));
+					final Country country = module.countries().get(UUID.fromString(form.single("country_id")));
 					final String addressLine1 = form.single("address_line1");
 					final String addressLine2 = form.single("address_line2", StringUtils.EMPTY);
 					final String phone1 = form.single("phone1");
@@ -53,8 +55,8 @@ public final class TkUserSave extends TkBaseWrap {
 					final String msg;
 					final String ADMIN = "admin";
 					
-					if(id > 0) {	
-						item = module.users().get(id);
+					if(id.isPresent()) {
+						item = module.users().get(id.value());
 						
 						msg = String.format("L'utilisateur %s a été modifié avec succès !", item.name());
 					} else {

--- a/src/main/java/com/supervisor/takes/TkWhenCaseComparatorEdit.java
+++ b/src/main/java/com/supervisor/takes/TkWhenCaseComparatorEdit.java
@@ -3,9 +3,11 @@ package com.supervisor.takes;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.supervisor.sdk.datasource.Base;
 import com.supervisor.sdk.takes.TkForm;
+import com.supervisor.sdk.utils.OptUUID;
 import org.takes.Request;
 import org.takes.rq.RqHref;
 import org.takes.rq.form.RqFormSmart;
@@ -45,11 +47,11 @@ public final class TkWhenCaseComparatorEdit extends TkForm {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model")); 
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		AggregatedModel model = module.aggregatedModels()
 									 .get(modelId);
 		
-		Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		FormularDataField formular = model.formulars().get(formularId);
 		
 		List<XeSource> content = new ArrayList<>();
@@ -65,20 +67,20 @@ public final class TkWhenCaseComparatorEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource preItemDataToShow(final Long id, final Request req) throws IOException {
+	protected XeSource preItemDataToShow(final OptUUID id, final Request req) throws IOException {
 		
 		final Supervisor module = new PxSupervisor(base, req);
 		
-		Long modelId = Long.parseLong(new RqHref.Smart(req).single("model"));
+		UUID modelId = UUID.fromString(new RqHref.Smart(req).single("model"));
 		AggregatedModel model = module.aggregatedModels().get(modelId); 
 		
-		Long formularId = Long.parseLong(new RqHref.Smart(req).single("formular"));
+		UUID formularId = UUID.fromString(new RqHref.Smart(req).single("formular"));
 		FormularDataField formular = model.formulars().get(formularId);
 		
-		Long expressionId = Long.parseLong(new RqHref.Smart(req).single("expression"));
+		UUID expressionId = UUID.fromString(new RqHref.Smart(req).single("expression"));
 		FormularCaseExpression expression = (FormularCaseExpression)formular.expressions().get(expressionId);
 
-		WhenCase item = expression.cases().get(id);
+		WhenCase item = expression.cases().get(id.value());
 		
 		return new XeChain(
 				new XeWhenCase("item", item)
@@ -86,9 +88,9 @@ public final class TkWhenCaseComparatorEdit extends TkForm {
 	}
 
 	@Override
-	protected XeSource postItemDataToShow(Long id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
+	protected XeSource postItemDataToShow(OptUUID id, Request req, RqFormSmart form, final Iterable<Directive> dir) throws IOException {
 		
-		if(id == 0)
+		if(id.isEmpty())
 			return newItemToShow(req);
 		else
 			return preItemDataToShow(id, req);

--- a/src/main/java/com/supervisor/takes/TkWhenCaseComparatorSave.java
+++ b/src/main/java/com/supervisor/takes/TkWhenCaseComparatorSave.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -28,16 +29,16 @@ public final class TkWhenCaseComparatorSave extends TkBaseWrap {
 					
 					final Comparator comparator = Comparator.valueOf(form.single("comparator_id"));
 					
-					final Long modelId = Long.parseLong(form.single("model_id"));
+					final UUID modelId = UUID.fromString(form.single("model_id"));
 					AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(form.single("formular_id"));
+					final UUID formularId = UUID.fromString(form.single("formular_id"));
 					FormularDataField formular = model.formulars().get(formularId); 
 					
-					Long expressionId = Long.parseLong(form.single("expression_id"));
+					UUID expressionId = UUID.fromString(form.single("expression_id"));
 					FormularCaseExpression expression = (FormularCaseExpression)formular.expressions().get(expressionId);
 					
-					final Long id = Long.parseLong(form.single("id"));
+					final UUID id = UUID.fromString(form.single("id"));
 					final WhenCase itemSaved = expression.cases().get(id);
 					itemSaved.updateComparator(comparator);
 					

--- a/src/main/java/com/supervisor/takes/TkWhenCaseDelete.java
+++ b/src/main/java/com/supervisor/takes/TkWhenCaseDelete.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -26,16 +27,16 @@ public final class TkWhenCaseDelete extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 
 					final Smart href = new RqHref.Smart(req);
-					final Long modelId = Long.parseLong(href.single("model"));
+					final UUID modelId = UUID.fromString(href.single("model"));
 					AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(href.single("formular"));
+					final UUID formularId = UUID.fromString(href.single("formular"));
 					FormularDataField formular = model.formulars().get(formularId);
 					
-					final Long expressionId = Long.parseLong(href.single("expression"));
+					final UUID expressionId = UUID.fromString(href.single("expression"));
 					FormularCaseExpression expression = (FormularCaseExpression)formular.expressions().get(expressionId);
 					
-					final Long id = Long.parseLong(href.single("id"));		
+					final UUID id = UUID.fromString(href.single("id"));
 					final WhenCase item = expression.cases().get(id);
 					expression.cases().remove(item);
 					

--- a/src/main/java/com/supervisor/takes/TkWhenCaseSave.java
+++ b/src/main/java/com/supervisor/takes/TkWhenCaseSave.java
@@ -1,5 +1,6 @@
 package com.supervisor.takes;
 
+import java.util.UUID;
 import java.util.logging.Level;
 
 import com.supervisor.sdk.datasource.Base;
@@ -25,13 +26,13 @@ public final class TkWhenCaseSave extends TkBaseWrap {
 					final Supervisor module = new PxSupervisor(base, req);
 					final Smart href = new RqHref.Smart(new RqGreedy(req));		
 					
-					final Long modelId = Long.parseLong(href.single("model"));
+					final UUID modelId = UUID.fromString(href.single("model"));
 					AggregatedModel model = module.aggregatedModels().get(modelId); 
 					
-					final Long formularId = Long.parseLong(href.single("formular"));
+					final UUID formularId = UUID.fromString(href.single("formular"));
 					FormularDataField formular = model.formulars().get(formularId); 
 					
-					final Long expressionId = Long.parseLong(href.single("expression"));
+					final UUID expressionId = UUID.fromString(href.single("expression"));
 					final FormularCaseExpression expression = (FormularCaseExpression)formular.expressions().get(expressionId);
 					
 					expression.cases().add();

--- a/src/main/java/com/supervisor/xe/XeActivityTemplatePublishedJson.java
+++ b/src/main/java/com/supervisor/xe/XeActivityTemplatePublishedJson.java
@@ -39,10 +39,10 @@ public final class XeActivityTemplatePublishedJson implements RsJson.Source {
 			final User user = new UserOf(item);
 			
 			builder.add(Json.createObjectBuilder()
-							.add("id", item.id())
+							.add("id", item.id().toString())
 			                .add("name", item.name())
 			                .add("profile", item.profile().name())
-			                .add("profile_id", item.profile().id())
+			                .add("profile_id", item.profile().id().toString())
 			                .add("description", item.description())
 			                .add("icon", item.icon())
 			                .add("version", item.version())
@@ -55,7 +55,7 @@ public final class XeActivityTemplatePublishedJson implements RsJson.Source {
 			                .add("availability", item.availability().toString())
 			                .add("availabilityId", item.availability().name())     
 			                .add("designer", item.designer().name())
-			                .add("designerId", item.designer().id())
+			                .add("designerId", item.designer().id().toString())
 			                .add("designerPhoto", item.designer().photo())
 			                .add("fromNow", user.prettyTimeOf(item.creationDate()).toString())
 	               );

--- a/src/main/java/com/supervisor/xe/XeChartCamembert.java
+++ b/src/main/java/com/supervisor/xe/XeChartCamembert.java
@@ -21,11 +21,11 @@ public final class XeChartCamembert implements RsJson.Source {
 	@Override
 	public JsonStructure toJson() throws IOException {
 		return Json.createObjectBuilder()
-				.add("id", origin.id())
+				.add("id", origin.id().toString())
                 .add("code", origin.code())
                 .add("name", origin.name())
                 .add("type", origin.type().name())
-                .add("type_id", origin.type().id())
+                .add("type_id", origin.type().id().toString())
                 .add("short_name", origin.type().shortName())
                 .add("description", origin.description())
                 .add("label", origin.label())
@@ -35,7 +35,7 @@ public final class XeChartCamembert implements RsJson.Source {
                 .add("values", Json.createArrayBuilder(origin.values()))
 				.add("camembert_type", origin.camembertType().toString())
 				.add("camembert_type_id", origin.camembertType().name().toLowerCase())
-				.add("activity_id", origin.activity().id())
+				.add("activity_id", origin.activity().id().toString())
                 .add("activity", origin.activity().name())
                 .add("sizeX", origin.sizeX())
                 .add("sizeY", origin.sizeY())

--- a/src/main/java/com/supervisor/xe/XeDynamicTable2Col.java
+++ b/src/main/java/com/supervisor/xe/XeDynamicTable2Col.java
@@ -20,11 +20,11 @@ public final class XeDynamicTable2Col implements RsJson.Source {
 	@Override
 	public JsonStructure toJson() throws IOException {
 		return Json.createObjectBuilder()
-				.add("id", origin.id())
+				.add("id", origin.id().toString())
                 .add("code", origin.code())
                 .add("name", origin.name())
                 .add("type", origin.type().name())
-                .add("type_id", origin.type().id())
+                .add("type_id", origin.type().id().toString())
                 .add("short_name", origin.type().shortName())
                 .add("description", origin.description())
                 .add("label", origin.label())                
@@ -35,7 +35,7 @@ public final class XeDynamicTable2Col implements RsJson.Source {
                 .add("manageEvolutionPercent", origin.manageEvolutionPercent())
 				.add("unitySymbol", origin.unitySymbol())
 				.add("symbolPosition", origin.symbolPosition().name())
-				.add("activity_id", origin.activity().id())
+				.add("activity_id", origin.activity().id().toString())
                 .add("activity", origin.activity().name())
                 .add("sizeX", origin.sizeX())
                 .add("sizeY", origin.sizeY())

--- a/src/main/java/com/supervisor/xe/XeGauge.java
+++ b/src/main/java/com/supervisor/xe/XeGauge.java
@@ -24,11 +24,11 @@ public final class XeGauge implements RsJson.Source {
 	@Override
 	public JsonStructure toJson() throws IOException {
 		return Json.createObjectBuilder()
-				.add("id", origin.id())
+				.add("id", origin.id().toString())
                 .add("code", origin.code())
                 .add("name", origin.name())
                 .add("type", origin.type().name())
-                .add("type_id", origin.type().id())
+                .add("type_id", origin.type().id().toString())
                 .add("short_name", origin.type().shortName())
                 .add("description", origin.description())
                 .add("label", origin.label())
@@ -42,7 +42,7 @@ public final class XeGauge implements RsJson.Source {
 				.add("min", origin.min())
 				.add("max", origin.max())
 				.add("minorTicks", origin.minorTicks())		
-				.add("activity_id", origin.activity().id())
+				.add("activity_id", origin.activity().id().toString())
                 .add("activity", origin.activity().name())
                 .add("sizeX", origin.sizeX())
                 .add("sizeY", origin.sizeY())

--- a/src/main/java/com/supervisor/xe/XeGoalNumber.java
+++ b/src/main/java/com/supervisor/xe/XeGoalNumber.java
@@ -20,7 +20,7 @@ public final class XeGoalNumber implements RsJson.Source {
 	@Override
 	public JsonStructure toJson() throws IOException {
 		return Json.createObjectBuilder()
-				.add("id", origin.id())
+				.add("id", origin.id().toString())
                 .add("code", origin.code())
                 .add("name", origin.name())
                 .add("type", origin.type().toString())
@@ -36,7 +36,7 @@ public final class XeGoalNumber implements RsJson.Source {
 				.add("numberInPercent", origin.numberInPercent())
 				.add("unitySymbol", origin.unitySymbol())
 				.add("symbolPosition", origin.symbolPosition().name())
-				.add("activity_id", origin.activity().id())
+				.add("activity_id", origin.activity().id().toString())
                 .add("activity", origin.activity().name())
                 .add("sizeX", origin.sizeX())
                 .add("sizeY", origin.sizeY())

--- a/src/main/java/com/supervisor/xe/XeNumberOriented.java
+++ b/src/main/java/com/supervisor/xe/XeNumberOriented.java
@@ -20,7 +20,7 @@ public final class XeNumberOriented implements RsJson.Source {
 	@Override
 	public JsonStructure toJson() throws IOException {
 		return Json.createObjectBuilder()
-				.add("id", origin.id())
+				.add("id", origin.id().toString())
                 .add("code", origin.code())
                 .add("name", origin.name())
                 .add("type", origin.type().toString())
@@ -34,7 +34,7 @@ public final class XeNumberOriented implements RsJson.Source {
 				.add("manageEvolutionPercent", origin.manageEvolutionPercent())
 				.add("unitySymbol", origin.unitySymbol())
 				.add("symbolPosition", origin.symbolPosition().name())
-				.add("activity_id", origin.activity().id())
+				.add("activity_id", origin.activity().id().toString())
                 .add("activity", origin.activity().name())
                 .add("sizeX", origin.sizeX())
                 .add("sizeY", origin.sizeY())

--- a/src/main/java/com/supervisor/xe/XeRuleFormular.java
+++ b/src/main/java/com/supervisor/xe/XeRuleFormular.java
@@ -3,6 +3,7 @@ package com.supervisor.xe;
 import java.io.IOException;
 import java.util.List;
 
+import com.supervisor.sdk.utils.OptUUID;
 import org.cactoos.iterable.Joined;
 import org.cactoos.iterable.Mapped;
 import org.takes.rs.xe.XeSource;
@@ -86,7 +87,7 @@ public final class XeRuleFormular extends XeWrap {
 	                    .add("param_id", condition.param().id())
 	                    .add("param_code", condition.param().code())
 	                    .add("comparator_id", condition.comparator().name())
-	                    .add("state", condition.id() == 0 ? "removed" : "added")
+	                    .add("state", condition.id() == null ? "removed" : "added")
 	                    .add("value", condition.value())
 	                    .add("default_value", condition.defaultValue())         
                 )                

--- a/src/main/resources/liquibase/2022/001-initial-schema.xml
+++ b/src/main/resources/liquibase/2022/001-initial-schema.xml
@@ -18,9 +18,18 @@ SOFTWARE.
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd" logicalFilePath="001-initial-schema.xml">
   <changeSet id="001" author="baudoliver7">
     <sql>
+      CREATE TABLE public.recordable (
+        creation_date timestamp without time zone NOT NULL,
+        creator_id uuid NOT NULL,
+        last_modification_date timestamp without time zone NOT NULL,
+        last_modifier_id uuid NOT NULL,
+        owner_id uuid NOT NULL,
+        tag character varying
+      );
+    </sql>
+    <sql>
       CREATE TABLE public.base_address (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         address_line1 character varying,
         address_line2 character varying,
         company character varying,
@@ -29,787 +38,347 @@ SOFTWARE.
         phone2 character varying,
         state_or_province character varying,
         city character varying,
-        country_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.base_address_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.base_address_id_seq OWNED BY public.base_address.id;
+        country_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.base_country (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         phone_code integer NOT NULL,
         code character varying NOT NULL,
         name character varying NOT NULL,
-        currency_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.base_country_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.base_country_id_seq OWNED BY public.base_country.id;
+        currency_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.base_currency (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         name character varying NOT NULL,
         after boolean NOT NULL,
         "precision" integer NOT NULL,
         symbol character varying NOT NULL,
-        code character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.base_currency_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.base_currency_id_seq OWNED BY public.base_currency.id;
+        code character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.base_event (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         information character varying NOT NULL,
         details character varying NOT NULL,
         identifier character varying NOT NULL,
-        level character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.base_event_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.base_event_id_seq OWNED BY public.base_event.id;
+        level character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.base_language (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         iso_code character varying NOT NULL,
         code character varying NOT NULL,
         name character varying NOT NULL,
-        enabled boolean NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.base_language_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.base_language_id_seq OWNED BY public.base_language.id;
+        enabled boolean NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.base_person (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         name character varying NOT NULL,
-        preferred_language_id bigint NOT NULL,
-        billing_address_id bigint NOT NULL,
-        preferred_currency_id bigint NOT NULL,
+        preferred_language_id uuid NOT NULL,
+        billing_address_id uuid NOT NULL,
+        preferred_currency_id uuid NOT NULL,
         is_company boolean NOT NULL,
         photo character varying NOT NULL,
         time_zone_id character varying NOT NULL,
-        address_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.base_person_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.base_person_id_seq OWNED BY public.base_person.id;
+        address_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.base_planned_task (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         metadata character varying NOT NULL,
         description character varying NOT NULL,
         status character varying NOT NULL,
         type character varying NOT NULL,
-        start_date timestamp without time zone NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.base_planned_task_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.base_planned_task_id_seq OWNED BY public.base_planned_task.id;
+        start_date timestamp without time zone NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.base_sequence (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         step integer NOT NULL,
         next_number bigint NOT NULL,
         size integer NOT NULL,
         name character varying NOT NULL,
         prefix character varying,
         suffix character varying,
-        code character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.base_sequence_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.base_sequence_id_seq OWNED BY public.base_sequence.id;
+        code character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.billing_address (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        submitted_to_vat boolean NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY,
+        submitted_to_vat boolean NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.billing_invoice (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         due_date date NOT NULL,
-        purchase_order_id bigint NOT NULL,
-        state character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        purchase_order_id uuid NOT NULL,
+        state character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.billing_order (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        customer_address_id bigint NOT NULL,
-        supplier_address_id bigint NOT NULL,
+        id uuid PRIMARY KEY,
+        customer_address_id uuid NOT NULL,
+        supplier_address_id uuid NOT NULL,
         type character varying NOT NULL,
         reference character varying,
         publishing_date date NOT NULL,
-        customer_id bigint NOT NULL,
-        supplier_id bigint NOT NULL,
+        customer_id uuid NOT NULL,
+        supplier_id uuid NOT NULL,
         vat_amount double precision NOT NULL,
         total_amount double precision NOT NULL,
-        base_currency_id bigint NOT NULL,
+        base_currency_id uuid NOT NULL,
         exchange_rate double precision NOT NULL,
-        currency_id bigint NOT NULL,
+        currency_id uuid NOT NULL,
         description character varying,
-        amount double precision NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.billing_order_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.billing_order_id_seq OWNED BY public.billing_order.id;
+        amount double precision NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.billing_order_line (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        product_id bigint NOT NULL,
+        id uuid PRIMARY KEY,
+        product_id uuid NOT NULL,
         description character varying,
-        order_id bigint NOT NULL,
+        order_id uuid NOT NULL,
         unit_price double precision NOT NULL,
         no integer NOT NULL,
         name character varying NOT NULL,
         base_unit_price double precision NOT NULL,
         ht_amount double precision NOT NULL,
-        quantity integer NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.billing_order_line_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.billing_order_line_id_seq OWNED BY public.billing_order_line.id;
+        quantity integer NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.billing_order_tax (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         amount double precision NOT NULL,
         name character varying NOT NULL,
-        order_id bigint NOT NULL,
-        origin_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.billing_order_tax_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.billing_order_tax_id_seq OWNED BY public.billing_order_tax.id;
+        order_id uuid NOT NULL,
+        origin_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.billing_payment_method (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         password character varying,
         online boolean NOT NULL,
         username character varying,
-        default_cashier_id bigint NOT NULL,
+        default_cashier_id uuid NOT NULL,
         logo character varying NOT NULL,
         enabled boolean NOT NULL,
         type character varying NOT NULL,
-        name character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.billing_payment_method_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.billing_payment_method_id_seq OWNED BY public.billing_payment_method.id;
+        name character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.billing_payment_receipt (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         object character varying NOT NULL,
         state character varying NOT NULL,
         reference character varying NOT NULL,
-        order_id bigint NOT NULL,
+        order_id uuid NOT NULL,
         payment_date date NOT NULL,
         description character varying,
-        request_id bigint NOT NULL,
+        request_id uuid NOT NULL,
         metadata character varying NOT NULL,
         amount double precision NOT NULL,
-        method_id bigint NOT NULL,
-        remitter_id bigint NOT NULL,
-        cashier_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.billing_payment_receipt_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.billing_payment_receipt_id_seq OWNED BY public.billing_payment_receipt.id;
+        method_id uuid NOT NULL,
+        remitter_id uuid NOT NULL,
+        cashier_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.billing_payment_request (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         amount double precision NOT NULL,
         metadata character varying NOT NULL,
         reference character varying NOT NULL,
-        order_id bigint NOT NULL,
+        order_id uuid NOT NULL,
         status character varying NOT NULL,
         object character varying NOT NULL,
-        notes character varying,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.billing_payment_request_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.billing_payment_request_id_seq OWNED BY public.billing_payment_request.id;
+        notes character varying
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.billing_product (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         name character varying NOT NULL,
         enabled boolean NOT NULL,
         description character varying,
         price double precision NOT NULL,
         reference character varying NOT NULL,
-        catalog_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        catalog_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.billing_product_catalog (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         name character varying NOT NULL,
-        currency_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.billing_product_catalog_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.billing_product_catalog_id_seq OWNED BY public.billing_product_catalog.id;
-      CREATE SEQUENCE public.billing_product_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.billing_product_id_seq OWNED BY public.billing_product.id;
+        currency_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.billing_purchase_order (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        state character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-    </sql>
-    <sql>
-      CREATE TABLE public.billing_software_engineering_service (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        no integer NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY,
+        state character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.billing_subscription_contract (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        invoice_id bigint,
-        subscriber_id bigint NOT NULL,
+        id uuid PRIMARY KEY,
+        invoice_id uuid,
+        subscriber_id uuid NOT NULL,
         begin_date date NOT NULL,
         end_date date NOT NULL,
-        purchase_order_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.billing_subscription_contract_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.billing_subscription_contract_id_seq OWNED BY public.billing_subscription_contract.id;
+        purchase_order_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.billing_tax (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         short_name character varying NOT NULL,
         value_type character varying NOT NULL,
         type character varying NOT NULL,
         value double precision NOT NULL,
-        name character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.billing_tax_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.billing_tax_id_seq OWNED BY public.billing_tax.id;
+        name character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.membership_access (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         name character varying NOT NULL,
-        code character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.membership_access_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.membership_access_id_seq OWNED BY public.membership_access.id;
+        code character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.membership_access_param (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         name character varying NOT NULL,
-        access_id bigint NOT NULL,
+        access_id uuid NOT NULL,
         message character varying NOT NULL,
         default_value character varying NOT NULL,
         value_type character varying NOT NULL,
         quantifier character varying NOT NULL,
-        code character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.membership_access_param_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.membership_access_param_id_seq OWNED BY public.membership_access_param.id;
+        code character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.membership_plan (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         preferred boolean NOT NULL,
         no integer NOT NULL,
-        profile_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        profile_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.membership_plan_feature (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         description character varying,
         name character varying NOT NULL,
         no integer NOT NULL,
-        plan_id bigint NOT NULL,
+        plan_id uuid NOT NULL,
         enabled boolean NOT NULL,
-        basic boolean NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.membership_plan_feature_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.membership_plan_feature_id_seq OWNED BY public.membership_plan_feature.id;
+        basic boolean NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.membership_plan_subscription_contract (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        plan_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY,
+        plan_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.membership_profile (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         name character varying NOT NULL,
         code character varying NOT NULL,
-        parent_id bigint,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        parent_id uuid
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.membership_profile_access (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        access_inherited_id bigint NOT NULL,
-        profile_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.membership_profile_access_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.membership_profile_access_id_seq OWNED BY public.membership_profile_access.id;
+        id uuid PRIMARY KEY,
+        access_inherited_id uuid NOT NULL,
+        profile_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.membership_profile_access_param (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         value character varying NOT NULL,
-        param_inherited_id bigint NOT NULL,
-        access_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.membership_profile_access_param_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.membership_profile_access_param_id_seq OWNED BY public.membership_profile_access_param.id;
-      CREATE SEQUENCE public.membership_profile_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.membership_profile_id_seq OWNED BY public.membership_profile.id;
+        param_inherited_id uuid NOT NULL,
+        access_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.membership_registration_request (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         password character varying NOT NULL,
         name character varying NOT NULL,
-        preferred_language_id bigint NOT NULL,
+        preferred_language_id uuid NOT NULL,
         dead_line timestamp without time zone NOT NULL,
         status character varying NOT NULL,
         salt character varying NOT NULL,
-        applicant_id bigint,
-        email character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.membership_registration_request_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.membership_registration_request_id_seq OWNED BY public.membership_registration_request.id;
+        applicant_id uuid,
+        email character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.membership_user (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        profile_id bigint NOT NULL,
+        id uuid PRIMARY KEY,
+        profile_id uuid NOT NULL,
         active boolean NOT NULL,
         salt character varying NOT NULL,
-        password character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        password character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_activity (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         name character varying NOT NULL,
-        periodicity_id bigint NOT NULL,
-        app_owner_id bigint NOT NULL,
+        periodicity_id uuid NOT NULL,
+        app_owner_id uuid NOT NULL,
         description character varying NOT NULL,
         default_shown boolean NOT NULL,
         version character varying NOT NULL,
         is_template boolean NOT NULL,
-        template_src_id bigint,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying,
+        template_src_id uuid,
         tags character varying,
         state character varying,
-        designer_id bigint,
+        designer_id uuid,
         license character varying
-      );
-      CREATE SEQUENCE public.supervisor_activity_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_activity_id_seq OWNED BY public.supervisor_activity.id;
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_activity_param (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         value character varying NOT NULL,
-        activity_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        activity_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_activity_template_like (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        template_id bigint NOT NULL,
-        user_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_activity_template_like_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_activity_template_like_id_seq OWNED BY public.supervisor_activity_template_like.id;
+        id uuid PRIMARY KEY,
+        template_id uuid NOT NULL,
+        user_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_activity_template_published (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        profile_id bigint NOT NULL,
+        id uuid PRIMARY KEY,
+        profile_id uuid NOT NULL,
         nb_subscriptions bigint NOT NULL,
         nb_likes bigint NOT NULL,
         score double precision NOT NULL,
@@ -817,1380 +386,582 @@ SOFTWARE.
         nb_paid bigint NOT NULL,
         icon character varying NOT NULL,
         availability character varying NOT NULL,
-        nb_views bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        nb_views bigint NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_activity_template_release (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         notes character varying NOT NULL,
-        template_id bigint NOT NULL,
-        version character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_activity_template_release_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_activity_template_release_id_seq OWNED BY public.supervisor_activity_template_release.id;
+        template_id uuid NOT NULL,
+        version character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_activity_template_subscription (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        template_id bigint NOT NULL,
-        user_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_activity_template_subscription_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_activity_template_subscription_id_seq OWNED BY public.supervisor_activity_template_subscription.id;
+        id uuid PRIMARY KEY,
+        template_id uuid NOT NULL,
+        user_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_activity_template_view (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        template_id bigint NOT NULL,
-        user_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_activity_template_view_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_activity_template_view_id_seq OWNED BY public.supervisor_activity_template_view.id;
+        id uuid PRIMARY KEY,
+        template_id uuid NOT NULL,
+        user_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_aggregated_model (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        core_model_id bigint NOT NULL,
-        model_id bigint NOT NULL,
-        date_reference_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY,
+        core_model_id uuid NOT NULL,
+        model_id uuid NOT NULL,
+        date_reference_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_aggregated_model_shared (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        activity_id bigint NOT NULL,
-        template_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY,
+        activity_id uuid NOT NULL,
+        template_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_chart_camembert_setting (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         camembert_type character varying NOT NULL,
-        sub_label character varying,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        sub_label character varying
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_data_field (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         style character varying NOT NULL,
         name character varying NOT NULL,
         type character varying NOT NULL,
         code character varying NOT NULL,
         description character varying NOT NULL,
-        model_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        model_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_data_field_expression_arg (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        field_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_data_field_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_data_field_id_seq OWNED BY public.supervisor_data_field.id;
+        id uuid PRIMARY KEY,
+        field_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_data_field_of_sheet (
-      id bigint NOT NULL,
-      guid uuid NOT NULL,
-      origin_field_id bigint NOT NULL,
-      sheet_id bigint NOT NULL,
-      value character varying,
-      creation_date timestamp without time zone NOT NULL,
-      creator_id bigint NOT NULL,
-      last_modification_date timestamp without time zone NOT NULL,
-      last_modifier_id bigint NOT NULL,
-      owner_id bigint NOT NULL,
-      tag character varying,
-      default_value character varying,
-      structure_id bigint,
-      sheet_to_refer_id bigint
-      );
-      CREATE SEQUENCE public.supervisor_data_field_of_sheet_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_data_field_of_sheet_id_seq OWNED BY public.supervisor_data_field_of_sheet.id;
+        id uuid PRIMARY KEY,
+        origin_field_id uuid NOT NULL,
+        sheet_id uuid NOT NULL,
+        value character varying,
+        default_value character varying,
+        structure_id uuid,
+        sheet_to_refer_id uuid
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_data_link (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         name character varying NOT NULL,
         data_domain_definition character varying NOT NULL,
-        indicator_id bigint NOT NULL,
+        indicator_id uuid NOT NULL,
         active boolean NOT NULL,
-        model_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_data_link_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_data_link_id_seq OWNED BY public.supervisor_data_link.id;
+        model_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_data_link_param (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         value character varying NOT NULL,
-        link_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        link_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_data_link_shared (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        activity_id bigint NOT NULL,
-        template_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY,
+        activity_id uuid NOT NULL,
+        template_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_data_model (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         description character varying NOT NULL,
         is_template boolean NOT NULL,
         active boolean NOT NULL,
-        activity_id bigint NOT NULL,
+        activity_id uuid NOT NULL,
         name character varying NOT NULL,
         interacting boolean NOT NULL,
         type character varying NOT NULL,
-        code character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_data_model_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_data_model_id_seq OWNED BY public.supervisor_data_model.id;
+        code character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_data_sheet (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         date date NOT NULL,
         reference character varying NOT NULL,
-        model_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying,
-        table_id bigint
-      );
-      CREATE SEQUENCE public.supervisor_data_sheet_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_data_sheet_id_seq OWNED BY public.supervisor_data_sheet.id;
+        model_id uuid NOT NULL,
+        table_id uuid
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_data_sheet_model (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        can_merge_at_same_date boolean NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY,
+        can_merge_at_same_date boolean NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_data_sheet_shared (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        activity_id bigint NOT NULL,
-        template_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY,
+        activity_id uuid NOT NULL,
+        template_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_dynamic_table_2_col (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         unity_symbol character varying NOT NULL,
         manage_evolution_percent boolean NOT NULL,
         nb_max_of_elements_to_show integer NOT NULL,
         symbol_position character varying NOT NULL,
-        ordering_mode character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        ordering_mode character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_editable_data_field (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         is_mandatory boolean NOT NULL,
         user_scope character varying NOT NULL,
         no integer NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying,
         is_read_only boolean,
         default_value character varying,
         must_edit_once boolean,
         take_last_value boolean,
-        structure_id bigint,
+        structure_id uuid,
         order_direction character varying,
         nb_max_values integer,
         can_be_updated boolean
-      );
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_expression_arg (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        expression_id bigint NOT NULL,
+        id uuid PRIMARY KEY,
+        expression_id uuid NOT NULL,
         type character varying NOT NULL,
-        no integer NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_expression_arg_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_expression_arg_id_seq OWNED BY public.supervisor_expression_arg.id;
+        no integer NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_expression_value_arg (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        target_expr_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY,
+        target_expr_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_formular_case_expression (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_formular_condition (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         default_value double precision NOT NULL,
         comparator character varying NOT NULL,
-        param_id bigint NOT NULL,
-        value character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        param_id uuid NOT NULL,
+        value character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_formular_data_field (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_formular_expression (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        formular_id bigint NOT NULL,
+        id uuid PRIMARY KEY,
+        formular_id uuid NOT NULL,
         no integer NOT NULL,
         type character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying,
         extended_model_aggregate character varying,
         extended_child_aggregate character varying
-      );
-      CREATE SEQUENCE public.supervisor_formular_expression_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_formular_expression_id_seq OWNED BY public.supervisor_formular_expression.id;
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_formular_extended_to_model_source (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        reference_id bigint NOT NULL,
-        model_id bigint NOT NULL,
-        expr_id bigint NOT NULL,
+        id uuid PRIMARY KEY,
+        reference_id uuid NOT NULL,
+        model_id uuid NOT NULL,
+        expr_id uuid NOT NULL,
         comparator character varying NOT NULL,
         interacting boolean NOT NULL,
         active boolean NOT NULL,
-        model_field_id bigint NOT NULL,
-        field_to_extend_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-    </sql>
-    <sql>
-      CREATE SEQUENCE public.supervisor_formular_extended_to_model_source_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_formular_extended_to_model_source_id_seq OWNED BY public.supervisor_formular_extended_to_model_source.id;
+        model_field_id uuid NOT NULL,
+        field_to_extend_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_formular_extended_to_parent_source (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        expr_id bigint NOT NULL,
-        list_source_id bigint NOT NULL,
-        field_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_formular_extended_to_parent_source_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_formular_extended_to_parent_source_id_seq OWNED BY public.supervisor_formular_extended_to_parent_source.id;
+        id uuid PRIMARY KEY,
+        expr_id uuid NOT NULL,
+        list_source_id uuid NOT NULL,
+        field_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_formular_simple_expression (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        func character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY,
+        func character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_gauge_setting (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         minor_ticks integer NOT NULL,
         symbol_position character varying NOT NULL,
         max double precision NOT NULL,
         min double precision NOT NULL,
         gauge_type character varying NOT NULL,
         unity_symbol character varying NOT NULL,
-        major_ticks integer NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        major_ticks integer NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_gauge_zone (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         color character varying NOT NULL,
         max double precision NOT NULL,
-        gauge_id bigint NOT NULL,
-        min double precision NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_gauge_zone_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_gauge_zone_id_seq OWNED BY public.supervisor_gauge_zone.id;
+        gauge_id uuid NOT NULL,
+        min double precision NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_goal_number_setting (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         symbol_position character varying NOT NULL,
         color character varying NOT NULL,
-        unity_symbol character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        unity_symbol character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_indicator_dynamic_number_param (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         "precision" integer NOT NULL,
-        apply_thousands_separator boolean NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        apply_thousands_separator boolean NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_indicator_dynamic_param (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         aggregate_func character varying NOT NULL,
-        origin_id bigint NOT NULL,
-        indicator_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_indicator_dynamic_param_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_indicator_dynamic_param_id_seq OWNED BY public.supervisor_indicator_dynamic_param.id;
+        origin_id uuid NOT NULL,
+        indicator_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_indicator_dynamic_string_param (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        markup character varying,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY,
+        markup character varying
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_indicator_general_setting (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         description character varying,
         col integer NOT NULL,
         size_x integer NOT NULL,
         "row" integer NOT NULL,
-        activity_id bigint NOT NULL,
+        activity_id uuid NOT NULL,
         single_label character varying NOT NULL,
-        periodicity_id bigint,
+        periodicity_id uuid,
         is_template boolean NOT NULL,
-        type_id bigint NOT NULL,
+        type_id uuid NOT NULL,
         size_y integer NOT NULL,
         plural_label character varying NOT NULL,
         code character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying,
         state character varying,
         tags character varying,
         name character varying
-      );
-      CREATE SEQUENCE public.supervisor_indicator_general_setting_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_indicator_general_setting_id_seq OWNED BY public.supervisor_indicator_general_setting.id;
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_indicator_static_param (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        origin_id bigint NOT NULL,
+        id uuid PRIMARY KEY,
+        origin_id uuid NOT NULL,
         value character varying NOT NULL,
-        indicator_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_indicator_static_param_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_indicator_static_param_id_seq OWNED BY public.supervisor_indicator_static_param.id;
+        indicator_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_indicator_type (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         description character varying NOT NULL,
         name character varying NOT NULL,
         default_size_x integer NOT NULL,
         default_size_y integer NOT NULL,
-        short_name character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_indicator_type_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_indicator_type_id_seq OWNED BY public.supervisor_indicator_type.id;
+        short_name character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_indicator_type_param (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         code character varying NOT NULL,
         type character varying NOT NULL,
         no integer NOT NULL,
         category character varying NOT NULL,
         name character varying NOT NULL,
-        indicator_type_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying,
+        indicator_type_id uuid NOT NULL,
         predefined_values character varying
-      );
-      CREATE SEQUENCE public.supervisor_indicator_type_param_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_indicator_type_param_id_seq OWNED BY public.supervisor_indicator_type_param.id;
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_list_data_field_source (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         active boolean NOT NULL,
-        model_id bigint NOT NULL,
-        order_field_id bigint NOT NULL,
-        field_to_display_id bigint NOT NULL,
-        field_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_list_data_field_source_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_list_data_field_source_id_seq OWNED BY public.supervisor_list_data_field_source.id;
+        model_id uuid NOT NULL,
+        order_field_id uuid NOT NULL,
+        field_to_display_id uuid NOT NULL,
+        field_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_list_data_field_source_shared (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        template_id bigint NOT NULL,
-        activity_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY,
+        template_id uuid NOT NULL,
+        activity_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_mapped_data_field (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        field_to_use_id bigint NOT NULL,
-        param_id bigint NOT NULL,
-        link_id bigint NOT NULL,
-        operator character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_mapped_data_field_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_mapped_data_field_id_seq OWNED BY public.supervisor_mapped_data_field.id;
+        id uuid PRIMARY KEY,
+        field_to_use_id uuid NOT NULL,
+        param_id uuid NOT NULL,
+        link_id uuid NOT NULL,
+        operator character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_model_filter (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        model_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY,
+        model_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_model_filter_condition (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        field_id bigint NOT NULL,
-        filter_id bigint NOT NULL,
+        id uuid PRIMARY KEY,
+        field_id uuid NOT NULL,
+        filter_id uuid NOT NULL,
         value character varying,
-        comparator character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_model_filter_condition_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_model_filter_condition_id_seq OWNED BY public.supervisor_model_filter_condition.id;
-      CREATE SEQUENCE public.supervisor_model_filter_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_model_filter_id_seq OWNED BY public.supervisor_model_filter.id;
+        comparator character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_number_oriented_setting (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         manage_evolution_percent boolean NOT NULL,
         unity_symbol character varying NOT NULL,
-        symbol_position character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        symbol_position character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_param_data_field (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        value character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        id uuid PRIMARY KEY,
+        value character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_periodicity (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         close_interval boolean NOT NULL,
         unit character varying NOT NULL,
         number integer NOT NULL,
-        reference date NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_periodicity_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_periodicity_id_seq OWNED BY public.supervisor_periodicity.id;
+        reference date NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_shared_resource (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        resource_id bigint NOT NULL,
+        id uuid PRIMARY KEY,
+        resource_id uuid NOT NULL,
         type character varying NOT NULL,
-        subscriber_id bigint NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_shared_resource_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_shared_resource_id_seq OWNED BY public.supervisor_shared_resource.id;
+        subscriber_id uuid NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_value_expression_arg (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
+        id uuid PRIMARY KEY,
         value_type character varying NOT NULL,
-        value character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
+        value character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
       CREATE TABLE public.supervisor_when_case (
-        id bigint NOT NULL,
-        guid uuid NOT NULL,
-        left_arg_id bigint NOT NULL,
-        expression_id bigint NOT NULL,
-        right_arg_id bigint,
-        result_id bigint NOT NULL,
-        comparator character varying NOT NULL,
-        creation_date timestamp without time zone NOT NULL,
-        creator_id bigint NOT NULL,
-        last_modification_date timestamp without time zone NOT NULL,
-        last_modifier_id bigint NOT NULL,
-        owner_id bigint NOT NULL,
-        tag character varying
-      );
-      CREATE SEQUENCE public.supervisor_when_case_id_seq
-        START WITH 1
-        INCREMENT BY 1
-        NO MINVALUE
-        NO MAXVALUE
-        CACHE 1;
-      ALTER SEQUENCE public.supervisor_when_case_id_seq OWNED BY public.supervisor_when_case.id;
+        id uuid PRIMARY KEY,
+        left_arg_id uuid NOT NULL,
+        expression_id uuid NOT NULL,
+        right_arg_id uuid,
+        result_id uuid NOT NULL,
+        comparator character varying NOT NULL
+      ) INHERITS (public.recordable);
     </sql>
     <sql>
-      ALTER TABLE ONLY public.base_address ALTER COLUMN id SET DEFAULT nextval('public.base_address_id_seq'::regclass);
-      ALTER TABLE ONLY public.base_country ALTER COLUMN id SET DEFAULT nextval('public.base_country_id_seq'::regclass);
-      ALTER TABLE ONLY public.base_currency ALTER COLUMN id SET DEFAULT nextval('public.base_currency_id_seq'::regclass);
-      ALTER TABLE ONLY public.base_event ALTER COLUMN id SET DEFAULT nextval('public.base_event_id_seq'::regclass);
-      ALTER TABLE ONLY public.base_language ALTER COLUMN id SET DEFAULT nextval('public.base_language_id_seq'::regclass);
-      ALTER TABLE ONLY public.base_person ALTER COLUMN id SET DEFAULT nextval('public.base_person_id_seq'::regclass);
-      ALTER TABLE ONLY public.base_planned_task ALTER COLUMN id SET DEFAULT nextval('public.base_planned_task_id_seq'::regclass);
-      ALTER TABLE ONLY public.base_sequence ALTER COLUMN id SET DEFAULT nextval('public.base_sequence_id_seq'::regclass);
-      ALTER TABLE ONLY public.billing_order ALTER COLUMN id SET DEFAULT nextval('public.billing_order_id_seq'::regclass);
-      ALTER TABLE ONLY public.billing_order_line ALTER COLUMN id SET DEFAULT nextval('public.billing_order_line_id_seq'::regclass);
-      ALTER TABLE ONLY public.billing_order_tax ALTER COLUMN id SET DEFAULT nextval('public.billing_order_tax_id_seq'::regclass);
-      ALTER TABLE ONLY public.billing_payment_method ALTER COLUMN id SET DEFAULT nextval('public.billing_payment_method_id_seq'::regclass);
-      ALTER TABLE ONLY public.billing_payment_receipt ALTER COLUMN id SET DEFAULT nextval('public.billing_payment_receipt_id_seq'::regclass);
-      ALTER TABLE ONLY public.billing_payment_request ALTER COLUMN id SET DEFAULT nextval('public.billing_payment_request_id_seq'::regclass);
-      ALTER TABLE ONLY public.billing_product ALTER COLUMN id SET DEFAULT nextval('public.billing_product_id_seq'::regclass);
-      ALTER TABLE ONLY public.billing_product_catalog ALTER COLUMN id SET DEFAULT nextval('public.billing_product_catalog_id_seq'::regclass);
-      ALTER TABLE ONLY public.billing_subscription_contract ALTER COLUMN id SET DEFAULT nextval('public.billing_subscription_contract_id_seq'::regclass);
-      ALTER TABLE ONLY public.billing_tax ALTER COLUMN id SET DEFAULT nextval('public.billing_tax_id_seq'::regclass);
-      ALTER TABLE ONLY public.membership_access ALTER COLUMN id SET DEFAULT nextval('public.membership_access_id_seq'::regclass);
-      ALTER TABLE ONLY public.membership_access_param ALTER COLUMN id SET DEFAULT nextval('public.membership_access_param_id_seq'::regclass);
-      ALTER TABLE ONLY public.membership_plan_feature ALTER COLUMN id SET DEFAULT nextval('public.membership_plan_feature_id_seq'::regclass);
-      ALTER TABLE ONLY public.membership_profile ALTER COLUMN id SET DEFAULT nextval('public.membership_profile_id_seq'::regclass);
-      ALTER TABLE ONLY public.membership_profile_access ALTER COLUMN id SET DEFAULT nextval('public.membership_profile_access_id_seq'::regclass);
-      ALTER TABLE ONLY public.membership_profile_access_param ALTER COLUMN id SET DEFAULT nextval('public.membership_profile_access_param_id_seq'::regclass);
-      ALTER TABLE ONLY public.membership_registration_request ALTER COLUMN id SET DEFAULT nextval('public.membership_registration_request_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_activity ALTER COLUMN id SET DEFAULT nextval('public.supervisor_activity_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_activity_template_like ALTER COLUMN id SET DEFAULT nextval('public.supervisor_activity_template_like_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_activity_template_release ALTER COLUMN id SET DEFAULT nextval('public.supervisor_activity_template_release_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_activity_template_subscription ALTER COLUMN id SET DEFAULT nextval('public.supervisor_activity_template_subscription_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_activity_template_view ALTER COLUMN id SET DEFAULT nextval('public.supervisor_activity_template_view_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_data_field ALTER COLUMN id SET DEFAULT nextval('public.supervisor_data_field_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_data_field_of_sheet ALTER COLUMN id SET DEFAULT nextval('public.supervisor_data_field_of_sheet_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_data_link ALTER COLUMN id SET DEFAULT nextval('public.supervisor_data_link_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_data_model ALTER COLUMN id SET DEFAULT nextval('public.supervisor_data_model_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_data_sheet ALTER COLUMN id SET DEFAULT nextval('public.supervisor_data_sheet_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_expression_arg ALTER COLUMN id SET DEFAULT nextval('public.supervisor_expression_arg_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_formular_expression ALTER COLUMN id SET DEFAULT nextval('public.supervisor_formular_expression_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_formular_extended_to_model_source ALTER COLUMN id SET DEFAULT nextval('public.supervisor_formular_extended_to_model_source_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_formular_extended_to_parent_source ALTER COLUMN id SET DEFAULT nextval('public.supervisor_formular_extended_to_parent_source_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_gauge_zone ALTER COLUMN id SET DEFAULT nextval('public.supervisor_gauge_zone_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_indicator_dynamic_param ALTER COLUMN id SET DEFAULT nextval('public.supervisor_indicator_dynamic_param_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_indicator_general_setting ALTER COLUMN id SET DEFAULT nextval('public.supervisor_indicator_general_setting_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_indicator_static_param ALTER COLUMN id SET DEFAULT nextval('public.supervisor_indicator_static_param_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_indicator_type ALTER COLUMN id SET DEFAULT nextval('public.supervisor_indicator_type_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_indicator_type_param ALTER COLUMN id SET DEFAULT nextval('public.supervisor_indicator_type_param_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_list_data_field_source ALTER COLUMN id SET DEFAULT nextval('public.supervisor_list_data_field_source_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_mapped_data_field ALTER COLUMN id SET DEFAULT nextval('public.supervisor_mapped_data_field_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_model_filter ALTER COLUMN id SET DEFAULT nextval('public.supervisor_model_filter_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_model_filter_condition ALTER COLUMN id SET DEFAULT nextval('public.supervisor_model_filter_condition_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_periodicity ALTER COLUMN id SET DEFAULT nextval('public.supervisor_periodicity_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_shared_resource ALTER COLUMN id SET DEFAULT nextval('public.supervisor_shared_resource_id_seq'::regclass);
-      ALTER TABLE ONLY public.supervisor_when_case ALTER COLUMN id SET DEFAULT nextval('public.supervisor_when_case_id_seq'::regclass);
+      INSERT INTO public.base_address (id, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('f9c113e6-4013-48fb-8050-407582bd6917', 'ABOBO BAOULE LOT 451 ILOT 68 APPT. 5G.', NULL, NULL, 'admin@minlessika.com', '07622999', NULL, 'Côte d''Ivoire', 'Abidjan', '5a953d38-11aa-4781-8216-fcabf7b63fa0', '2022-01-15 18:04:18.332125', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.332125', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ADMIN');
+      INSERT INTO public.base_address (id, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('437884de-bfa1-416b-b142-ca8503160db3', 'ABOBO BAOULE LOT 451 ILOT 68 APPT. 5G.', NULL, NULL, 'anonymous@minlessika.com', '07622999', NULL, 'Côte d''Ivoire', 'Abidjan', '5a953d38-11aa-4781-8216-fcabf7b63fa0', '2022-01-15 18:04:18.336513', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.336513', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ANONYMOUS');
+      INSERT INTO public.base_address (id, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('727f74c2-0c81-4dc2-aab8-b290c3000210', NULL, NULL, NULL, 'info@mtn.ci', NULL, NULL, NULL, NULL, '5a953d38-11aa-4781-8216-fcabf7b63fa0', '2022-01-15 18:04:18.339173', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.339173', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'MTN');
+      INSERT INTO public.base_address (id, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('cc034a79-45c7-431f-96f7-da13a7a2533e', NULL, NULL, NULL, 'info@ocit.ci', NULL, NULL, NULL, NULL, '5a953d38-11aa-4781-8216-fcabf7b63fa0', '2022-01-15 18:04:18.341837', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.341837', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ORANGE');
+      INSERT INTO public.base_address (id, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('b38ec4eb-adbe-48fb-8432-f4779a625048', NULL, NULL, NULL, 'info@moov.ci', NULL, NULL, NULL, NULL, '5a953d38-11aa-4781-8216-fcabf7b63fa0', '2022-01-15 18:04:18.347241', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.347241', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'MOOV');
+      INSERT INTO public.base_address (id, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('c35142bd-4a15-4176-b8f9-ef9ef13b6e21', NULL, NULL, NULL, 'info@orabank.ci', NULL, NULL, NULL, NULL, '5a953d38-11aa-4781-8216-fcabf7b63fa0', '2022-01-15 18:04:18.350287', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.350287', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ORABANK');
+      INSERT INTO public.base_address (id, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('e198fdbe-2626-4519-8513-b37390ca98bf', NULL, NULL, NULL, 'info@bankonline.ci', NULL, NULL, NULL, NULL, 'bbf2ce39-ec2c-4a73-8dc0-e3cb7d5a8742', '2022-01-15 18:04:18.353029', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.353029', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'BANKONLINE');
+      INSERT INTO public.base_address (id, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('f3fee586-8346-47c8-bd72-2cd39accf98e', NULL, NULL, NULL, 'commercial.ci@hub2.io', NULL, NULL, NULL, NULL, '5a953d38-11aa-4781-8216-fcabf7b63fa0', '2022-01-15 18:04:18.356011', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.356011', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CONNEKT4');
+      INSERT INTO public.base_address (id, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('147ad348-9721-4e29-8a84-dd6c602c5d56', NULL, NULL, NULL, 'infos@cinetpay.com', NULL, NULL, NULL, NULL, '5a953d38-11aa-4781-8216-fcabf7b63fa0', '2022-01-15 18:04:18.358257', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.358257', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CINETPAY');
     </sql>
     <sql>
-      INSERT INTO public.base_address (id, guid, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, 'cdeb2867-11d1-479b-b2d3-ee588f0299fa', 'ABOBO BAOULE LOT 451 ILOT 68 APPT. 5G.', NULL, NULL, 'admin@minlessika.com', '07622999', NULL, 'Côte d''Ivoire', 'Abidjan', 1, '2022-01-15 18:04:18.332125', 2, '2022-01-15 18:04:18.332125', 2, 2, 'ADMIN');
-      INSERT INTO public.base_address (id, guid, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, '80eb01d3-6838-4cf1-a3e1-777f93b2bf39', 'ABOBO BAOULE LOT 451 ILOT 68 APPT. 5G.', NULL, NULL, 'anonymous@minlessika.com', '07622999', NULL, 'Côte d''Ivoire', 'Abidjan', 1, '2022-01-15 18:04:18.336513', 2, '2022-01-15 18:04:18.336513', 2, 2, 'ANONYMOUS');
-      INSERT INTO public.base_address (id, guid, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (3, '7d304030-a81a-498d-9c36-524b3a59e720', NULL, NULL, NULL, 'info@mtn.ci', NULL, NULL, NULL, NULL, 1, '2022-01-15 18:04:18.339173', 2, '2022-01-15 18:04:18.339173', 2, 2, 'MTN');
-      INSERT INTO public.base_address (id, guid, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (4, 'ebb7ba12-8e3c-4c87-a914-024fd851a956', NULL, NULL, NULL, 'info@ocit.ci', NULL, NULL, NULL, NULL, 1, '2022-01-15 18:04:18.341837', 2, '2022-01-15 18:04:18.341837', 2, 2, 'ORANGE');
-      INSERT INTO public.base_address (id, guid, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (5, 'fd0c0e21-d317-4efe-b81b-4279f85fefb3', NULL, NULL, NULL, 'info@moov.ci', NULL, NULL, NULL, NULL, 1, '2022-01-15 18:04:18.347241', 2, '2022-01-15 18:04:18.347241', 2, 2, 'MOOV');
-      INSERT INTO public.base_address (id, guid, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (6, 'a148cd35-4f6e-490c-91ed-879551a507d7', NULL, NULL, NULL, 'info@orabank.ci', NULL, NULL, NULL, NULL, 1, '2022-01-15 18:04:18.350287', 2, '2022-01-15 18:04:18.350287', 2, 2, 'ORABANK');
-      INSERT INTO public.base_address (id, guid, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (7, 'd408909d-360d-4287-a4f6-06c9ed55a177', NULL, NULL, NULL, 'info@bankonline.ci', NULL, NULL, NULL, NULL, 3, '2022-01-15 18:04:18.353029', 2, '2022-01-15 18:04:18.353029', 2, 2, 'BANKONLINE');
-      INSERT INTO public.base_address (id, guid, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (8, 'a2a3f60d-a060-4303-85b4-c00a07728fe0', NULL, NULL, NULL, 'commercial.ci@hub2.io', NULL, NULL, NULL, NULL, 1, '2022-01-15 18:04:18.356011', 2, '2022-01-15 18:04:18.356011', 2, 2, 'CONNEKT4');
-      INSERT INTO public.base_address (id, guid, address_line1, address_line2, company, email, phone1, phone2, state_or_province, city, country_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (9, '45c7d5d2-2db9-428c-a6bf-f3635cb6c018', NULL, NULL, NULL, 'infos@cinetpay.com', NULL, NULL, NULL, NULL, 1, '2022-01-15 18:04:18.358257', 2, '2022-01-15 18:04:18.358257', 2, 2, 'CINETPAY');
+      INSERT INTO public.base_country (id, phone_code, code, name, currency_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('5a953d38-11aa-4781-8216-fcabf7b63fa0', 225, 'CI', 'Côte d''Ivoire', 'b87e85d4-0831-4c40-bfab-1b01c4fe5cc3', '2022-01-15 18:04:17.839281', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.839281', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CI');
+      INSERT INTO public.base_country (id, phone_code, code, name, currency_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('e16a45f8-74e0-45c8-b0c9-f5b78c8ea3f7', 226, 'BF', 'Burkina Faso', 'b87e85d4-0831-4c40-bfab-1b01c4fe5cc3', '2022-01-15 18:04:17.843345', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.843345', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'BF');
+      INSERT INTO public.base_country (id, phone_code, code, name, currency_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('bbf2ce39-ec2c-4a73-8dc0-e3cb7d5a8742', 33, 'FR', 'France', '75932d0b-f391-4def-a2e0-854e45376f07', '2022-01-15 18:04:17.845974', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.845974', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FR');
+      INSERT INTO public.base_country (id, phone_code, code, name, currency_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('308e0b53-5846-4f4c-918b-afbf89545cd1', 1, 'US', 'United States', '75932d0b-f391-4def-a2e0-854e45376f07', '2022-01-15 18:04:17.848235', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.848235', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'US');
+      INSERT INTO public.base_country (id, phone_code, code, name, currency_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('78eebaaf-f791-40e6-b8bc-1ae01f745cb7', 354, 'IE', 'Ireland', '75932d0b-f391-4def-a2e0-854e45376f07', '2022-01-15 18:04:17.850778', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.850778', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'IE');
     </sql>
     <sql>
-      INSERT INTO public.base_country (id, guid, phone_code, code, name, currency_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, '5a953d38-11aa-4781-8216-fcabf7b63fa0', 225, 'CI', 'Côte d''Ivoire', 1, '2022-01-15 18:04:17.839281', 2, '2022-01-15 18:04:17.839281', 2, 2, 'CI');
-      INSERT INTO public.base_country (id, guid, phone_code, code, name, currency_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, 'e16a45f8-74e0-45c8-b0c9-f5b78c8ea3f7', 226, 'BF', 'Burkina Faso', 1, '2022-01-15 18:04:17.843345', 2, '2022-01-15 18:04:17.843345', 2, 2, 'BF');
-      INSERT INTO public.base_country (id, guid, phone_code, code, name, currency_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (3, 'bbf2ce39-ec2c-4a73-8dc0-e3cb7d5a8742', 33, 'FR', 'France', 2, '2022-01-15 18:04:17.845974', 2, '2022-01-15 18:04:17.845974', 2, 2, 'FR');
-      INSERT INTO public.base_country (id, guid, phone_code, code, name, currency_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (4, '308e0b53-5846-4f4c-918b-afbf89545cd1', 1, 'US', 'United States', 2, '2022-01-15 18:04:17.848235', 2, '2022-01-15 18:04:17.848235', 2, 2, 'US');
-      INSERT INTO public.base_country (id, guid, phone_code, code, name, currency_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (5, '78eebaaf-f791-40e6-b8bc-1ae01f745cb7', 354, 'IE', 'Ireland', 2, '2022-01-15 18:04:17.850778', 2, '2022-01-15 18:04:17.850778', 2, 2, 'IE');
+      INSERT INTO public.base_currency (id, name, after, "precision", symbol, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('b87e85d4-0831-4c40-bfab-1b01c4fe5cc3', 'Francs CFA', true, 0, 'XOF', 'XOF', '2022-01-15 18:04:17.776827', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.776827', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'XOF');
+      INSERT INTO public.base_currency (id, name, after, "precision", symbol, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('75932d0b-f391-4def-a2e0-854e45376f07', 'Euro', false, 2, '€', 'EUR', '2022-01-15 18:04:17.779777', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.779777', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'EUR');
     </sql>
     <sql>
-      INSERT INTO public.base_currency (id, guid, name, after, "precision", symbol, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, 'b87e85d4-0831-4c40-bfab-1b01c4fe5cc3', 'Francs CFA', true, 0, 'XOF', 'XOF', '2022-01-15 18:04:17.776827', 2, '2022-01-15 18:04:17.776827', 2, 2, 'XOF');
-      INSERT INTO public.base_currency (id, guid, name, after, "precision", symbol, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, '75932d0b-f391-4def-a2e0-854e45376f07', 'Euro', false, 2, '€', 'EUR', '2022-01-15 18:04:17.779777', 2, '2022-01-15 18:04:17.779777', 2, 2, 'EUR');
+      INSERT INTO public.base_language (id, iso_code, code, name, enabled, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('602667bc-8014-4a02-be12-164a8e1c29cb', 'en', 'en_US', 'English', true, '2022-01-15 18:04:17.879671', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.879671', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'EN');
+      INSERT INTO public.base_language (id, iso_code, code, name, enabled, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('58b5bcdf-f78c-49b6-b02c-eab3e9f9f67b', 'fr', 'fr_FR', 'French / Français', true, '2022-01-15 18:04:17.882573', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.882573', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FR');
     </sql>
     <sql>
-      INSERT INTO public.base_language (id, guid, iso_code, code, name, enabled, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, '602667bc-8014-4a02-be12-164a8e1c29cb', 'en', 'en_US', 'English', true, '2022-01-15 18:04:17.879671', 2, '2022-01-15 18:04:17.879671', 2, 2, 'EN');
-      INSERT INTO public.base_language (id, guid, iso_code, code, name, enabled, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, '58b5bcdf-f78c-49b6-b02c-eab3e9f9f67b', 'fr', 'fr_FR', 'French / Français', true, '2022-01-15 18:04:17.882573', 2, '2022-01-15 18:04:17.882573', 2, 2, 'FR');
+      INSERT INTO public.base_person (id, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('4788fb05-d7ac-4739-9b64-70a80f5e7af4', 'Minlessika', '58b5bcdf-f78c-49b6-b02c-eab3e9f9f67b', 'f9c113e6-4013-48fb-8050-407582bd6917', 'b87e85d4-0831-4c40-bfab-1b01c4fe5cc3', true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4gobCAYAArkuKAAAECZJREFUeNrtnXtwXNV9xz/n3pXsyCBZWCuTVgSwhR53BTaucdJODM60pSQOkEnqdkgGrZ1Q+p6GTqfTJJ0+JtNMm+SPpGmbkDaxjdukHdpJAiEtCZm4hHaKhRlks2vrUWzHosFa+QFGRq+9p3/87r26Wkt4tffec9eE74zH3l3vPY/f/n7n9z6KOoDj5AEF6NC72gZ1FXAd0AV0A51AB9AOtAKrgBWA5X3JBaaBSeAsMA6cBP4XGAKGgeNac0YpyvNjydjF4t60twKV1sCOk0cpjdb+FDSgWoFe4BbvTy9wDdACNEYccgZ4GSHQEeAAMAAcBX12fis0oFIjjlGC9PbuRCld+XYrsBn4JeBWhBOaDU3pFYRzngQeB55BOCsETbH4kLE9MkKQvr57cV0r/JYF9AB3AXcDNwFNxla9OC4Ah4BvAY8ARxERKBulyhQK/5j4JBIlSF9fHtdd8FYDsAXoB7YDP534CmvDi8BjwEOIaJv1P7AseP755MRZYgRxnDxag5IRbOAdwG8ghGhNbEXx4ixCmC8B/wOUkz5jYieI4+wixOkgB/PvAL8KrElkFcnjNPAvwBcQUebBoljcHetAdpwPE/U1OLRbgF8HPo8c2GmfEVHQhGh97/ZeHwWmldK0t2+kVBqMbaBYOGTduvtZuXIawBdTtwB/CtxBzESvA5SB/wD+XGsGPJGMUhcoFB6O/PDIm+U4eTKZwMZaqRT3AX+DqLJWzQ+uX1iIoXqHUrwGHAbK0EA2uyEyt0QiiOPkcV3lH9xvBf4S+BhwVdq7ZgAtwO3A1Yj98qplKdraoomwmgki50WgRd0IPAjsiPLMyxA2IgluBp7VmnEgEqfUtHk+MTzcCnwFUWt/UrEO2AoUQJ0AyGZr45RlE6SCGNuBv0fcHT/pWAu8CxgFPQKqJqIsiyC53M7wy7sRg+malDbARXxRE4hX9wzi/tCIIzINx+lqYBso37u8bKJUPekKzngP8GXMuz6mgQLwQ8SlMYoYbVPe5ysR4/MGxG64FXAQF71JvAjcD3wHQClFobCnqi9WRZCKeMVtwB4kTmEKU8D3gN3AD5ViQuuqvteGyPZdwC8iBDOF40AeeNK2FXNzLkeOXNprfEmCdHZ+iMbGjP+yD/i697cpDAJ/hXhhL0BgfPLKKxcYG1tojHV07KClpYkKgjUhIvaPEM+yKRwGPgg8D5DJuBw6tO91v3BJgoRE1dXAPuAXDC1GA/8M/DHwQviDah17FWIWRBv6C8SvZuqMeQK4F3ipmrm/7qEeWtAK5Ff6K4YW4QJ/B/y+LKQM2BSLe5d1QJZKg5RKg2SzG8lkNK6rznobdCViP5ggyjrgCm/c8qUO+SUJ0t2dx5p3fNyHWOAZzOAfgD8EzgMoFS1qVyoN0tbWh+fJmUaUgnbgZwyt50bgJVAHQbNmzQYmJhYnypK+JnueVLcAn8CcpvIEIqZelZc6lkhdofBPhDzRr3pjfN/QmlYAnwC9GRSWtTRjLsohvb153yXSDPw1QhQTeAkJYg2BHN7VaCbVolQaZO3aDX5ixSQwghi3VxhYWwvwU0jAa3op0XURQXI5ifR54up+JLhkymv7eaX0Q6Aii6mlMD4+SDZ7E94YY16q0VZD61uP/OgOKKVYu/ZmxsefW/AfLtpoX6XUmh7g9zDnLDwG7PXTggqF5DI9isV93loViE11zNAabWRPe7TWuBUJB1BBkK4uEVWWhQX8NkJRU/h2udw2AjA1lfxxJWNoJic7RoBvG1znemRvLYDu7vsWfLiAIJmMcIjr8g7gHoOTfA34jm1PAPDCC19OfEAZQ7Fq1RiIi2Mq2hOXhXvwvOO2Pbvgg4AguVy//88GJBZuMiHhR0hOFOVydT6ROGDbQaTzEHDC4HrXIHvcAAsN2IAg8ymdbAHuNDg5EG1nAmBoyFyW4OHDvjqtJ7w5mMSdyF4vgLXI637M500dR3JvU4I1483BJFqBe0FflNIZZpkeRC83jQkA1zUnrnzImDqYg2FsB9UD8zTwqBOIq7tIJ71zBsC2zceUQmOmwaEdyJ7jujIPjyAaJNp1dwqTAs8tU2WMI1aExjQdxPJxF7DasmQiVm9vIK42YzZWEEZbKA/YKEI1Km0prf0mPCen4+SFQ7yNSDPd8zqlaEyHQxRK6UbMRkDDWIXsPQCW5yZpRUKzaaELyAL09vZHfFT1CI2V9eaQFm5DjoxA7e1OeULXABtAEgJMITTWBtLLngHZ/x6YJ8gWxD2cFlYC231NY5HQa+zwucMTk9sxmwBRiRa8EIelNTbm4h2vh+2WpY0l3PncoRTdpGN7VWKLUliWUqwBcmnPBrgW2KW1+JcqkvJiheMIdzQ0zIKkCF2b9uIBR2vWWMDbqJ9av11K2VsBtNZ0d3849gHkmcIds7MNfs5WPaADuNavdUjz/AijHfgkUtqAbZfp6NgR34o7doQ9vG/1xmpPe9EeWoAuvzw5LSt1MdwGfAqvVr25uYmuruiHfFdXnubmwMxq9sZIU9WvxAqg28JsVLBa9AOfwfM623Y0zSuXy9PYGKi4rd6zzRk81WN9hnT176VgIQkWbcDHlGIY/FJrXXUmiuPsBDRay5mE6PufAt6f9gKXwNuU4+SHSNcovBSKwKeBfyPI1QI/M6VQWJiaKRrURcbllcAHkOS73rQX9DoYUo6TP0X9HGxLYQbYj2S/73dd9ZLvHV0KWtsoVb4aKaLZCWwjegObpHEqw+VRP96IFFi+CxiyLP0U8DTSbuk0kiQB8BYkXt2lVPntwDsRMdWQ9gKqxCrlOPmZy2jCYWgk+/A8kq8LoqlciXhQU2s9FQGzGcwlUMcNhaSAmkgDNYXMG7Gw/7KGBcylPYk3EWDOYl7+von0MW3h1e29ibrApMVFPQbfRIo4l0GK7uutE4OLJD9PQbidayywkejgSuqvW9GpDNI2tR5wBimBPoCUE59EbIy4E9gaEVulA0nB2YLE1Ouhg9HJDNINIU0cAx4G/hXxW00aHPtriBHpAL+MdDO6PsW9GM0g9XzTmI+JnAf2Is3Ohio/bG8/wf79+xMZeNu2bYyPX+dViulJYEBrNaCU3o2U8PUjXGQS03jOxc1IIaJJB+MI8HGt9TeUUsEZMTPTzOjoF4zuQmfn77JixStBSqlS2FrzfsRN32lwKuPA9gxSqDKGOYIcBH4TGJjP/DDTpHgx+D8Av+u21pQREXoC+CKwydBUxoATGa31aaVU0dDAh4CPAINp91ivxJEjewC/Jz1ozQFvrg8hhf9JowD6tKWUchHNJmn8GPgooklRT8QIw5+T16P+OeABvD4lCeMAqKAh+wByc0BSKAOfVoofVC68HlEo7A3OFK35PvBZ4reHwngZoUFgGB1lEU0nRvwA2O0vsp6J4cNvWuAdc19FblBICsH+W1prlFLnkBBpEphCDseXZaH1TwwfxWLAKWe9NSTliP1PrfU5pRSWUsrPyPguyRhlzxA0eUmhACQiQh2RngCeTWCISeBx0Tg1VugXe5DgwI0VjwEvu65t9GKUuCBZLRqES/49gSEG8QhdKOz1zxAX4BxykUmcOI/0psKykjwTk0YQnn+S+KXIt5C9B4JDPeDLRxADJS68iFzIdVmdHZUIzX0U+L8YHz0GPBp+wwoPqBRDxNuI5SQh6r8BcBb5kcWFR0EdhXkaLIgHaI2LWKZnYhpwglQ7NMQHSUdlGijF9MgzwL7KYvCAIErJLQdKMUAFG0XAhWJxrxv9MelD2lYpl/mkvKh4BM8YDKeQBQTxOy9rzRxy00EcrSaaHCdfb1G5mqG1togn03MC2eM5gGJxT/DBwsYnls8l6mmkYXJUrMeLK0gm+uWJnp6gcqGFeAJYX8PzH1ZWHS8gyOHDe/zUfRf4W6JHE3sJWrFefkahj1AX0c145csRMILsrQtc1BN+EXESiPwh4HNEc6pdCfwWEib1im7+LJldSwAdHTvChUJXhNdSI+aQPR0GvWhN/kUNLkulQ2SzG/2XR5FYQJSslC7kYsb/Btxs9hzt7ZsolZ5LcCujo68vT2NjkIPeCHwc+DDRMlUeRX6RM7C4bbZox1G/Pbf3xWHktrXVNU7CAn4OqesbAKZcF9rbo1+glRTkbq3gF3wVUhz6UaJVCZxAOOwEsKQbackWsG1tG33X848Rd8Ht1J4pnwF+FsnuOKyU6PLZ7EZaWzdx+vRziWzscpHL9QfSwSPGjYi87ydau9xp5GaGx0Asj6VajS85yMTEYFh0FZCYe5SODwoRfT+PWO9DQNmydM33NcWFXG4H2ay/NAWSRPchJCMmjru1HkTK8soAR44s7UZaznUVaxEr/vYYJvgaUjP4WaUYDNuqZn1eO8jlmpDCUIVlNeC6szcDf4AUhsbR/+S7CIedqmZ9lySI5DAFnSdyiA4dV6OzMSQat5eKO0Lm5mB4OBni5HK7EM1e4PXMWo90ddhJfJ0tBpELXYoAxeL1XErLrPLKowWVre/0NnBdjHs0jBD6YVBDoBeo2lqrICukVuRyO/1AXHj5Nuge5F6UDxJvHtYLyJVHTyl1BVq/WhX313op2B3IdXkdMS4AxJP6PeAbwNNKTZ7SeqHaXy7PYduXDnY5zk7vl7+oK+1q4O3A+5C7qeLu9TIG/BpyZy6SYbOnqi8uqzCygih3InHmJBrXTCNc819IgGsQOKmUPq+1WpbJrxRKa5qZb5K2FeHyG0imTHoMUW8DB+1yzsVlV6pWEOXdiFqYZIKyi7i8jyFEGvUWfQpJnLiAGJ4gdkITYjOtRTi4EzFOr0c6QyTp7DyGNNoPQr3LVVJqKh32ieJ1Et2KXPy+IcGFLoYZ788s8+4dGyFKI+abBAwiidpP+W/UojHWZOyUSoO0tweG44+QWHMnZpOTbWTT34JwRZP378Za1xUBjyO9WQ76b9Sqvtc8cd+94rouSqkSom83ISrx5Vr7vlxMIdfPPgAcn511se1oKbKRfklClE0+p0wiuUsvIuJrddq7lTCOI+6QzyB38mLbRE51iqn9xA4cZ0EgbRPwJ0hzyTcat8whiSCfVEo969s2cXkYYu0HEkrlB4mF3It4SW8wtl3JYgSJZ+wDzvvEiPMmuVgPv5DbHkQDGkAOPBcJ50YJ7qSJEnLZ5QOIsTcD4hGOkxiQYMec8A3TloXlutyCXPNzF2avU4qC00h2yIPIj8v1JUBSTtBEWxht2HAPs7ONYTGWQeLS/cB7qc/2giAJfo8ioukZQv1gZmYyjI5+JbGBjfSU6ur6CJnMfI8b10VZFl0It7wP0crSFmeTiHH3TeARUMPhJLbZWYuRkd2JT8Jok6+enn4sS1FxV8hqRCu7HWnD1405lfkcEijbj9hRB1mkksxkjCa1rmsSt56vv/DE2mrE77QZ6bDQh/ijVhO9jn4aIcAYcuH8AeRcGFGKcz4vuK6FZbmpJYfXRRs8/5afcFaM1tpSSq1BzpkuhHM6vddrkf67TUhUz9cWy4j1fAFJjD6FnAejCCcMe69PE8p38jm2HjL0/x848s2hrn9akAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0xMC0yN1QwODowNjowMCswMDowMNiFiREAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMTAtMjdUMDg6MDY6MDArMDA6MDCp2DGtAAAAAElFTkSuQmCC', 'Africa/Abidjan', 'f9c113e6-4013-48fb-8050-407582bd6917', '2022-01-15 18:04:18.501476', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.501476', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ADMIN');
+      INSERT INTO public.base_person (id, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('71078f08-0531-4ffc-bd29-a11fc633c4c7', 'Anonyme', '58b5bcdf-f78c-49b6-b02c-eab3e9f9f67b', '437884de-bfa1-416b-b142-ca8503160db3', 'b87e85d4-0831-4c40-bfab-1b01c4fe5cc3', false, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4gobCAYAArkuKAAAECZJREFUeNrtnXtwXNV9xz/n3pXsyCBZWCuTVgSwhR53BTaucdJODM60pSQOkEnqdkgGrZ1Q+p6GTqfTJJ0+JtNMm+SPpGmbkDaxjdukHdpJAiEtCZm4hHaKhRlks2vrUWzHosFa+QFGRq+9p3/87r26Wkt4tffec9eE74zH3l3vPY/f/n7n9z6KOoDj5AEF6NC72gZ1FXAd0AV0A51AB9AOtAKrgBWA5X3JBaaBSeAsMA6cBP4XGAKGgeNac0YpyvNjydjF4t60twKV1sCOk0cpjdb+FDSgWoFe4BbvTy9wDdACNEYccgZ4GSHQEeAAMAAcBX12fis0oFIjjlGC9PbuRCld+XYrsBn4JeBWhBOaDU3pFYRzngQeB55BOCsETbH4kLE9MkKQvr57cV0r/JYF9AB3AXcDNwFNxla9OC4Ah4BvAY8ARxERKBulyhQK/5j4JBIlSF9fHtdd8FYDsAXoB7YDP534CmvDi8BjwEOIaJv1P7AseP755MRZYgRxnDxag5IRbOAdwG8ghGhNbEXx4ixCmC8B/wOUkz5jYieI4+wixOkgB/PvAL8KrElkFcnjNPAvwBcQUebBoljcHetAdpwPE/U1OLRbgF8HPo8c2GmfEVHQhGh97/ZeHwWmldK0t2+kVBqMbaBYOGTduvtZuXIawBdTtwB/CtxBzESvA5SB/wD+XGsGPJGMUhcoFB6O/PDIm+U4eTKZwMZaqRT3AX+DqLJWzQ+uX1iIoXqHUrwGHAbK0EA2uyEyt0QiiOPkcV3lH9xvBf4S+BhwVdq7ZgAtwO3A1Yj98qplKdraoomwmgki50WgRd0IPAjsiPLMyxA2IgluBp7VmnEgEqfUtHk+MTzcCnwFUWt/UrEO2AoUQJ0AyGZr45RlE6SCGNuBv0fcHT/pWAu8CxgFPQKqJqIsiyC53M7wy7sRg+malDbARXxRE4hX9wzi/tCIIzINx+lqYBso37u8bKJUPekKzngP8GXMuz6mgQLwQ8SlMYoYbVPe5ysR4/MGxG64FXAQF71JvAjcD3wHQClFobCnqi9WRZCKeMVtwB4kTmEKU8D3gN3AD5ViQuuqvteGyPZdwC8iBDOF40AeeNK2FXNzLkeOXNprfEmCdHZ+iMbGjP+yD/i697cpDAJ/hXhhL0BgfPLKKxcYG1tojHV07KClpYkKgjUhIvaPEM+yKRwGPgg8D5DJuBw6tO91v3BJgoRE1dXAPuAXDC1GA/8M/DHwQviDah17FWIWRBv6C8SvZuqMeQK4F3ipmrm/7qEeWtAK5Ff6K4YW4QJ/B/y+LKQM2BSLe5d1QJZKg5RKg2SzG8lkNK6rznobdCViP5ggyjrgCm/c8qUO+SUJ0t2dx5p3fNyHWOAZzOAfgD8EzgMoFS1qVyoN0tbWh+fJmUaUgnbgZwyt50bgJVAHQbNmzQYmJhYnypK+JnueVLcAn8CcpvIEIqZelZc6lkhdofBPhDzRr3pjfN/QmlYAnwC9GRSWtTRjLsohvb153yXSDPw1QhQTeAkJYg2BHN7VaCbVolQaZO3aDX5ixSQwghi3VxhYWwvwU0jAa3op0XURQXI5ifR54up+JLhkymv7eaX0Q6Aii6mlMD4+SDZ7E94YY16q0VZD61uP/OgOKKVYu/ZmxsefW/AfLtpoX6XUmh7g9zDnLDwG7PXTggqF5DI9isV93loViE11zNAabWRPe7TWuBUJB1BBkK4uEVWWhQX8NkJRU/h2udw2AjA1lfxxJWNoJic7RoBvG1znemRvLYDu7vsWfLiAIJmMcIjr8g7gHoOTfA34jm1PAPDCC19OfEAZQ7Fq1RiIi2Mq2hOXhXvwvOO2Pbvgg4AguVy//88GJBZuMiHhR0hOFOVydT6ROGDbQaTzEHDC4HrXIHvcAAsN2IAg8ymdbAHuNDg5EG1nAmBoyFyW4OHDvjqtJ7w5mMSdyF4vgLXI637M500dR3JvU4I1483BJFqBe0FflNIZZpkeRC83jQkA1zUnrnzImDqYg2FsB9UD8zTwqBOIq7tIJ71zBsC2zceUQmOmwaEdyJ7jujIPjyAaJNp1dwqTAs8tU2WMI1aExjQdxPJxF7DasmQiVm9vIK42YzZWEEZbKA/YKEI1Km0prf0mPCen4+SFQ7yNSDPd8zqlaEyHQxRK6UbMRkDDWIXsPQCW5yZpRUKzaaELyAL09vZHfFT1CI2V9eaQFm5DjoxA7e1OeULXABtAEgJMITTWBtLLngHZ/x6YJ8gWxD2cFlYC231NY5HQa+zwucMTk9sxmwBRiRa8EIelNTbm4h2vh+2WpY0l3PncoRTdpGN7VWKLUliWUqwBcmnPBrgW2KW1+JcqkvJiheMIdzQ0zIKkCF2b9uIBR2vWWMDbqJ9av11K2VsBtNZ0d3849gHkmcIds7MNfs5WPaADuNavdUjz/AijHfgkUtqAbZfp6NgR34o7doQ9vG/1xmpPe9EeWoAuvzw5LSt1MdwGfAqvVr25uYmuruiHfFdXnubmwMxq9sZIU9WvxAqg28JsVLBa9AOfwfM623Y0zSuXy9PYGKi4rd6zzRk81WN9hnT176VgIQkWbcDHlGIY/FJrXXUmiuPsBDRay5mE6PufAt6f9gKXwNuU4+SHSNcovBSKwKeBfyPI1QI/M6VQWJiaKRrURcbllcAHkOS73rQX9DoYUo6TP0X9HGxLYQbYj2S/73dd9ZLvHV0KWtsoVb4aKaLZCWwjegObpHEqw+VRP96IFFi+CxiyLP0U8DTSbuk0kiQB8BYkXt2lVPntwDsRMdWQ9gKqxCrlOPmZy2jCYWgk+/A8kq8LoqlciXhQU2s9FQGzGcwlUMcNhaSAmkgDNYXMG7Gw/7KGBcylPYk3EWDOYl7+von0MW3h1e29ibrApMVFPQbfRIo4l0GK7uutE4OLJD9PQbidayywkejgSuqvW9GpDNI2tR5wBimBPoCUE59EbIy4E9gaEVulA0nB2YLE1Ouhg9HJDNINIU0cAx4G/hXxW00aHPtriBHpAL+MdDO6PsW9GM0g9XzTmI+JnAf2Is3Ohio/bG8/wf79+xMZeNu2bYyPX+dViulJYEBrNaCU3o2U8PUjXGQS03jOxc1IIaJJB+MI8HGt9TeUUsEZMTPTzOjoF4zuQmfn77JixStBSqlS2FrzfsRN32lwKuPA9gxSqDKGOYIcBH4TGJjP/DDTpHgx+D8Av+u21pQREXoC+CKwydBUxoATGa31aaVU0dDAh4CPAINp91ivxJEjewC/Jz1ozQFvrg8hhf9JowD6tKWUchHNJmn8GPgooklRT8QIw5+T16P+OeABvD4lCeMAqKAh+wByc0BSKAOfVoofVC68HlEo7A3OFK35PvBZ4reHwngZoUFgGB1lEU0nRvwA2O0vsp6J4cNvWuAdc19FblBICsH+W1prlFLnkBBpEphCDseXZaH1TwwfxWLAKWe9NSTliP1PrfU5pRSWUsrPyPguyRhlzxA0eUmhACQiQh2RngCeTWCISeBx0Tg1VugXe5DgwI0VjwEvu65t9GKUuCBZLRqES/49gSEG8QhdKOz1zxAX4BxykUmcOI/0psKykjwTk0YQnn+S+KXIt5C9B4JDPeDLRxADJS68iFzIdVmdHZUIzX0U+L8YHz0GPBp+wwoPqBRDxNuI5SQh6r8BcBb5kcWFR0EdhXkaLIgHaI2LWKZnYhpwglQ7NMQHSUdlGijF9MgzwL7KYvCAIErJLQdKMUAFG0XAhWJxrxv9MelD2lYpl/mkvKh4BM8YDKeQBQTxOy9rzRxy00EcrSaaHCdfb1G5mqG1togn03MC2eM5gGJxT/DBwsYnls8l6mmkYXJUrMeLK0gm+uWJnp6gcqGFeAJYX8PzH1ZWHS8gyOHDe/zUfRf4W6JHE3sJWrFefkahj1AX0c145csRMILsrQtc1BN+EXESiPwh4HNEc6pdCfwWEib1im7+LJldSwAdHTvChUJXhNdSI+aQPR0GvWhN/kUNLkulQ2SzG/2XR5FYQJSslC7kYsb/Btxs9hzt7ZsolZ5LcCujo68vT2NjkIPeCHwc+DDRMlUeRX6RM7C4bbZox1G/Pbf3xWHktrXVNU7CAn4OqesbAKZcF9rbo1+glRTkbq3gF3wVUhz6UaJVCZxAOOwEsKQbackWsG1tG33X848Rd8Ht1J4pnwF+FsnuOKyU6PLZ7EZaWzdx+vRziWzscpHL9QfSwSPGjYi87ydau9xp5GaGx0Asj6VajS85yMTEYFh0FZCYe5SODwoRfT+PWO9DQNmydM33NcWFXG4H2ay/NAWSRPchJCMmjru1HkTK8soAR44s7UZaznUVaxEr/vYYJvgaUjP4WaUYDNuqZn1eO8jlmpDCUIVlNeC6szcDf4AUhsbR/+S7CIedqmZ9lySI5DAFnSdyiA4dV6OzMSQat5eKO0Lm5mB4OBni5HK7EM1e4PXMWo90ddhJfJ0tBpELXYoAxeL1XErLrPLKowWVre/0NnBdjHs0jBD6YVBDoBeo2lqrICukVuRyO/1AXHj5Nuge5F6UDxJvHtYLyJVHTyl1BVq/WhX313op2B3IdXkdMS4AxJP6PeAbwNNKTZ7SeqHaXy7PYduXDnY5zk7vl7+oK+1q4O3A+5C7qeLu9TIG/BpyZy6SYbOnqi8uqzCygih3InHmJBrXTCNc819IgGsQOKmUPq+1WpbJrxRKa5qZb5K2FeHyG0imTHoMUW8DB+1yzsVlV6pWEOXdiFqYZIKyi7i8jyFEGvUWfQpJnLiAGJ4gdkITYjOtRTi4EzFOr0c6QyTp7DyGNNoPQr3LVVJqKh32ieJ1Et2KXPy+IcGFLoYZ788s8+4dGyFKI+abBAwiidpP+W/UojHWZOyUSoO0tweG44+QWHMnZpOTbWTT34JwRZP378Za1xUBjyO9WQ76b9Sqvtc8cd+94rouSqkSom83ISrx5Vr7vlxMIdfPPgAcn511se1oKbKRfklClE0+p0wiuUsvIuJrddq7lTCOI+6QzyB38mLbRE51iqn9xA4cZ0EgbRPwJ0hzyTcat8whiSCfVEo969s2cXkYYu0HEkrlB4mF3It4SW8wtl3JYgSJZ+wDzvvEiPMmuVgPv5DbHkQDGkAOPBcJ50YJ7qSJEnLZ5QOIsTcD4hGOkxiQYMec8A3TloXlutyCXPNzF2avU4qC00h2yIPIj8v1JUBSTtBEWxht2HAPs7ONYTGWQeLS/cB7qc/2giAJfo8ioukZQv1gZmYyjI5+JbGBjfSU6ur6CJnMfI8b10VZFl0It7wP0crSFmeTiHH3TeARUMPhJLbZWYuRkd2JT8Jok6+enn4sS1FxV8hqRCu7HWnD1405lfkcEijbj9hRB1mkksxkjCa1rmsSt56vv/DE2mrE77QZ6bDQh/ijVhO9jn4aIcAYcuH8AeRcGFGKcz4vuK6FZbmpJYfXRRs8/5afcFaM1tpSSq1BzpkuhHM6vddrkf67TUhUz9cWy4j1fAFJjD6FnAejCCcMe69PE8p38jm2HjL0/x848s2hrn9akAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0xMC0yN1QwODowNjowMCswMDowMNiFiREAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMTAtMjdUMDg6MDY6MDArMDA6MDCp2DGtAAAAAElFTkSuQmCC', 'Africa/Abidjan', '437884de-bfa1-416b-b142-ca8503160db3', '2022-01-15 18:04:18.507821', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.507821', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ANONYMOUS');
+      INSERT INTO public.base_person (id, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('83cb0342-a471-407e-9e84-969ccb80623d', 'MTN', '58b5bcdf-f78c-49b6-b02c-eab3e9f9f67b', '727f74c2-0c81-4dc2-aab8-b290c3000210', 'b87e85d4-0831-4c40-bfab-1b01c4fe5cc3', true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4gobCAYAArkuKAAAECZJREFUeNrtnXtwXNV9xz/n3pXsyCBZWCuTVgSwhR53BTaucdJODM60pSQOkEnqdkgGrZ1Q+p6GTqfTJJ0+JtNMm+SPpGmbkDaxjdukHdpJAiEtCZm4hHaKhRlks2vrUWzHosFa+QFGRq+9p3/87r26Wkt4tffec9eE74zH3l3vPY/f/n7n9z6KOoDj5AEF6NC72gZ1FXAd0AV0A51AB9AOtAKrgBWA5X3JBaaBSeAsMA6cBP4XGAKGgeNac0YpyvNjydjF4t60twKV1sCOk0cpjdb+FDSgWoFe4BbvTy9wDdACNEYccgZ4GSHQEeAAMAAcBX12fis0oFIjjlGC9PbuRCld+XYrsBn4JeBWhBOaDU3pFYRzngQeB55BOCsETbH4kLE9MkKQvr57cV0r/JYF9AB3AXcDNwFNxla9OC4Ah4BvAY8ARxERKBulyhQK/5j4JBIlSF9fHtdd8FYDsAXoB7YDP534CmvDi8BjwEOIaJv1P7AseP755MRZYgRxnDxag5IRbOAdwG8ghGhNbEXx4ixCmC8B/wOUkz5jYieI4+wixOkgB/PvAL8KrElkFcnjNPAvwBcQUebBoljcHetAdpwPE/U1OLRbgF8HPo8c2GmfEVHQhGh97/ZeHwWmldK0t2+kVBqMbaBYOGTduvtZuXIawBdTtwB/CtxBzESvA5SB/wD+XGsGPJGMUhcoFB6O/PDIm+U4eTKZwMZaqRT3AX+DqLJWzQ+uX1iIoXqHUrwGHAbK0EA2uyEyt0QiiOPkcV3lH9xvBf4S+BhwVdq7ZgAtwO3A1Yj98qplKdraoomwmgki50WgRd0IPAjsiPLMyxA2IgluBp7VmnEgEqfUtHk+MTzcCnwFUWt/UrEO2AoUQJ0AyGZr45RlE6SCGNuBv0fcHT/pWAu8CxgFPQKqJqIsiyC53M7wy7sRg+malDbARXxRE4hX9wzi/tCIIzINx+lqYBso37u8bKJUPekKzngP8GXMuz6mgQLwQ8SlMYoYbVPe5ysR4/MGxG64FXAQF71JvAjcD3wHQClFobCnqi9WRZCKeMVtwB4kTmEKU8D3gN3AD5ViQuuqvteGyPZdwC8iBDOF40AeeNK2FXNzLkeOXNprfEmCdHZ+iMbGjP+yD/i697cpDAJ/hXhhL0BgfPLKKxcYG1tojHV07KClpYkKgjUhIvaPEM+yKRwGPgg8D5DJuBw6tO91v3BJgoRE1dXAPuAXDC1GA/8M/DHwQviDah17FWIWRBv6C8SvZuqMeQK4F3ipmrm/7qEeWtAK5Ff6K4YW4QJ/B/y+LKQM2BSLe5d1QJZKg5RKg2SzG8lkNK6rznobdCViP5ggyjrgCm/c8qUO+SUJ0t2dx5p3fNyHWOAZzOAfgD8EzgMoFS1qVyoN0tbWh+fJmUaUgnbgZwyt50bgJVAHQbNmzQYmJhYnypK+JnueVLcAn8CcpvIEIqZelZc6lkhdofBPhDzRr3pjfN/QmlYAnwC9GRSWtTRjLsohvb153yXSDPw1QhQTeAkJYg2BHN7VaCbVolQaZO3aDX5ixSQwghi3VxhYWwvwU0jAa3op0XURQXI5ifR54up+JLhkymv7eaX0Q6Aii6mlMD4+SDZ7E94YY16q0VZD61uP/OgOKKVYu/ZmxsefW/AfLtpoX6XUmh7g9zDnLDwG7PXTggqF5DI9isV93loViE11zNAabWRPe7TWuBUJB1BBkK4uEVWWhQX8NkJRU/h2udw2AjA1lfxxJWNoJic7RoBvG1znemRvLYDu7vsWfLiAIJmMcIjr8g7gHoOTfA34jm1PAPDCC19OfEAZQ7Fq1RiIi2Mq2hOXhXvwvOO2Pbvgg4AguVy//88GJBZuMiHhR0hOFOVydT6ROGDbQaTzEHDC4HrXIHvcAAsN2IAg8ymdbAHuNDg5EG1nAmBoyFyW4OHDvjqtJ7w5mMSdyF4vgLXI637M500dR3JvU4I1483BJFqBe0FflNIZZpkeRC83jQkA1zUnrnzImDqYg2FsB9UD8zTwqBOIq7tIJ71zBsC2zceUQmOmwaEdyJ7jujIPjyAaJNp1dwqTAs8tU2WMI1aExjQdxPJxF7DasmQiVm9vIK42YzZWEEZbKA/YKEI1Km0prf0mPCen4+SFQ7yNSDPd8zqlaEyHQxRK6UbMRkDDWIXsPQCW5yZpRUKzaaELyAL09vZHfFT1CI2V9eaQFm5DjoxA7e1OeULXABtAEgJMITTWBtLLngHZ/x6YJ8gWxD2cFlYC231NY5HQa+zwucMTk9sxmwBRiRa8EIelNTbm4h2vh+2WpY0l3PncoRTdpGN7VWKLUliWUqwBcmnPBrgW2KW1+JcqkvJiheMIdzQ0zIKkCF2b9uIBR2vWWMDbqJ9av11K2VsBtNZ0d3849gHkmcIds7MNfs5WPaADuNavdUjz/AijHfgkUtqAbZfp6NgR34o7doQ9vG/1xmpPe9EeWoAuvzw5LSt1MdwGfAqvVr25uYmuruiHfFdXnubmwMxq9sZIU9WvxAqg28JsVLBa9AOfwfM623Y0zSuXy9PYGKi4rd6zzRk81WN9hnT176VgIQkWbcDHlGIY/FJrXXUmiuPsBDRay5mE6PufAt6f9gKXwNuU4+SHSNcovBSKwKeBfyPI1QI/M6VQWJiaKRrURcbllcAHkOS73rQX9DoYUo6TP0X9HGxLYQbYj2S/73dd9ZLvHV0KWtsoVb4aKaLZCWwjegObpHEqw+VRP96IFFi+CxiyLP0U8DTSbuk0kiQB8BYkXt2lVPntwDsRMdWQ9gKqxCrlOPmZy2jCYWgk+/A8kq8LoqlciXhQU2s9FQGzGcwlUMcNhaSAmkgDNYXMG7Gw/7KGBcylPYk3EWDOYl7+von0MW3h1e29ibrApMVFPQbfRIo4l0GK7uutE4OLJD9PQbidayywkejgSuqvW9GpDNI2tR5wBimBPoCUE59EbIy4E9gaEVulA0nB2YLE1Ouhg9HJDNINIU0cAx4G/hXxW00aHPtriBHpAL+MdDO6PsW9GM0g9XzTmI+JnAf2Is3Ohio/bG8/wf79+xMZeNu2bYyPX+dViulJYEBrNaCU3o2U8PUjXGQS03jOxc1IIaJJB+MI8HGt9TeUUsEZMTPTzOjoF4zuQmfn77JixStBSqlS2FrzfsRN32lwKuPA9gxSqDKGOYIcBH4TGJjP/DDTpHgx+D8Av+u21pQREXoC+CKwydBUxoATGa31aaVU0dDAh4CPAINp91ivxJEjewC/Jz1ozQFvrg8hhf9JowD6tKWUchHNJmn8GPgooklRT8QIw5+T16P+OeABvD4lCeMAqKAh+wByc0BSKAOfVoofVC68HlEo7A3OFK35PvBZ4reHwngZoUFgGB1lEU0nRvwA2O0vsp6J4cNvWuAdc19FblBICsH+W1prlFLnkBBpEphCDseXZaH1TwwfxWLAKWe9NSTliP1PrfU5pRSWUsrPyPguyRhlzxA0eUmhACQiQh2RngCeTWCISeBx0Tg1VugXe5DgwI0VjwEvu65t9GKUuCBZLRqES/49gSEG8QhdKOz1zxAX4BxykUmcOI/0psKykjwTk0YQnn+S+KXIt5C9B4JDPeDLRxADJS68iFzIdVmdHZUIzX0U+L8YHz0GPBp+wwoPqBRDxNuI5SQh6r8BcBb5kcWFR0EdhXkaLIgHaI2LWKZnYhpwglQ7NMQHSUdlGijF9MgzwL7KYvCAIErJLQdKMUAFG0XAhWJxrxv9MelD2lYpl/mkvKh4BM8YDKeQBQTxOy9rzRxy00EcrSaaHCdfb1G5mqG1togn03MC2eM5gGJxT/DBwsYnls8l6mmkYXJUrMeLK0gm+uWJnp6gcqGFeAJYX8PzH1ZWHS8gyOHDe/zUfRf4W6JHE3sJWrFefkahj1AX0c145csRMILsrQtc1BN+EXESiPwh4HNEc6pdCfwWEib1im7+LJldSwAdHTvChUJXhNdSI+aQPR0GvWhN/kUNLkulQ2SzG/2XR5FYQJSslC7kYsb/Btxs9hzt7ZsolZ5LcCujo68vT2NjkIPeCHwc+DDRMlUeRX6RM7C4bbZox1G/Pbf3xWHktrXVNU7CAn4OqesbAKZcF9rbo1+glRTkbq3gF3wVUhz6UaJVCZxAOOwEsKQbackWsG1tG33X848Rd8Ht1J4pnwF+FsnuOKyU6PLZ7EZaWzdx+vRziWzscpHL9QfSwSPGjYi87ydau9xp5GaGx0Asj6VajS85yMTEYFh0FZCYe5SODwoRfT+PWO9DQNmydM33NcWFXG4H2ay/NAWSRPchJCMmjru1HkTK8soAR44s7UZaznUVaxEr/vYYJvgaUjP4WaUYDNuqZn1eO8jlmpDCUIVlNeC6szcDf4AUhsbR/+S7CIedqmZ9lySI5DAFnSdyiA4dV6OzMSQat5eKO0Lm5mB4OBni5HK7EM1e4PXMWo90ddhJfJ0tBpELXYoAxeL1XErLrPLKowWVre/0NnBdjHs0jBD6YVBDoBeo2lqrICukVuRyO/1AXHj5Nuge5F6UDxJvHtYLyJVHTyl1BVq/WhX313op2B3IdXkdMS4AxJP6PeAbwNNKTZ7SeqHaXy7PYduXDnY5zk7vl7+oK+1q4O3A+5C7qeLu9TIG/BpyZy6SYbOnqi8uqzCygih3InHmJBrXTCNc819IgGsQOKmUPq+1WpbJrxRKa5qZb5K2FeHyG0imTHoMUW8DB+1yzsVlV6pWEOXdiFqYZIKyi7i8jyFEGvUWfQpJnLiAGJ4gdkITYjOtRTi4EzFOr0c6QyTp7DyGNNoPQr3LVVJqKh32ieJ1Et2KXPy+IcGFLoYZ788s8+4dGyFKI+abBAwiidpP+W/UojHWZOyUSoO0tweG44+QWHMnZpOTbWTT34JwRZP378Za1xUBjyO9WQ76b9Sqvtc8cd+94rouSqkSom83ISrx5Vr7vlxMIdfPPgAcn511se1oKbKRfklClE0+p0wiuUsvIuJrddq7lTCOI+6QzyB38mLbRE51iqn9xA4cZ0EgbRPwJ0hzyTcat8whiSCfVEo969s2cXkYYu0HEkrlB4mF3It4SW8wtl3JYgSJZ+wDzvvEiPMmuVgPv5DbHkQDGkAOPBcJ50YJ7qSJEnLZ5QOIsTcD4hGOkxiQYMec8A3TloXlutyCXPNzF2avU4qC00h2yIPIj8v1JUBSTtBEWxht2HAPs7ONYTGWQeLS/cB7qc/2giAJfo8ioukZQv1gZmYyjI5+JbGBjfSU6ur6CJnMfI8b10VZFl0It7wP0crSFmeTiHH3TeARUMPhJLbZWYuRkd2JT8Jok6+enn4sS1FxV8hqRCu7HWnD1405lfkcEijbj9hRB1mkksxkjCa1rmsSt56vv/DE2mrE77QZ6bDQh/ijVhO9jn4aIcAYcuH8AeRcGFGKcz4vuK6FZbmpJYfXRRs8/5afcFaM1tpSSq1BzpkuhHM6vddrkf67TUhUz9cWy4j1fAFJjD6FnAejCCcMe69PE8p38jm2HjL0/x848s2hrn9akAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0xMC0yN1QwODowNjowMCswMDowMNiFiREAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMTAtMjdUMDg6MDY6MDArMDA6MDCp2DGtAAAAAElFTkSuQmCC', 'Africa/Abidjan', '727f74c2-0c81-4dc2-aab8-b290c3000210', '2022-01-15 18:04:18.510975', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.510975', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'MTN');
+      INSERT INTO public.base_person (id, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('10dfea50-8ce4-4be2-9c4b-aa8b4daaceb3', 'Orange', '58b5bcdf-f78c-49b6-b02c-eab3e9f9f67b', 'cc034a79-45c7-431f-96f7-da13a7a2533e', 'b87e85d4-0831-4c40-bfab-1b01c4fe5cc3', true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4gobCAYAArkuKAAAECZJREFUeNrtnXtwXNV9xz/n3pXsyCBZWCuTVgSwhR53BTaucdJODM60pSQOkEnqdkgGrZ1Q+p6GTqfTJJ0+JtNMm+SPpGmbkDaxjdukHdpJAiEtCZm4hHaKhRlks2vrUWzHosFa+QFGRq+9p3/87r26Wkt4tffec9eE74zH3l3vPY/f/n7n9z6KOoDj5AEF6NC72gZ1FXAd0AV0A51AB9AOtAKrgBWA5X3JBaaBSeAsMA6cBP4XGAKGgeNac0YpyvNjydjF4t60twKV1sCOk0cpjdb+FDSgWoFe4BbvTy9wDdACNEYccgZ4GSHQEeAAMAAcBX12fis0oFIjjlGC9PbuRCld+XYrsBn4JeBWhBOaDU3pFYRzngQeB55BOCsETbH4kLE9MkKQvr57cV0r/JYF9AB3AXcDNwFNxla9OC4Ah4BvAY8ARxERKBulyhQK/5j4JBIlSF9fHtdd8FYDsAXoB7YDP534CmvDi8BjwEOIaJv1P7AseP755MRZYgRxnDxag5IRbOAdwG8ghGhNbEXx4ixCmC8B/wOUkz5jYieI4+wixOkgB/PvAL8KrElkFcnjNPAvwBcQUebBoljcHetAdpwPE/U1OLRbgF8HPo8c2GmfEVHQhGh97/ZeHwWmldK0t2+kVBqMbaBYOGTduvtZuXIawBdTtwB/CtxBzESvA5SB/wD+XGsGPJGMUhcoFB6O/PDIm+U4eTKZwMZaqRT3AX+DqLJWzQ+uX1iIoXqHUrwGHAbK0EA2uyEyt0QiiOPkcV3lH9xvBf4S+BhwVdq7ZgAtwO3A1Yj98qplKdraoomwmgki50WgRd0IPAjsiPLMyxA2IgluBp7VmnEgEqfUtHk+MTzcCnwFUWt/UrEO2AoUQJ0AyGZr45RlE6SCGNuBv0fcHT/pWAu8CxgFPQKqJqIsiyC53M7wy7sRg+malDbARXxRE4hX9wzi/tCIIzINx+lqYBso37u8bKJUPekKzngP8GXMuz6mgQLwQ8SlMYoYbVPe5ysR4/MGxG64FXAQF71JvAjcD3wHQClFobCnqi9WRZCKeMVtwB4kTmEKU8D3gN3AD5ViQuuqvteGyPZdwC8iBDOF40AeeNK2FXNzLkeOXNprfEmCdHZ+iMbGjP+yD/i697cpDAJ/hXhhL0BgfPLKKxcYG1tojHV07KClpYkKgjUhIvaPEM+yKRwGPgg8D5DJuBw6tO91v3BJgoRE1dXAPuAXDC1GA/8M/DHwQviDah17FWIWRBv6C8SvZuqMeQK4F3ipmrm/7qEeWtAK5Ff6K4YW4QJ/B/y+LKQM2BSLe5d1QJZKg5RKg2SzG8lkNK6rznobdCViP5ggyjrgCm/c8qUO+SUJ0t2dx5p3fNyHWOAZzOAfgD8EzgMoFS1qVyoN0tbWh+fJmUaUgnbgZwyt50bgJVAHQbNmzQYmJhYnypK+JnueVLcAn8CcpvIEIqZelZc6lkhdofBPhDzRr3pjfN/QmlYAnwC9GRSWtTRjLsohvb153yXSDPw1QhQTeAkJYg2BHN7VaCbVolQaZO3aDX5ixSQwghi3VxhYWwvwU0jAa3op0XURQXI5ifR54up+JLhkymv7eaX0Q6Aii6mlMD4+SDZ7E94YY16q0VZD61uP/OgOKKVYu/ZmxsefW/AfLtpoX6XUmh7g9zDnLDwG7PXTggqF5DI9isV93loViE11zNAabWRPe7TWuBUJB1BBkK4uEVWWhQX8NkJRU/h2udw2AjA1lfxxJWNoJic7RoBvG1znemRvLYDu7vsWfLiAIJmMcIjr8g7gHoOTfA34jm1PAPDCC19OfEAZQ7Fq1RiIi2Mq2hOXhXvwvOO2Pbvgg4AguVy//88GJBZuMiHhR0hOFOVydT6ROGDbQaTzEHDC4HrXIHvcAAsN2IAg8ymdbAHuNDg5EG1nAmBoyFyW4OHDvjqtJ7w5mMSdyF4vgLXI637M500dR3JvU4I1483BJFqBe0FflNIZZpkeRC83jQkA1zUnrnzImDqYg2FsB9UD8zTwqBOIq7tIJ71zBsC2zceUQmOmwaEdyJ7jujIPjyAaJNp1dwqTAs8tU2WMI1aExjQdxPJxF7DasmQiVm9vIK42YzZWEEZbKA/YKEI1Km0prf0mPCen4+SFQ7yNSDPd8zqlaEyHQxRK6UbMRkDDWIXsPQCW5yZpRUKzaaELyAL09vZHfFT1CI2V9eaQFm5DjoxA7e1OeULXABtAEgJMITTWBtLLngHZ/x6YJ8gWxD2cFlYC231NY5HQa+zwucMTk9sxmwBRiRa8EIelNTbm4h2vh+2WpY0l3PncoRTdpGN7VWKLUliWUqwBcmnPBrgW2KW1+JcqkvJiheMIdzQ0zIKkCF2b9uIBR2vWWMDbqJ9av11K2VsBtNZ0d3849gHkmcIds7MNfs5WPaADuNavdUjz/AijHfgkUtqAbZfp6NgR34o7doQ9vG/1xmpPe9EeWoAuvzw5LSt1MdwGfAqvVr25uYmuruiHfFdXnubmwMxq9sZIU9WvxAqg28JsVLBa9AOfwfM623Y0zSuXy9PYGKi4rd6zzRk81WN9hnT176VgIQkWbcDHlGIY/FJrXXUmiuPsBDRay5mE6PufAt6f9gKXwNuU4+SHSNcovBSKwKeBfyPI1QI/M6VQWJiaKRrURcbllcAHkOS73rQX9DoYUo6TP0X9HGxLYQbYj2S/73dd9ZLvHV0KWtsoVb4aKaLZCWwjegObpHEqw+VRP96IFFi+CxiyLP0U8DTSbuk0kiQB8BYkXt2lVPntwDsRMdWQ9gKqxCrlOPmZy2jCYWgk+/A8kq8LoqlciXhQU2s9FQGzGcwlUMcNhaSAmkgDNYXMG7Gw/7KGBcylPYk3EWDOYl7+von0MW3h1e29ibrApMVFPQbfRIo4l0GK7uutE4OLJD9PQbidayywkejgSuqvW9GpDNI2tR5wBimBPoCUE59EbIy4E9gaEVulA0nB2YLE1Ouhg9HJDNINIU0cAx4G/hXxW00aHPtriBHpAL+MdDO6PsW9GM0g9XzTmI+JnAf2Is3Ohio/bG8/wf79+xMZeNu2bYyPX+dViulJYEBrNaCU3o2U8PUjXGQS03jOxc1IIaJJB+MI8HGt9TeUUsEZMTPTzOjoF4zuQmfn77JixStBSqlS2FrzfsRN32lwKuPA9gxSqDKGOYIcBH4TGJjP/DDTpHgx+D8Av+u21pQREXoC+CKwydBUxoATGa31aaVU0dDAh4CPAINp91ivxJEjewC/Jz1ozQFvrg8hhf9JowD6tKWUchHNJmn8GPgooklRT8QIw5+T16P+OeABvD4lCeMAqKAh+wByc0BSKAOfVoofVC68HlEo7A3OFK35PvBZ4reHwngZoUFgGB1lEU0nRvwA2O0vsp6J4cNvWuAdc19FblBICsH+W1prlFLnkBBpEphCDseXZaH1TwwfxWLAKWe9NSTliP1PrfU5pRSWUsrPyPguyRhlzxA0eUmhACQiQh2RngCeTWCISeBx0Tg1VugXe5DgwI0VjwEvu65t9GKUuCBZLRqES/49gSEG8QhdKOz1zxAX4BxykUmcOI/0psKykjwTk0YQnn+S+KXIt5C9B4JDPeDLRxADJS68iFzIdVmdHZUIzX0U+L8YHz0GPBp+wwoPqBRDxNuI5SQh6r8BcBb5kcWFR0EdhXkaLIgHaI2LWKZnYhpwglQ7NMQHSUdlGijF9MgzwL7KYvCAIErJLQdKMUAFG0XAhWJxrxv9MelD2lYpl/mkvKh4BM8YDKeQBQTxOy9rzRxy00EcrSaaHCdfb1G5mqG1togn03MC2eM5gGJxT/DBwsYnls8l6mmkYXJUrMeLK0gm+uWJnp6gcqGFeAJYX8PzH1ZWHS8gyOHDe/zUfRf4W6JHE3sJWrFefkahj1AX0c145csRMILsrQtc1BN+EXESiPwh4HNEc6pdCfwWEib1im7+LJldSwAdHTvChUJXhNdSI+aQPR0GvWhN/kUNLkulQ2SzG/2XR5FYQJSslC7kYsb/Btxs9hzt7ZsolZ5LcCujo68vT2NjkIPeCHwc+DDRMlUeRX6RM7C4bbZox1G/Pbf3xWHktrXVNU7CAn4OqesbAKZcF9rbo1+glRTkbq3gF3wVUhz6UaJVCZxAOOwEsKQbackWsG1tG33X848Rd8Ht1J4pnwF+FsnuOKyU6PLZ7EZaWzdx+vRziWzscpHL9QfSwSPGjYi87ydau9xp5GaGx0Asj6VajS85yMTEYFh0FZCYe5SODwoRfT+PWO9DQNmydM33NcWFXG4H2ay/NAWSRPchJCMmjru1HkTK8soAR44s7UZaznUVaxEr/vYYJvgaUjP4WaUYDNuqZn1eO8jlmpDCUIVlNeC6szcDf4AUhsbR/+S7CIedqmZ9lySI5DAFnSdyiA4dV6OzMSQat5eKO0Lm5mB4OBni5HK7EM1e4PXMWo90ddhJfJ0tBpELXYoAxeL1XErLrPLKowWVre/0NnBdjHs0jBD6YVBDoBeo2lqrICukVuRyO/1AXHj5Nuge5F6UDxJvHtYLyJVHTyl1BVq/WhX313op2B3IdXkdMS4AxJP6PeAbwNNKTZ7SeqHaXy7PYduXDnY5zk7vl7+oK+1q4O3A+5C7qeLu9TIG/BpyZy6SYbOnqi8uqzCygih3InHmJBrXTCNc819IgGsQOKmUPq+1WpbJrxRKa5qZb5K2FeHyG0imTHoMUW8DB+1yzsVlV6pWEOXdiFqYZIKyi7i8jyFEGvUWfQpJnLiAGJ4gdkITYjOtRTi4EzFOr0c6QyTp7DyGNNoPQr3LVVJqKh32ieJ1Et2KXPy+IcGFLoYZ788s8+4dGyFKI+abBAwiidpP+W/UojHWZOyUSoO0tweG44+QWHMnZpOTbWTT34JwRZP378Za1xUBjyO9WQ76b9Sqvtc8cd+94rouSqkSom83ISrx5Vr7vlxMIdfPPgAcn511se1oKbKRfklClE0+p0wiuUsvIuJrddq7lTCOI+6QzyB38mLbRE51iqn9xA4cZ0EgbRPwJ0hzyTcat8whiSCfVEo969s2cXkYYu0HEkrlB4mF3It4SW8wtl3JYgSJZ+wDzvvEiPMmuVgPv5DbHkQDGkAOPBcJ50YJ7qSJEnLZ5QOIsTcD4hGOkxiQYMec8A3TloXlutyCXPNzF2avU4qC00h2yIPIj8v1JUBSTtBEWxht2HAPs7ONYTGWQeLS/cB7qc/2giAJfo8ioukZQv1gZmYyjI5+JbGBjfSU6ur6CJnMfI8b10VZFl0It7wP0crSFmeTiHH3TeARUMPhJLbZWYuRkd2JT8Jok6+enn4sS1FxV8hqRCu7HWnD1405lfkcEijbj9hRB1mkksxkjCa1rmsSt56vv/DE2mrE77QZ6bDQh/ijVhO9jn4aIcAYcuH8AeRcGFGKcz4vuK6FZbmpJYfXRRs8/5afcFaM1tpSSq1BzpkuhHM6vddrkf67TUhUz9cWy4j1fAFJjD6FnAejCCcMe69PE8p38jm2HjL0/x848s2hrn9akAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0xMC0yN1QwODowNjowMCswMDowMNiFiREAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMTAtMjdUMDg6MDY6MDArMDA6MDCp2DGtAAAAAElFTkSuQmCC', 'Africa/Abidjan', 'cc034a79-45c7-431f-96f7-da13a7a2533e', '2022-01-15 18:04:18.513508', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.513508', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ORANGE');
+      INSERT INTO public.base_person (id, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('3217cea9-4670-4869-b0ae-3dfa28000e6e', 'Moov', '58b5bcdf-f78c-49b6-b02c-eab3e9f9f67b', 'b38ec4eb-adbe-48fb-8432-f4779a625048', 'b87e85d4-0831-4c40-bfab-1b01c4fe5cc3', true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4gobCAYAArkuKAAAECZJREFUeNrtnXtwXNV9xz/n3pXsyCBZWCuTVgSwhR53BTaucdJODM60pSQOkEnqdkgGrZ1Q+p6GTqfTJJ0+JtNMm+SPpGmbkDaxjdukHdpJAiEtCZm4hHaKhRlks2vrUWzHosFa+QFGRq+9p3/87r26Wkt4tffec9eE74zH3l3vPY/f/n7n9z6KOoDj5AEF6NC72gZ1FXAd0AV0A51AB9AOtAKrgBWA5X3JBaaBSeAsMA6cBP4XGAKGgeNac0YpyvNjydjF4t60twKV1sCOk0cpjdb+FDSgWoFe4BbvTy9wDdACNEYccgZ4GSHQEeAAMAAcBX12fis0oFIjjlGC9PbuRCld+XYrsBn4JeBWhBOaDU3pFYRzngQeB55BOCsETbH4kLE9MkKQvr57cV0r/JYF9AB3AXcDNwFNxla9OC4Ah4BvAY8ARxERKBulyhQK/5j4JBIlSF9fHtdd8FYDsAXoB7YDP534CmvDi8BjwEOIaJv1P7AseP755MRZYgRxnDxag5IRbOAdwG8ghGhNbEXx4ixCmC8B/wOUkz5jYieI4+wixOkgB/PvAL8KrElkFcnjNPAvwBcQUebBoljcHetAdpwPE/U1OLRbgF8HPo8c2GmfEVHQhGh97/ZeHwWmldK0t2+kVBqMbaBYOGTduvtZuXIawBdTtwB/CtxBzESvA5SB/wD+XGsGPJGMUhcoFB6O/PDIm+U4eTKZwMZaqRT3AX+DqLJWzQ+uX1iIoXqHUrwGHAbK0EA2uyEyt0QiiOPkcV3lH9xvBf4S+BhwVdq7ZgAtwO3A1Yj98qplKdraoomwmgki50WgRd0IPAjsiPLMyxA2IgluBp7VmnEgEqfUtHk+MTzcCnwFUWt/UrEO2AoUQJ0AyGZr45RlE6SCGNuBv0fcHT/pWAu8CxgFPQKqJqIsiyC53M7wy7sRg+malDbARXxRE4hX9wzi/tCIIzINx+lqYBso37u8bKJUPekKzngP8GXMuz6mgQLwQ8SlMYoYbVPe5ysR4/MGxG64FXAQF71JvAjcD3wHQClFobCnqi9WRZCKeMVtwB4kTmEKU8D3gN3AD5ViQuuqvteGyPZdwC8iBDOF40AeeNK2FXNzLkeOXNprfEmCdHZ+iMbGjP+yD/i697cpDAJ/hXhhL0BgfPLKKxcYG1tojHV07KClpYkKgjUhIvaPEM+yKRwGPgg8D5DJuBw6tO91v3BJgoRE1dXAPuAXDC1GA/8M/DHwQviDah17FWIWRBv6C8SvZuqMeQK4F3ipmrm/7qEeWtAK5Ff6K4YW4QJ/B/y+LKQM2BSLe5d1QJZKg5RKg2SzG8lkNK6rznobdCViP5ggyjrgCm/c8qUO+SUJ0t2dx5p3fNyHWOAZzOAfgD8EzgMoFS1qVyoN0tbWh+fJmUaUgnbgZwyt50bgJVAHQbNmzQYmJhYnypK+JnueVLcAn8CcpvIEIqZelZc6lkhdofBPhDzRr3pjfN/QmlYAnwC9GRSWtTRjLsohvb153yXSDPw1QhQTeAkJYg2BHN7VaCbVolQaZO3aDX5ixSQwghi3VxhYWwvwU0jAa3op0XURQXI5ifR54up+JLhkymv7eaX0Q6Aii6mlMD4+SDZ7E94YY16q0VZD61uP/OgOKKVYu/ZmxsefW/AfLtpoX6XUmh7g9zDnLDwG7PXTggqF5DI9isV93loViE11zNAabWRPe7TWuBUJB1BBkK4uEVWWhQX8NkJRU/h2udw2AjA1lfxxJWNoJic7RoBvG1znemRvLYDu7vsWfLiAIJmMcIjr8g7gHoOTfA34jm1PAPDCC19OfEAZQ7Fq1RiIi2Mq2hOXhXvwvOO2Pbvgg4AguVy//88GJBZuMiHhR0hOFOVydT6ROGDbQaTzEHDC4HrXIHvcAAsN2IAg8ymdbAHuNDg5EG1nAmBoyFyW4OHDvjqtJ7w5mMSdyF4vgLXI637M500dR3JvU4I1483BJFqBe0FflNIZZpkeRC83jQkA1zUnrnzImDqYg2FsB9UD8zTwqBOIq7tIJ71zBsC2zceUQmOmwaEdyJ7jujIPjyAaJNp1dwqTAs8tU2WMI1aExjQdxPJxF7DasmQiVm9vIK42YzZWEEZbKA/YKEI1Km0prf0mPCen4+SFQ7yNSDPd8zqlaEyHQxRK6UbMRkDDWIXsPQCW5yZpRUKzaaELyAL09vZHfFT1CI2V9eaQFm5DjoxA7e1OeULXABtAEgJMITTWBtLLngHZ/x6YJ8gWxD2cFlYC231NY5HQa+zwucMTk9sxmwBRiRa8EIelNTbm4h2vh+2WpY0l3PncoRTdpGN7VWKLUliWUqwBcmnPBrgW2KW1+JcqkvJiheMIdzQ0zIKkCF2b9uIBR2vWWMDbqJ9av11K2VsBtNZ0d3849gHkmcIds7MNfs5WPaADuNavdUjz/AijHfgkUtqAbZfp6NgR34o7doQ9vG/1xmpPe9EeWoAuvzw5LSt1MdwGfAqvVr25uYmuruiHfFdXnubmwMxq9sZIU9WvxAqg28JsVLBa9AOfwfM623Y0zSuXy9PYGKi4rd6zzRk81WN9hnT176VgIQkWbcDHlGIY/FJrXXUmiuPsBDRay5mE6PufAt6f9gKXwNuU4+SHSNcovBSKwKeBfyPI1QI/M6VQWJiaKRrURcbllcAHkOS73rQX9DoYUo6TP0X9HGxLYQbYj2S/73dd9ZLvHV0KWtsoVb4aKaLZCWwjegObpHEqw+VRP96IFFi+CxiyLP0U8DTSbuk0kiQB8BYkXt2lVPntwDsRMdWQ9gKqxCrlOPmZy2jCYWgk+/A8kq8LoqlciXhQU2s9FQGzGcwlUMcNhaSAmkgDNYXMG7Gw/7KGBcylPYk3EWDOYl7+von0MW3h1e29ibrApMVFPQbfRIo4l0GK7uutE4OLJD9PQbidayywkejgSuqvW9GpDNI2tR5wBimBPoCUE59EbIy4E9gaEVulA0nB2YLE1Ouhg9HJDNINIU0cAx4G/hXxW00aHPtriBHpAL+MdDO6PsW9GM0g9XzTmI+JnAf2Is3Ohio/bG8/wf79+xMZeNu2bYyPX+dViulJYEBrNaCU3o2U8PUjXGQS03jOxc1IIaJJB+MI8HGt9TeUUsEZMTPTzOjoF4zuQmfn77JixStBSqlS2FrzfsRN32lwKuPA9gxSqDKGOYIcBH4TGJjP/DDTpHgx+D8Av+u21pQREXoC+CKwydBUxoATGa31aaVU0dDAh4CPAINp91ivxJEjewC/Jz1ozQFvrg8hhf9JowD6tKWUchHNJmn8GPgooklRT8QIw5+T16P+OeABvD4lCeMAqKAh+wByc0BSKAOfVoofVC68HlEo7A3OFK35PvBZ4reHwngZoUFgGB1lEU0nRvwA2O0vsp6J4cNvWuAdc19FblBICsH+W1prlFLnkBBpEphCDseXZaH1TwwfxWLAKWe9NSTliP1PrfU5pRSWUsrPyPguyRhlzxA0eUmhACQiQh2RngCeTWCISeBx0Tg1VugXe5DgwI0VjwEvu65t9GKUuCBZLRqES/49gSEG8QhdKOz1zxAX4BxykUmcOI/0psKykjwTk0YQnn+S+KXIt5C9B4JDPeDLRxADJS68iFzIdVmdHZUIzX0U+L8YHz0GPBp+wwoPqBRDxNuI5SQh6r8BcBb5kcWFR0EdhXkaLIgHaI2LWKZnYhpwglQ7NMQHSUdlGijF9MgzwL7KYvCAIErJLQdKMUAFG0XAhWJxrxv9MelD2lYpl/mkvKh4BM8YDKeQBQTxOy9rzRxy00EcrSaaHCdfb1G5mqG1togn03MC2eM5gGJxT/DBwsYnls8l6mmkYXJUrMeLK0gm+uWJnp6gcqGFeAJYX8PzH1ZWHS8gyOHDe/zUfRf4W6JHE3sJWrFefkahj1AX0c145csRMILsrQtc1BN+EXESiPwh4HNEc6pdCfwWEib1im7+LJldSwAdHTvChUJXhNdSI+aQPR0GvWhN/kUNLkulQ2SzG/2XR5FYQJSslC7kYsb/Btxs9hzt7ZsolZ5LcCujo68vT2NjkIPeCHwc+DDRMlUeRX6RM7C4bbZox1G/Pbf3xWHktrXVNU7CAn4OqesbAKZcF9rbo1+glRTkbq3gF3wVUhz6UaJVCZxAOOwEsKQbackWsG1tG33X848Rd8Ht1J4pnwF+FsnuOKyU6PLZ7EZaWzdx+vRziWzscpHL9QfSwSPGjYi87ydau9xp5GaGx0Asj6VajS85yMTEYFh0FZCYe5SODwoRfT+PWO9DQNmydM33NcWFXG4H2ay/NAWSRPchJCMmjru1HkTK8soAR44s7UZaznUVaxEr/vYYJvgaUjP4WaUYDNuqZn1eO8jlmpDCUIVlNeC6szcDf4AUhsbR/+S7CIedqmZ9lySI5DAFnSdyiA4dV6OzMSQat5eKO0Lm5mB4OBni5HK7EM1e4PXMWo90ddhJfJ0tBpELXYoAxeL1XErLrPLKowWVre/0NnBdjHs0jBD6YVBDoBeo2lqrICukVuRyO/1AXHj5Nuge5F6UDxJvHtYLyJVHTyl1BVq/WhX313op2B3IdXkdMS4AxJP6PeAbwNNKTZ7SeqHaXy7PYduXDnY5zk7vl7+oK+1q4O3A+5C7qeLu9TIG/BpyZy6SYbOnqi8uqzCygih3InHmJBrXTCNc819IgGsQOKmUPq+1WpbJrxRKa5qZb5K2FeHyG0imTHoMUW8DB+1yzsVlV6pWEOXdiFqYZIKyi7i8jyFEGvUWfQpJnLiAGJ4gdkITYjOtRTi4EzFOr0c6QyTp7DyGNNoPQr3LVVJqKh32ieJ1Et2KXPy+IcGFLoYZ788s8+4dGyFKI+abBAwiidpP+W/UojHWZOyUSoO0tweG44+QWHMnZpOTbWTT34JwRZP378Za1xUBjyO9WQ76b9Sqvtc8cd+94rouSqkSom83ISrx5Vr7vlxMIdfPPgAcn511se1oKbKRfklClE0+p0wiuUsvIuJrddq7lTCOI+6QzyB38mLbRE51iqn9xA4cZ0EgbRPwJ0hzyTcat8whiSCfVEo969s2cXkYYu0HEkrlB4mF3It4SW8wtl3JYgSJZ+wDzvvEiPMmuVgPv5DbHkQDGkAOPBcJ50YJ7qSJEnLZ5QOIsTcD4hGOkxiQYMec8A3TloXlutyCXPNzF2avU4qC00h2yIPIj8v1JUBSTtBEWxht2HAPs7ONYTGWQeLS/cB7qc/2giAJfo8ioukZQv1gZmYyjI5+JbGBjfSU6ur6CJnMfI8b10VZFl0It7wP0crSFmeTiHH3TeARUMPhJLbZWYuRkd2JT8Jok6+enn4sS1FxV8hqRCu7HWnD1405lfkcEijbj9hRB1mkksxkjCa1rmsSt56vv/DE2mrE77QZ6bDQh/ijVhO9jn4aIcAYcuH8AeRcGFGKcz4vuK6FZbmpJYfXRRs8/5afcFaM1tpSSq1BzpkuhHM6vddrkf67TUhUz9cWy4j1fAFJjD6FnAejCCcMe69PE8p38jm2HjL0/x848s2hrn9akAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0xMC0yN1QwODowNjowMCswMDowMNiFiREAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMTAtMjdUMDg6MDY6MDArMDA6MDCp2DGtAAAAAElFTkSuQmCC', 'Africa/Abidjan', 'b38ec4eb-adbe-48fb-8432-f4779a625048', '2022-01-15 18:04:18.516155', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.516155', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'MOOV');
+      INSERT INTO public.base_person (id, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('f3e5436a-1e38-43e5-b9c0-a3105a900673', 'Orabank', '58b5bcdf-f78c-49b6-b02c-eab3e9f9f67b', 'c35142bd-4a15-4176-b8f9-ef9ef13b6e21', 'b87e85d4-0831-4c40-bfab-1b01c4fe5cc3', true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4gobCAYAArkuKAAAECZJREFUeNrtnXtwXNV9xz/n3pXsyCBZWCuTVgSwhR53BTaucdJODM60pSQOkEnqdkgGrZ1Q+p6GTqfTJJ0+JtNMm+SPpGmbkDaxjdukHdpJAiEtCZm4hHaKhRlks2vrUWzHosFa+QFGRq+9p3/87r26Wkt4tffec9eE74zH3l3vPY/f/n7n9z6KOoDj5AEF6NC72gZ1FXAd0AV0A51AB9AOtAKrgBWA5X3JBaaBSeAsMA6cBP4XGAKGgeNac0YpyvNjydjF4t60twKV1sCOk0cpjdb+FDSgWoFe4BbvTy9wDdACNEYccgZ4GSHQEeAAMAAcBX12fis0oFIjjlGC9PbuRCld+XYrsBn4JeBWhBOaDU3pFYRzngQeB55BOCsETbH4kLE9MkKQvr57cV0r/JYF9AB3AXcDNwFNxla9OC4Ah4BvAY8ARxERKBulyhQK/5j4JBIlSF9fHtdd8FYDsAXoB7YDP534CmvDi8BjwEOIaJv1P7AseP755MRZYgRxnDxag5IRbOAdwG8ghGhNbEXx4ixCmC8B/wOUkz5jYieI4+wixOkgB/PvAL8KrElkFcnjNPAvwBcQUebBoljcHetAdpwPE/U1OLRbgF8HPo8c2GmfEVHQhGh97/ZeHwWmldK0t2+kVBqMbaBYOGTduvtZuXIawBdTtwB/CtxBzESvA5SB/wD+XGsGPJGMUhcoFB6O/PDIm+U4eTKZwMZaqRT3AX+DqLJWzQ+uX1iIoXqHUrwGHAbK0EA2uyEyt0QiiOPkcV3lH9xvBf4S+BhwVdq7ZgAtwO3A1Yj98qplKdraoomwmgki50WgRd0IPAjsiPLMyxA2IgluBp7VmnEgEqfUtHk+MTzcCnwFUWt/UrEO2AoUQJ0AyGZr45RlE6SCGNuBv0fcHT/pWAu8CxgFPQKqJqIsiyC53M7wy7sRg+malDbARXxRE4hX9wzi/tCIIzINx+lqYBso37u8bKJUPekKzngP8GXMuz6mgQLwQ8SlMYoYbVPe5ysR4/MGxG64FXAQF71JvAjcD3wHQClFobCnqi9WRZCKeMVtwB4kTmEKU8D3gN3AD5ViQuuqvteGyPZdwC8iBDOF40AeeNK2FXNzLkeOXNprfEmCdHZ+iMbGjP+yD/i697cpDAJ/hXhhL0BgfPLKKxcYG1tojHV07KClpYkKgjUhIvaPEM+yKRwGPgg8D5DJuBw6tO91v3BJgoRE1dXAPuAXDC1GA/8M/DHwQviDah17FWIWRBv6C8SvZuqMeQK4F3ipmrm/7qEeWtAK5Ff6K4YW4QJ/B/y+LKQM2BSLe5d1QJZKg5RKg2SzG8lkNK6rznobdCViP5ggyjrgCm/c8qUO+SUJ0t2dx5p3fNyHWOAZzOAfgD8EzgMoFS1qVyoN0tbWh+fJmUaUgnbgZwyt50bgJVAHQbNmzQYmJhYnypK+JnueVLcAn8CcpvIEIqZelZc6lkhdofBPhDzRr3pjfN/QmlYAnwC9GRSWtTRjLsohvb153yXSDPw1QhQTeAkJYg2BHN7VaCbVolQaZO3aDX5ixSQwghi3VxhYWwvwU0jAa3op0XURQXI5ifR54up+JLhkymv7eaX0Q6Aii6mlMD4+SDZ7E94YY16q0VZD61uP/OgOKKVYu/ZmxsefW/AfLtpoX6XUmh7g9zDnLDwG7PXTggqF5DI9isV93loViE11zNAabWRPe7TWuBUJB1BBkK4uEVWWhQX8NkJRU/h2udw2AjA1lfxxJWNoJic7RoBvG1znemRvLYDu7vsWfLiAIJmMcIjr8g7gHoOTfA34jm1PAPDCC19OfEAZQ7Fq1RiIi2Mq2hOXhXvwvOO2Pbvgg4AguVy//88GJBZuMiHhR0hOFOVydT6ROGDbQaTzEHDC4HrXIHvcAAsN2IAg8ymdbAHuNDg5EG1nAmBoyFyW4OHDvjqtJ7w5mMSdyF4vgLXI637M500dR3JvU4I1483BJFqBe0FflNIZZpkeRC83jQkA1zUnrnzImDqYg2FsB9UD8zTwqBOIq7tIJ71zBsC2zceUQmOmwaEdyJ7jujIPjyAaJNp1dwqTAs8tU2WMI1aExjQdxPJxF7DasmQiVm9vIK42YzZWEEZbKA/YKEI1Km0prf0mPCen4+SFQ7yNSDPd8zqlaEyHQxRK6UbMRkDDWIXsPQCW5yZpRUKzaaELyAL09vZHfFT1CI2V9eaQFm5DjoxA7e1OeULXABtAEgJMITTWBtLLngHZ/x6YJ8gWxD2cFlYC231NY5HQa+zwucMTk9sxmwBRiRa8EIelNTbm4h2vh+2WpY0l3PncoRTdpGN7VWKLUliWUqwBcmnPBrgW2KW1+JcqkvJiheMIdzQ0zIKkCF2b9uIBR2vWWMDbqJ9av11K2VsBtNZ0d3849gHkmcIds7MNfs5WPaADuNavdUjz/AijHfgkUtqAbZfp6NgR34o7doQ9vG/1xmpPe9EeWoAuvzw5LSt1MdwGfAqvVr25uYmuruiHfFdXnubmwMxq9sZIU9WvxAqg28JsVLBa9AOfwfM623Y0zSuXy9PYGKi4rd6zzRk81WN9hnT176VgIQkWbcDHlGIY/FJrXXUmiuPsBDRay5mE6PufAt6f9gKXwNuU4+SHSNcovBSKwKeBfyPI1QI/M6VQWJiaKRrURcbllcAHkOS73rQX9DoYUo6TP0X9HGxLYQbYj2S/73dd9ZLvHV0KWtsoVb4aKaLZCWwjegObpHEqw+VRP96IFFi+CxiyLP0U8DTSbuk0kiQB8BYkXt2lVPntwDsRMdWQ9gKqxCrlOPmZy2jCYWgk+/A8kq8LoqlciXhQU2s9FQGzGcwlUMcNhaSAmkgDNYXMG7Gw/7KGBcylPYk3EWDOYl7+von0MW3h1e29ibrApMVFPQbfRIo4l0GK7uutE4OLJD9PQbidayywkejgSuqvW9GpDNI2tR5wBimBPoCUE59EbIy4E9gaEVulA0nB2YLE1Ouhg9HJDNINIU0cAx4G/hXxW00aHPtriBHpAL+MdDO6PsW9GM0g9XzTmI+JnAf2Is3Ohio/bG8/wf79+xMZeNu2bYyPX+dViulJYEBrNaCU3o2U8PUjXGQS03jOxc1IIaJJB+MI8HGt9TeUUsEZMTPTzOjoF4zuQmfn77JixStBSqlS2FrzfsRN32lwKuPA9gxSqDKGOYIcBH4TGJjP/DDTpHgx+D8Av+u21pQREXoC+CKwydBUxoATGa31aaVU0dDAh4CPAINp91ivxJEjewC/Jz1ozQFvrg8hhf9JowD6tKWUchHNJmn8GPgooklRT8QIw5+T16P+OeABvD4lCeMAqKAh+wByc0BSKAOfVoofVC68HlEo7A3OFK35PvBZ4reHwngZoUFgGB1lEU0nRvwA2O0vsp6J4cNvWuAdc19FblBICsH+W1prlFLnkBBpEphCDseXZaH1TwwfxWLAKWe9NSTliP1PrfU5pRSWUsrPyPguyRhlzxA0eUmhACQiQh2RngCeTWCISeBx0Tg1VugXe5DgwI0VjwEvu65t9GKUuCBZLRqES/49gSEG8QhdKOz1zxAX4BxykUmcOI/0psKykjwTk0YQnn+S+KXIt5C9B4JDPeDLRxADJS68iFzIdVmdHZUIzX0U+L8YHz0GPBp+wwoPqBRDxNuI5SQh6r8BcBb5kcWFR0EdhXkaLIgHaI2LWKZnYhpwglQ7NMQHSUdlGijF9MgzwL7KYvCAIErJLQdKMUAFG0XAhWJxrxv9MelD2lYpl/mkvKh4BM8YDKeQBQTxOy9rzRxy00EcrSaaHCdfb1G5mqG1togn03MC2eM5gGJxT/DBwsYnls8l6mmkYXJUrMeLK0gm+uWJnp6gcqGFeAJYX8PzH1ZWHS8gyOHDe/zUfRf4W6JHE3sJWrFefkahj1AX0c145csRMILsrQtc1BN+EXESiPwh4HNEc6pdCfwWEib1im7+LJldSwAdHTvChUJXhNdSI+aQPR0GvWhN/kUNLkulQ2SzG/2XR5FYQJSslC7kYsb/Btxs9hzt7ZsolZ5LcCujo68vT2NjkIPeCHwc+DDRMlUeRX6RM7C4bbZox1G/Pbf3xWHktrXVNU7CAn4OqesbAKZcF9rbo1+glRTkbq3gF3wVUhz6UaJVCZxAOOwEsKQbackWsG1tG33X848Rd8Ht1J4pnwF+FsnuOKyU6PLZ7EZaWzdx+vRziWzscpHL9QfSwSPGjYi87ydau9xp5GaGx0Asj6VajS85yMTEYFh0FZCYe5SODwoRfT+PWO9DQNmydM33NcWFXG4H2ay/NAWSRPchJCMmjru1HkTK8soAR44s7UZaznUVaxEr/vYYJvgaUjP4WaUYDNuqZn1eO8jlmpDCUIVlNeC6szcDf4AUhsbR/+S7CIedqmZ9lySI5DAFnSdyiA4dV6OzMSQat5eKO0Lm5mB4OBni5HK7EM1e4PXMWo90ddhJfJ0tBpELXYoAxeL1XErLrPLKowWVre/0NnBdjHs0jBD6YVBDoBeo2lqrICukVuRyO/1AXHj5Nuge5F6UDxJvHtYLyJVHTyl1BVq/WhX313op2B3IdXkdMS4AxJP6PeAbwNNKTZ7SeqHaXy7PYduXDnY5zk7vl7+oK+1q4O3A+5C7qeLu9TIG/BpyZy6SYbOnqi8uqzCygih3InHmJBrXTCNc819IgGsQOKmUPq+1WpbJrxRKa5qZb5K2FeHyG0imTHoMUW8DB+1yzsVlV6pWEOXdiFqYZIKyi7i8jyFEGvUWfQpJnLiAGJ4gdkITYjOtRTi4EzFOr0c6QyTp7DyGNNoPQr3LVVJqKh32ieJ1Et2KXPy+IcGFLoYZ788s8+4dGyFKI+abBAwiidpP+W/UojHWZOyUSoO0tweG44+QWHMnZpOTbWTT34JwRZP378Za1xUBjyO9WQ76b9Sqvtc8cd+94rouSqkSom83ISrx5Vr7vlxMIdfPPgAcn511se1oKbKRfklClE0+p0wiuUsvIuJrddq7lTCOI+6QzyB38mLbRE51iqn9xA4cZ0EgbRPwJ0hzyTcat8whiSCfVEo969s2cXkYYu0HEkrlB4mF3It4SW8wtl3JYgSJZ+wDzvvEiPMmuVgPv5DbHkQDGkAOPBcJ50YJ7qSJEnLZ5QOIsTcD4hGOkxiQYMec8A3TloXlutyCXPNzF2avU4qC00h2yIPIj8v1JUBSTtBEWxht2HAPs7ONYTGWQeLS/cB7qc/2giAJfo8ioukZQv1gZmYyjI5+JbGBjfSU6ur6CJnMfI8b10VZFl0It7wP0crSFmeTiHH3TeARUMPhJLbZWYuRkd2JT8Jok6+enn4sS1FxV8hqRCu7HWnD1405lfkcEijbj9hRB1mkksxkjCa1rmsSt56vv/DE2mrE77QZ6bDQh/ijVhO9jn4aIcAYcuH8AeRcGFGKcz4vuK6FZbmpJYfXRRs8/5afcFaM1tpSSq1BzpkuhHM6vddrkf67TUhUz9cWy4j1fAFJjD6FnAejCCcMe69PE8p38jm2HjL0/x848s2hrn9akAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0xMC0yN1QwODowNjowMCswMDowMNiFiREAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMTAtMjdUMDg6MDY6MDArMDA6MDCp2DGtAAAAAElFTkSuQmCC', 'Africa/Abidjan', 'c35142bd-4a15-4176-b8f9-ef9ef13b6e21', '2022-01-15 18:04:18.518784', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.518784', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ORABANK');
+      INSERT INTO public.base_person (id, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('41dcaa5b-5300-4120-b758-d367c2d720ff', 'Banque en ligne', '58b5bcdf-f78c-49b6-b02c-eab3e9f9f67b', 'e198fdbe-2626-4519-8513-b37390ca98bf', 'b87e85d4-0831-4c40-bfab-1b01c4fe5cc3', true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4gobCAYAArkuKAAAECZJREFUeNrtnXtwXNV9xz/n3pXsyCBZWCuTVgSwhR53BTaucdJODM60pSQOkEnqdkgGrZ1Q+p6GTqfTJJ0+JtNMm+SPpGmbkDaxjdukHdpJAiEtCZm4hHaKhRlks2vrUWzHosFa+QFGRq+9p3/87r26Wkt4tffec9eE74zH3l3vPY/f/n7n9z6KOoDj5AEF6NC72gZ1FXAd0AV0A51AB9AOtAKrgBWA5X3JBaaBSeAsMA6cBP4XGAKGgeNac0YpyvNjydjF4t60twKV1sCOk0cpjdb+FDSgWoFe4BbvTy9wDdACNEYccgZ4GSHQEeAAMAAcBX12fis0oFIjjlGC9PbuRCld+XYrsBn4JeBWhBOaDU3pFYRzngQeB55BOCsETbH4kLE9MkKQvr57cV0r/JYF9AB3AXcDNwFNxla9OC4Ah4BvAY8ARxERKBulyhQK/5j4JBIlSF9fHtdd8FYDsAXoB7YDP534CmvDi8BjwEOIaJv1P7AseP755MRZYgRxnDxag5IRbOAdwG8ghGhNbEXx4ixCmC8B/wOUkz5jYieI4+wixOkgB/PvAL8KrElkFcnjNPAvwBcQUebBoljcHetAdpwPE/U1OLRbgF8HPo8c2GmfEVHQhGh97/ZeHwWmldK0t2+kVBqMbaBYOGTduvtZuXIawBdTtwB/CtxBzESvA5SB/wD+XGsGPJGMUhcoFB6O/PDIm+U4eTKZwMZaqRT3AX+DqLJWzQ+uX1iIoXqHUrwGHAbK0EA2uyEyt0QiiOPkcV3lH9xvBf4S+BhwVdq7ZgAtwO3A1Yj98qplKdraoomwmgki50WgRd0IPAjsiPLMyxA2IgluBp7VmnEgEqfUtHk+MTzcCnwFUWt/UrEO2AoUQJ0AyGZr45RlE6SCGNuBv0fcHT/pWAu8CxgFPQKqJqIsiyC53M7wy7sRg+malDbARXxRE4hX9wzi/tCIIzINx+lqYBso37u8bKJUPekKzngP8GXMuz6mgQLwQ8SlMYoYbVPe5ysR4/MGxG64FXAQF71JvAjcD3wHQClFobCnqi9WRZCKeMVtwB4kTmEKU8D3gN3AD5ViQuuqvteGyPZdwC8iBDOF40AeeNK2FXNzLkeOXNprfEmCdHZ+iMbGjP+yD/i697cpDAJ/hXhhL0BgfPLKKxcYG1tojHV07KClpYkKgjUhIvaPEM+yKRwGPgg8D5DJuBw6tO91v3BJgoRE1dXAPuAXDC1GA/8M/DHwQviDah17FWIWRBv6C8SvZuqMeQK4F3ipmrm/7qEeWtAK5Ff6K4YW4QJ/B/y+LKQM2BSLe5d1QJZKg5RKg2SzG8lkNK6rznobdCViP5ggyjrgCm/c8qUO+SUJ0t2dx5p3fNyHWOAZzOAfgD8EzgMoFS1qVyoN0tbWh+fJmUaUgnbgZwyt50bgJVAHQbNmzQYmJhYnypK+JnueVLcAn8CcpvIEIqZelZc6lkhdofBPhDzRr3pjfN/QmlYAnwC9GRSWtTRjLsohvb153yXSDPw1QhQTeAkJYg2BHN7VaCbVolQaZO3aDX5ixSQwghi3VxhYWwvwU0jAa3op0XURQXI5ifR54up+JLhkymv7eaX0Q6Aii6mlMD4+SDZ7E94YY16q0VZD61uP/OgOKKVYu/ZmxsefW/AfLtpoX6XUmh7g9zDnLDwG7PXTggqF5DI9isV93loViE11zNAabWRPe7TWuBUJB1BBkK4uEVWWhQX8NkJRU/h2udw2AjA1lfxxJWNoJic7RoBvG1znemRvLYDu7vsWfLiAIJmMcIjr8g7gHoOTfA34jm1PAPDCC19OfEAZQ7Fq1RiIi2Mq2hOXhXvwvOO2Pbvgg4AguVy//88GJBZuMiHhR0hOFOVydT6ROGDbQaTzEHDC4HrXIHvcAAsN2IAg8ymdbAHuNDg5EG1nAmBoyFyW4OHDvjqtJ7w5mMSdyF4vgLXI637M500dR3JvU4I1483BJFqBe0FflNIZZpkeRC83jQkA1zUnrnzImDqYg2FsB9UD8zTwqBOIq7tIJ71zBsC2zceUQmOmwaEdyJ7jujIPjyAaJNp1dwqTAs8tU2WMI1aExjQdxPJxF7DasmQiVm9vIK42YzZWEEZbKA/YKEI1Km0prf0mPCen4+SFQ7yNSDPd8zqlaEyHQxRK6UbMRkDDWIXsPQCW5yZpRUKzaaELyAL09vZHfFT1CI2V9eaQFm5DjoxA7e1OeULXABtAEgJMITTWBtLLngHZ/x6YJ8gWxD2cFlYC231NY5HQa+zwucMTk9sxmwBRiRa8EIelNTbm4h2vh+2WpY0l3PncoRTdpGN7VWKLUliWUqwBcmnPBrgW2KW1+JcqkvJiheMIdzQ0zIKkCF2b9uIBR2vWWMDbqJ9av11K2VsBtNZ0d3849gHkmcIds7MNfs5WPaADuNavdUjz/AijHfgkUtqAbZfp6NgR34o7doQ9vG/1xmpPe9EeWoAuvzw5LSt1MdwGfAqvVr25uYmuruiHfFdXnubmwMxq9sZIU9WvxAqg28JsVLBa9AOfwfM623Y0zSuXy9PYGKi4rd6zzRk81WN9hnT176VgIQkWbcDHlGIY/FJrXXUmiuPsBDRay5mE6PufAt6f9gKXwNuU4+SHSNcovBSKwKeBfyPI1QI/M6VQWJiaKRrURcbllcAHkOS73rQX9DoYUo6TP0X9HGxLYQbYj2S/73dd9ZLvHV0KWtsoVb4aKaLZCWwjegObpHEqw+VRP96IFFi+CxiyLP0U8DTSbuk0kiQB8BYkXt2lVPntwDsRMdWQ9gKqxCrlOPmZy2jCYWgk+/A8kq8LoqlciXhQU2s9FQGzGcwlUMcNhaSAmkgDNYXMG7Gw/7KGBcylPYk3EWDOYl7+von0MW3h1e29ibrApMVFPQbfRIo4l0GK7uutE4OLJD9PQbidayywkejgSuqvW9GpDNI2tR5wBimBPoCUE59EbIy4E9gaEVulA0nB2YLE1Ouhg9HJDNINIU0cAx4G/hXxW00aHPtriBHpAL+MdDO6PsW9GM0g9XzTmI+JnAf2Is3Ohio/bG8/wf79+xMZeNu2bYyPX+dViulJYEBrNaCU3o2U8PUjXGQS03jOxc1IIaJJB+MI8HGt9TeUUsEZMTPTzOjoF4zuQmfn77JixStBSqlS2FrzfsRN32lwKuPA9gxSqDKGOYIcBH4TGJjP/DDTpHgx+D8Av+u21pQREXoC+CKwydBUxoATGa31aaVU0dDAh4CPAINp91ivxJEjewC/Jz1ozQFvrg8hhf9JowD6tKWUchHNJmn8GPgooklRT8QIw5+T16P+OeABvD4lCeMAqKAh+wByc0BSKAOfVoofVC68HlEo7A3OFK35PvBZ4reHwngZoUFgGB1lEU0nRvwA2O0vsp6J4cNvWuAdc19FblBICsH+W1prlFLnkBBpEphCDseXZaH1TwwfxWLAKWe9NSTliP1PrfU5pRSWUsrPyPguyRhlzxA0eUmhACQiQh2RngCeTWCISeBx0Tg1VugXe5DgwI0VjwEvu65t9GKUuCBZLRqES/49gSEG8QhdKOz1zxAX4BxykUmcOI/0psKykjwTk0YQnn+S+KXIt5C9B4JDPeDLRxADJS68iFzIdVmdHZUIzX0U+L8YHz0GPBp+wwoPqBRDxNuI5SQh6r8BcBb5kcWFR0EdhXkaLIgHaI2LWKZnYhpwglQ7NMQHSUdlGijF9MgzwL7KYvCAIErJLQdKMUAFG0XAhWJxrxv9MelD2lYpl/mkvKh4BM8YDKeQBQTxOy9rzRxy00EcrSaaHCdfb1G5mqG1togn03MC2eM5gGJxT/DBwsYnls8l6mmkYXJUrMeLK0gm+uWJnp6gcqGFeAJYX8PzH1ZWHS8gyOHDe/zUfRf4W6JHE3sJWrFefkahj1AX0c145csRMILsrQtc1BN+EXESiPwh4HNEc6pdCfwWEib1im7+LJldSwAdHTvChUJXhNdSI+aQPR0GvWhN/kUNLkulQ2SzG/2XR5FYQJSslC7kYsb/Btxs9hzt7ZsolZ5LcCujo68vT2NjkIPeCHwc+DDRMlUeRX6RM7C4bbZox1G/Pbf3xWHktrXVNU7CAn4OqesbAKZcF9rbo1+glRTkbq3gF3wVUhz6UaJVCZxAOOwEsKQbackWsG1tG33X848Rd8Ht1J4pnwF+FsnuOKyU6PLZ7EZaWzdx+vRziWzscpHL9QfSwSPGjYi87ydau9xp5GaGx0Asj6VajS85yMTEYFh0FZCYe5SODwoRfT+PWO9DQNmydM33NcWFXG4H2ay/NAWSRPchJCMmjru1HkTK8soAR44s7UZaznUVaxEr/vYYJvgaUjP4WaUYDNuqZn1eO8jlmpDCUIVlNeC6szcDf4AUhsbR/+S7CIedqmZ9lySI5DAFnSdyiA4dV6OzMSQat5eKO0Lm5mB4OBni5HK7EM1e4PXMWo90ddhJfJ0tBpELXYoAxeL1XErLrPLKowWVre/0NnBdjHs0jBD6YVBDoBeo2lqrICukVuRyO/1AXHj5Nuge5F6UDxJvHtYLyJVHTyl1BVq/WhX313op2B3IdXkdMS4AxJP6PeAbwNNKTZ7SeqHaXy7PYduXDnY5zk7vl7+oK+1q4O3A+5C7qeLu9TIG/BpyZy6SYbOnqi8uqzCygih3InHmJBrXTCNc819IgGsQOKmUPq+1WpbJrxRKa5qZb5K2FeHyG0imTHoMUW8DB+1yzsVlV6pWEOXdiFqYZIKyi7i8jyFEGvUWfQpJnLiAGJ4gdkITYjOtRTi4EzFOr0c6QyTp7DyGNNoPQr3LVVJqKh32ieJ1Et2KXPy+IcGFLoYZ788s8+4dGyFKI+abBAwiidpP+W/UojHWZOyUSoO0tweG44+QWHMnZpOTbWTT34JwRZP378Za1xUBjyO9WQ76b9Sqvtc8cd+94rouSqkSom83ISrx5Vr7vlxMIdfPPgAcn511se1oKbKRfklClE0+p0wiuUsvIuJrddq7lTCOI+6QzyB38mLbRE51iqn9xA4cZ0EgbRPwJ0hzyTcat8whiSCfVEo969s2cXkYYu0HEkrlB4mF3It4SW8wtl3JYgSJZ+wDzvvEiPMmuVgPv5DbHkQDGkAOPBcJ50YJ7qSJEnLZ5QOIsTcD4hGOkxiQYMec8A3TloXlutyCXPNzF2avU4qC00h2yIPIj8v1JUBSTtBEWxht2HAPs7ONYTGWQeLS/cB7qc/2giAJfo8ioukZQv1gZmYyjI5+JbGBjfSU6ur6CJnMfI8b10VZFl0It7wP0crSFmeTiHH3TeARUMPhJLbZWYuRkd2JT8Jok6+enn4sS1FxV8hqRCu7HWnD1405lfkcEijbj9hRB1mkksxkjCa1rmsSt56vv/DE2mrE77QZ6bDQh/ijVhO9jn4aIcAYcuH8AeRcGFGKcz4vuK6FZbmpJYfXRRs8/5afcFaM1tpSSq1BzpkuhHM6vddrkf67TUhUz9cWy4j1fAFJjD6FnAejCCcMe69PE8p38jm2HjL0/x848s2hrn9akAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0xMC0yN1QwODowNjowMCswMDowMNiFiREAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMTAtMjdUMDg6MDY6MDArMDA6MDCp2DGtAAAAAElFTkSuQmCC', 'Europe/Paris', 'e198fdbe-2626-4519-8513-b37390ca98bf', '2022-01-15 18:04:18.521496', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.521496', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'BANKONLINE');
+      INSERT INTO public.base_person (id, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('f59938b7-6f4d-47e5-adbe-7f4198f8d23f', 'CONNEKT4', '58b5bcdf-f78c-49b6-b02c-eab3e9f9f67b', 'f3fee586-8346-47c8-bd72-2cd39accf98e', 'b87e85d4-0831-4c40-bfab-1b01c4fe5cc3', true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAABcSAAAXEgFnn9JSAAAAB3RJTUUH4QoNBiUocN2mVAAAEs9JREFUeNrtnaFzG0n2gN+6UmUziclMYgqyjGJm6UjCYh24wFgL7uhq/4Io9w+clh5ZJcfyAz/FLEFymENOCrKZxGQ2YjLaA89T9uWyWXdP90xPz/dVuTapyu4qo+mv33v9uvuH3/4uvwkAVJIdHgEAAgAABAAACAAAEAAAIAAAQAAAgAAAAAEAAAIAAAQAAAgAABAAACAAAEAAAIAAAAABAEA4POIRVIjdmsj+4cP+7DYRuV7wzBAABE+jI7JXF2n2bn9/qL8XEWn13Pw/kqX+iIisZvrP67mKYnXOd1BSfuBMwBJRa+oM3jjUwV5v6U8IbBOR9VylsJ6LbJaIAQFAJppdHejNng78dFYvE8uZSmE1uxXDiu8VAcAfDnhXoXtoJEuRq6kKYTkTudnwvSOAirJbE2n3dbC3++Wc4V1ECFdT/SE6QACVGfTtvsjjPs/jPuu5yGKCDBBAhLRPRA4GDHpTGSwmpAkIoKTUmiJHQ5HOoJrhvStSEbCqgABKM9s/GcZbyCuKZClyPtIUgagAAQTHwalIdxTO2nysbBONCC7G1AoQQMHs1jTMPxoS5heVHpyPEAECYOB/c6Zcz+9+n7bwPpT7LcUhdR0iAgRQKMevwhn4aY/+aqb/3Nz+3tdASDcU7dVVEPWWSK0VTr0DESCAaHP8+7321/PwquKNjkoh3a9QpBTOR1ojoFiIADLT7Io8HT98K63LAb+albtttsj25m0i8mEo8uUN7zACsAx3n411HT8vLqd3vfKxhbG7tbu25zxbn9dzkY9D+ggQgAFPftJwP4+XNB30VVvfbnRUru1+PmnVxVhTA9ICBPC71Joizyf+w9Xl7K7vnRdSm6fyiAy2icjZQOTqPc8cAeQ8628TnYUWE6rU30sT2n1dZfFZc7mcqggqLl8EkMesn872FKPMaHY1RfBVg9kmIu/6la4NIID2iQ5+H7P+5VTk85jikwtB+9xUdTEW+fgzAqhcqOmrwk8zir/vzFf35XquKUHFTkKupgAaHZ31XeeYl1NdbmLgl1MEFewbqJ4AfIT8y5nIpxGhfixRXIVSgmoJ4PiVVvldkSx1xmdJqfgagesi7nKmBcLIVwmqIYDdmr4gro7jSpfzPr1m8IUW3T0du2sqSpYqgYjrAvELYLcm8nLmLt9fzrRYRJ4fdn3AVaQX+VJh3AJodEReTN3MCGwsKd9377LQ+34Q5XcfrwAaHZ35XRT76BorLy7rPh+GIp9/QQClyAVdVPq3ia7nR/alVzIacBUJLiYiZz9G82h2ovuyD071y846+Ndzkbc9Bn8MXC9E/nmogzcrnYHI818RQLCD/8TBl7yY6OCvWFdY1NxsdOZ+P9DIDglEJgAXg3+b6Aty9iP5fqx8eaNyv39YaoUlsMPgvyVZ6otBlb8aKcHbnhZ3Ky6B8gugfZJ98K/nmiMS8lcrJfi/P2tDV4UlUG4BpGu9LvJ9Qv5q8vFnTfuySuD4FQLIffBnXedPl3QY/NQF3vWzFQe7I01FEUAO7NayL/WlxT4AEd3Q9baXTQInE01JEYDnwf9ylq2pI9K2TshIWhzMIoHnE41OEYAnsvZ3M/jBpwT26jpB7dYQgHOOX2Xb0svgByRQUgG0T7Jt6mDwQ54S2D/U04oQgAOyLvcx+KEICXQGwa8MhC+A9DQf24o/gx+KlMDJJOiiYPgCeJbhVl4u4wBXEniXofb0YhpsPSBsARyc2p/4Gtm+bSiY1bl9x2C9lb1jtXICqDXtiyjruZ7eAuCSL2/0gBgbHveDrAeEKwDbvD/d1Ud7L/jg02v7g0WejXViQwB/wJOf7M54T09wZfCDTz4M7c4T2KsHlwqEJ4Asof+HIVt6wT83G/vNQ62eTnAI4Duhvw1U/CFPNis9KdqG7iiYVCAsAdiG/hT9oAiu3tsdKBJQKhCOAHZrdq2+24Qz+6E4Pv5sVw9o9YLYOvwomAf5bGxX9T8f5Zv3Z+lNIJ2Jk3d9kb/Nzd/fp2O9aq7AySsMATS7doPqcpr/uf31lttbaL/FasagKls94HxkXryut/QewwIvmQ0jBXhqkUeloT9ACHz+RWdzUwouCBYvgINTu17/D0PyfgiLs4Hd0uDTcUUFYFv4W87IkSHcVMCUx31NgysngKOh+dl+hP4QYypwPKqYAHZrKgBTLsZqWoBQ+WjxXrd6hUQBxQngaGi+bJIsC62YAjyI64Vdg1ABUUAxArCd/T/S7Qcl4XxkXhAsIAooRgA2s/9ypq2XAGXgZlOKKCD/RiDb2f/TiJcqFg5Os13s8qD3JYBU8dNrbXAz+bumUcDqPFIBtPvms//lNLcHAjnQGfjvpgylVnQ+Mr+9+ngk8q8/RZoC2Kz7k/tDWfnyRovXprWAnLoD8xVA+8Q89FtMWPaDcmPTHJTlEpxgBfBkmM/DAyh7FNAZ5HKUeH4CqDXN877LKbM/VDcK8L3tPFcB2FT+P495caC6UcDRMCIBmNpsOaPyD3Fhepx4veW9MSgfAbRPzJf+bM9eBwgVm8Ygz2lAPgI4MPxLbBO2+0J83GzMJ7Z232sx0L8Admu639m3KQFijAL26iqB0grA5sMT/kOsXC/MTxGulACWM5b+IG5MJ7jH/tIAvwKwCf+Z/QEB5BYF+BWAzYe+mvKCQNzcbLTJDQF8w4yc9AtVwHSi87R70q8ATD80sz8ggG+zV/dylZg/ATS75s0/nPgDpAHfGVO9MgnA8MNeMvsDUUDeAvB3IpBp/k/4f0dn4OXLzsT1XG/CheIEsH+oK2sO62R+BLBbM7/uiwsx76i3/J+ZB2GkAeu52Vhp9Zymyn5SANPBv57T/APVxHTicxwZ+hGA6Ydk9gfSAAQAUL0IwPDMC5ubtINPAZYIACqM6fvv8JAQ9wJodMzW/9dzuv+AOkBBaYB7AZhWr6/nvABQbUzHQOMwYAE0LFYAAKqM6RhwuETsXgCm4QkRAFSdzcrsJuH9kCMAUztx8i+AeRTQ6EQgAMJ/gNuJcFZIGuBWAKZWMr0oASBWTMeCo0KgWwGYbv8l/we4rQMYCiDICMC0AEgEAHCbAhjWwmohCsC39QDALtrOpwZgmJcQAQDcYdIS7Ggp0O15AKZWYgvw778IoW2QQtZRUpwATBofKpcPzkQ+veY5VI3rudlBus1u5j4atymASVhCD8D3BQDVo4BJcYenDlBdEABAWSM/B0uB7gRQaxLmAuRJPSQBcIotACkAACAAAEAAAPBgWAYEqDDXCwQAAAgAoHqYLqUjAICIKGApHQEAkAIAAALIAtt7ASosANMlDFqHAQqfdItLAWoIAOC/MD1Sz8Gp2tQAAELB0UGfxQnA5Nw4UgCAwnnkXAAPHdgIwD+7NacXSZZ5posyBXBwrN6jwl/Qmw1fvC/2D0VezngOsaYADsaO2xTAtCgR4uwEUKSwH4qjZXe3AjD9UISCAHbjwdGp2sVGAA0iAAAdC4Y3a0cRAVAIBLAbC9chRgCmYQnNQAB20bCjq9rcCuBmYxYFmFyDBIAA7tiEKACbKMA09wEgBQi0CGiTm1AHADBbAkyWzvpn3AvANDdpkgZAxWl2C8n/w4gAWAqEygvAcBJ0eK2eewGY3ldOIRCqTgHbgP0JQMS8QGEaAgHEhOkkuA5dAKYhCnUAqOzs3zFrAU6WIptVbBEAAgDy/7xn/3AiAOoAgAD8jK1CBLBZmS9VtE94GaB6PO4XKgB/B4KsZiL1gYEA+iJX73khXKdibwOMrp6OOQvCZtLbJs4vEPUngKupSMdAANQB3HOzMV+WzQPukLib9EzHlGP8nQq8NAxV6i32BQD5v8sxVagAbjbmH9gkYgAoM42O+T6YUkUANh/YNCQCKCtHQ7M/v557OUA3LAHUW3QFAvn/t1hMvHwMvwLYrMwbF0gDIPrBf2J+IK6H8N+/AGzM1e7rfQEAsXJgOMmt507bf/MVgKm59urUAiBeak3z5h9P4X8+ArBJA0wLJABlwSbF9RT+5yMAG4PtH9ITAAhARJfSPYX/4QqAKACizP1Pzdf+PYb/+QngZmP+F+kMNF8CqOrsv028hv/5CcDWZCwJQiw0u+bb3q+m3m/Pzk8Aq3PzLcJHQ5YEIQ6OR+b/zvnI+8fayfUhXIzN/vxenVoAVHP291z8K0YAi4n5VlCiACg7Tywmsc/jXD5avgKwKQYSBUDZZ3/Txp9kmdvhODu5P5ALC7MRBQC5vxce5f5ANiuNAkwq/Ht1kWdjkbMfi/9CP73WHwAfuf82EfnyJrePuFPIg7ExHH0BUDaeWkS7F+NcP2IxAkijAFOeT3ipoBwcnJoffLpNKiIA2yig1ePAEAif3ZqmrDazv+fGn3AEkCUKoCAIIdMdmR/4kSxzn/2LFYBtFFBvsSwI4dLs2r2f56PcZ//iBbBZ2UmgO2K7MISJTeEvWeZa+Q9HAGneY3NRBAVBCI3jV3Y3Hp0NCvvIxQvgZmMXBewf6gMHCIFGRyNTU5azQm9v2gni4X3+xe7aY1IBCIHdmn1EWuDsL1JEJ+Dv8XEo8nJmlwq87RVSQIEM37VplTxkuiO70P98lMuOv+/xw29/l9+CeZDPf7U7BGQxCaNNGKpH+0TkhcWpPclS5J+HhU9cO0E9zA9Du4JgZ6CdVwB5UmtmC/0DiFrDEsDNxj4nejamHgD58mJql8pcToO5tn0nuId69V4fkCl7dboEId901Sbv3yaFF/7CFkAaHtmkAvuH9AeAfw5O7Q+sDST0D1sAWVKBx32Rp//gJQU/NDoiJ5aTzMU4t5N+yi2ANBWw3RxxNKQoCH4Gv81StYhW/XM86af8AhDRB2bTICSilmbrMLgibfax7V941w+yVyVsAaSpgE09QESrtKwMgIvB/3JmV/QT0eXt60WQf7Wd4B/+9UIfoA17df3ikAAUNfgXE211D5SdUnwJX97Y1wOQAGTh2dh+8K/n9pMXAviKjz/b1wOQANhg25oucrfeH/gelZ1SfSFve+b3CyIByHvwi2jRL9C8v7wCuNnog7UtCiIBeEjOn3Xwvx8E0+oblwBE1Krv+vb/PhKA7w3+l7Nsg38xKex4r2oIQETt+n6ABMD94Lct+KWDv2Tb0ndK+4V9eZOtwrpXF/nbnI5BuOvwyzL4S1Dxj0sAIrq+anO3wH1OJpwtyODPPvjf9kp5KtVO6b/Asx+zS6A70sIPW4mrxcGpRoFZjicr8eCPQwCuJNAZ6EzABaTV4Pmv9rv6Ihn88QjAlQT2D3VGYBNRvNSaIn/9d7ZKfySDPy4BuJJAukJAXSA+2icq+Cz5fkSDPz4BuJJAWhf4679JCWJgt6aHxNie4Rfp4I9TAKkEXNy0mqYET35iEJWVtMrv4kLZyAZ/vAIQ0c1DWZqF7qcEz8Yif/l/ooGycfzKTcgvolFlZINfJLSLQXxwcKoD2MVNNNtETykKeH83iBZxn47dDPx08Ed68Uz8ArgfBrq6jmo50+utSrDbq3K5fnfkJtxPeT8oVW8/Avjey5G14+trLsYaEXAvYVyRXhrtveuXZlcfAnioBJ6Ns68BkxbEG+6LaLHvbFCJCK9aAkh58pOKwCXpsc8Rh4vBDfzjkUir5/a/ezktxUk+CMBFXeDFVKTeQgRlotbUGf9x3/1/+8OwcpFcdQWQpgTPJ35eJkRQjhk//a5KcoQXAvCVEnRH7gpIX79ci4kWDCkWmpPew+dj4ItUvpCLAO6Hls8n/l60bSJyNdUXjuXDP/4uOgP9cZ2i3f8+zgbB3dWHAGKOBlLW89uLIqdEBfdpn4gcDPykZPepWKEPAYQWDXz9Ml5NqyuDRkcbd9p9v9JN07GzQfRr+wjA5YyU5UJIZPD7z7XdF2n2/IX4X3M+og6DACzYrekM1R3l+/9dz1UEq1n5Z6xGRwd7s+c/vP+a5Uxn/c2KdxkBZEwLfK0/P/RFXs1Eruf665BnsmZXpHGoA77Vyy+CItxHALm83L7Wo01f8GSpUkiWIptl/i97o6MhfONQf+otty25NmwTbeih/wIBeBeB6x50l9GCiMoh5f6v70vkfmj8rbMQG4d3M3j663orv9zdZOBfjMnzEUDOtE9EngyLjwiqCgMfAZAaVBBarRFAkKTr2i63HMN/pzefx5Xv4EMAobNbUwkcDcPLl8sY5l9NdcZnOQ8BlDI96Azy6XaLbbZfTGiZRgARRQXtvv4U1U8QOuv53aBntkcAlZBBUc0yDHoEgAACoX1y1y4bYm+Bj5x+OSO8RwDwP9SadyKIQQjJUmf51ey2nZnzEBAAmKULqQxCabn93mBPW5Sv5zrwCesRAHjgfi9+vSVSa+XTprtNdGBvEx3k6V6E9ZxwHgFAMNzv7a9ZiuH+HgIGOAIAgHjY4REAIAAAQAAAgAAAAAEAAAIAAAQAAAgAABAAACAAAEAAAIAAAAABAAACAAAEAACh8h/f0FeRbf09+gAAAABJRU5ErkJggg==', 'Africa/Abidjan', 'f3fee586-8346-47c8-bd72-2cd39accf98e', '2022-01-15 18:04:18.524062', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.524062', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CONNEKT4');
+      INSERT INTO public.base_person (id, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('8732a69a-904c-465c-9a42-a53122b7582a', 'CINETPAY', '58b5bcdf-f78c-49b6-b02c-eab3e9f9f67b', '147ad348-9721-4e29-8a84-dd6c602c5d56', 'b87e85d4-0831-4c40-bfab-1b01c4fe5cc3', true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAABcSAAAXEgFnn9JSAAAAB3RJTUUH4QoNBiUocN2mVAAAEs9JREFUeNrtnaFzG0n2gN+6UmUziclMYgqyjGJm6UjCYh24wFgL7uhq/4Io9w+clh5ZJcfyAz/FLEFymENOCrKZxGQ2YjLaA89T9uWyWXdP90xPz/dVuTapyu4qo+mv33v9uvuH3/4uvwkAVJIdHgEAAgAABAAACAAAEAAAIAAAQAAAgAAAAAEAAAIAAAQAAAgAABAAACAAAEAAAIAAAAABAEA4POIRVIjdmsj+4cP+7DYRuV7wzBAABE+jI7JXF2n2bn9/qL8XEWn13Pw/kqX+iIisZvrP67mKYnXOd1BSfuBMwBJRa+oM3jjUwV5v6U8IbBOR9VylsJ6LbJaIAQFAJppdHejNng78dFYvE8uZSmE1uxXDiu8VAcAfDnhXoXtoJEuRq6kKYTkTudnwvSOAirJbE2n3dbC3++Wc4V1ECFdT/SE6QACVGfTtvsjjPs/jPuu5yGKCDBBAhLRPRA4GDHpTGSwmpAkIoKTUmiJHQ5HOoJrhvStSEbCqgABKM9s/GcZbyCuKZClyPtIUgagAAQTHwalIdxTO2nysbBONCC7G1AoQQMHs1jTMPxoS5heVHpyPEAECYOB/c6Zcz+9+n7bwPpT7LcUhdR0iAgRQKMevwhn4aY/+aqb/3Nz+3tdASDcU7dVVEPWWSK0VTr0DESCAaHP8+7321/PwquKNjkoh3a9QpBTOR1ojoFiIADLT7Io8HT98K63LAb+albtttsj25m0i8mEo8uUN7zACsAx3n411HT8vLqd3vfKxhbG7tbu25zxbn9dzkY9D+ggQgAFPftJwP4+XNB30VVvfbnRUru1+PmnVxVhTA9ICBPC71Joizyf+w9Xl7K7vnRdSm6fyiAy2icjZQOTqPc8cAeQ8628TnYUWE6rU30sT2n1dZfFZc7mcqggqLl8EkMesn872FKPMaHY1RfBVg9kmIu/6la4NIID2iQ5+H7P+5VTk85jikwtB+9xUdTEW+fgzAqhcqOmrwk8zir/vzFf35XquKUHFTkKupgAaHZ31XeeYl1NdbmLgl1MEFewbqJ4AfIT8y5nIpxGhfixRXIVSgmoJ4PiVVvldkSx1xmdJqfgagesi7nKmBcLIVwmqIYDdmr4gro7jSpfzPr1m8IUW3T0du2sqSpYqgYjrAvELYLcm8nLmLt9fzrRYRJ4fdn3AVaQX+VJh3AJodEReTN3MCGwsKd9377LQ+34Q5XcfrwAaHZ35XRT76BorLy7rPh+GIp9/QQClyAVdVPq3ia7nR/alVzIacBUJLiYiZz9G82h2ovuyD071y846+Ndzkbc9Bn8MXC9E/nmogzcrnYHI818RQLCD/8TBl7yY6OCvWFdY1NxsdOZ+P9DIDglEJgAXg3+b6Aty9iP5fqx8eaNyv39YaoUlsMPgvyVZ6otBlb8aKcHbnhZ3Ky6B8gugfZJ98K/nmiMS8lcrJfi/P2tDV4UlUG4BpGu9LvJ9Qv5q8vFnTfuySuD4FQLIffBnXedPl3QY/NQF3vWzFQe7I01FEUAO7NayL/WlxT4AEd3Q9baXTQInE01JEYDnwf9ylq2pI9K2TshIWhzMIoHnE41OEYAnsvZ3M/jBpwT26jpB7dYQgHOOX2Xb0svgByRQUgG0T7Jt6mDwQ54S2D/U04oQgAOyLvcx+KEICXQGwa8MhC+A9DQf24o/gx+KlMDJJOiiYPgCeJbhVl4u4wBXEniXofb0YhpsPSBsARyc2p/4Gtm+bSiY1bl9x2C9lb1jtXICqDXtiyjruZ7eAuCSL2/0gBgbHveDrAeEKwDbvD/d1Ud7L/jg02v7g0WejXViQwB/wJOf7M54T09wZfCDTz4M7c4T2KsHlwqEJ4Asof+HIVt6wT83G/vNQ62eTnAI4Duhvw1U/CFPNis9KdqG7iiYVCAsAdiG/hT9oAiu3tsdKBJQKhCOAHZrdq2+24Qz+6E4Pv5sVw9o9YLYOvwomAf5bGxX9T8f5Zv3Z+lNIJ2Jk3d9kb/Nzd/fp2O9aq7AySsMATS7doPqcpr/uf31lttbaL/FasagKls94HxkXryut/QewwIvmQ0jBXhqkUeloT9ACHz+RWdzUwouCBYvgINTu17/D0PyfgiLs4Hd0uDTcUUFYFv4W87IkSHcVMCUx31NgysngKOh+dl+hP4QYypwPKqYAHZrKgBTLsZqWoBQ+WjxXrd6hUQBxQngaGi+bJIsC62YAjyI64Vdg1ABUUAxArCd/T/S7Qcl4XxkXhAsIAooRgA2s/9ypq2XAGXgZlOKKCD/RiDb2f/TiJcqFg5Os13s8qD3JYBU8dNrbXAz+bumUcDqPFIBtPvms//lNLcHAjnQGfjvpgylVnQ+Mr+9+ngk8q8/RZoC2Kz7k/tDWfnyRovXprWAnLoD8xVA+8Q89FtMWPaDcmPTHJTlEpxgBfBkmM/DAyh7FNAZ5HKUeH4CqDXN877LKbM/VDcK8L3tPFcB2FT+P495caC6UcDRMCIBmNpsOaPyD3Fhepx4veW9MSgfAbRPzJf+bM9eBwgVm8Ygz2lAPgI4MPxLbBO2+0J83GzMJ7Z232sx0L8Admu639m3KQFijAL26iqB0grA5sMT/kOsXC/MTxGulACWM5b+IG5MJ7jH/tIAvwKwCf+Z/QEB5BYF+BWAzYe+mvKCQNzcbLTJDQF8w4yc9AtVwHSi87R70q8ATD80sz8ggG+zV/dylZg/ATS75s0/nPgDpAHfGVO9MgnA8MNeMvsDUUDeAvB3IpBp/k/4f0dn4OXLzsT1XG/CheIEsH+oK2sO62R+BLBbM7/uiwsx76i3/J+ZB2GkAeu52Vhp9Zymyn5SANPBv57T/APVxHTicxwZ+hGA6Ydk9gfSAAQAUL0IwPDMC5ubtINPAZYIACqM6fvv8JAQ9wJodMzW/9dzuv+AOkBBaYB7AZhWr6/nvABQbUzHQOMwYAE0LFYAAKqM6RhwuETsXgCm4QkRAFSdzcrsJuH9kCMAUztx8i+AeRTQ6EQgAMJ/gNuJcFZIGuBWAKZWMr0oASBWTMeCo0KgWwGYbv8l/we4rQMYCiDICMC0AEgEAHCbAhjWwmohCsC39QDALtrOpwZgmJcQAQDcYdIS7Ggp0O15AKZWYgvw778IoW2QQtZRUpwATBofKpcPzkQ+veY5VI3rudlBus1u5j4atymASVhCD8D3BQDVo4BJcYenDlBdEABAWSM/B0uB7gRQaxLmAuRJPSQBcIotACkAACAAAEAAAPBgWAYEqDDXCwQAAAgAoHqYLqUjAICIKGApHQEAkAIAAALIAtt7ASosANMlDFqHAQqfdItLAWoIAOC/MD1Sz8Gp2tQAAELB0UGfxQnA5Nw4UgCAwnnkXAAPHdgIwD+7NacXSZZ5posyBXBwrN6jwl/Qmw1fvC/2D0VezngOsaYADsaO2xTAtCgR4uwEUKSwH4qjZXe3AjD9UISCAHbjwdGp2sVGAA0iAAAdC4Y3a0cRAVAIBLAbC9chRgCmYQnNQAB20bCjq9rcCuBmYxYFmFyDBIAA7tiEKACbKMA09wEgBQi0CGiTm1AHADBbAkyWzvpn3AvANDdpkgZAxWl2C8n/w4gAWAqEygvAcBJ0eK2eewGY3ldOIRCqTgHbgP0JQMS8QGEaAgHEhOkkuA5dAKYhCnUAqOzs3zFrAU6WIptVbBEAAgDy/7xn/3AiAOoAgAD8jK1CBLBZmS9VtE94GaB6PO4XKgB/B4KsZiL1gYEA+iJX73khXKdibwOMrp6OOQvCZtLbJs4vEPUngKupSMdAANQB3HOzMV+WzQPukLib9EzHlGP8nQq8NAxV6i32BQD5v8sxVagAbjbmH9gkYgAoM42O+T6YUkUANh/YNCQCKCtHQ7M/v557OUA3LAHUW3QFAvn/t1hMvHwMvwLYrMwbF0gDIPrBf2J+IK6H8N+/AGzM1e7rfQEAsXJgOMmt507bf/MVgKm59urUAiBeak3z5h9P4X8+ArBJA0wLJABlwSbF9RT+5yMAG4PtH9ITAAhARJfSPYX/4QqAKACizP1Pzdf+PYb/+QngZmP+F+kMNF8CqOrsv028hv/5CcDWZCwJQiw0u+bb3q+m3m/Pzk8Aq3PzLcJHQ5YEIQ6OR+b/zvnI+8fayfUhXIzN/vxenVoAVHP291z8K0YAi4n5VlCiACg7Tywmsc/jXD5avgKwKQYSBUDZZ3/Txp9kmdvhODu5P5ALC7MRBQC5vxce5f5ANiuNAkwq/Ht1kWdjkbMfi/9CP73WHwAfuf82EfnyJrePuFPIg7ExHH0BUDaeWkS7F+NcP2IxAkijAFOeT3ipoBwcnJoffLpNKiIA2yig1ePAEAif3ZqmrDazv+fGn3AEkCUKoCAIIdMdmR/4kSxzn/2LFYBtFFBvsSwI4dLs2r2f56PcZ//iBbBZ2UmgO2K7MISJTeEvWeZa+Q9HAGneY3NRBAVBCI3jV3Y3Hp0NCvvIxQvgZmMXBewf6gMHCIFGRyNTU5azQm9v2gni4X3+xe7aY1IBCIHdmn1EWuDsL1JEJ+Dv8XEo8nJmlwq87RVSQIEM37VplTxkuiO70P98lMuOv+/xw29/l9+CeZDPf7U7BGQxCaNNGKpH+0TkhcWpPclS5J+HhU9cO0E9zA9Du4JgZ6CdVwB5UmtmC/0DiFrDEsDNxj4nejamHgD58mJql8pcToO5tn0nuId69V4fkCl7dboEId901Sbv3yaFF/7CFkAaHtmkAvuH9AeAfw5O7Q+sDST0D1sAWVKBx32Rp//gJQU/NDoiJ5aTzMU4t5N+yi2ANBWw3RxxNKQoCH4Gv81StYhW/XM86af8AhDRB2bTICSilmbrMLgibfax7V941w+yVyVsAaSpgE09QESrtKwMgIvB/3JmV/QT0eXt60WQf7Wd4B/+9UIfoA17df3ikAAUNfgXE211D5SdUnwJX97Y1wOQAGTh2dh+8K/n9pMXAviKjz/b1wOQANhg25oucrfeH/gelZ1SfSFve+b3CyIByHvwi2jRL9C8v7wCuNnog7UtCiIBeEjOn3Xwvx8E0+oblwBE1Krv+vb/PhKA7w3+l7Nsg38xKex4r2oIQETt+n6ABMD94Lct+KWDv2Tb0ndK+4V9eZOtwrpXF/nbnI5BuOvwyzL4S1Dxj0sAIrq+anO3wH1OJpwtyODPPvjf9kp5KtVO6b/Asx+zS6A70sIPW4mrxcGpRoFZjicr8eCPQwCuJNAZ6EzABaTV4Pmv9rv6Ihn88QjAlQT2D3VGYBNRvNSaIn/9d7ZKfySDPy4BuJJAukJAXSA+2icq+Cz5fkSDPz4BuJJAWhf4679JCWJgt6aHxNie4Rfp4I9TAKkEXNy0mqYET35iEJWVtMrv4kLZyAZ/vAIQ0c1DWZqF7qcEz8Yif/l/ooGycfzKTcgvolFlZINfJLSLQXxwcKoD2MVNNNtETykKeH83iBZxn47dDPx08Ed68Uz8ArgfBrq6jmo50+utSrDbq3K5fnfkJtxPeT8oVW8/Avjey5G14+trLsYaEXAvYVyRXhrtveuXZlcfAnioBJ6Ns68BkxbEG+6LaLHvbFCJCK9aAkh58pOKwCXpsc8Rh4vBDfzjkUir5/a/ezktxUk+CMBFXeDFVKTeQgRlotbUGf9x3/1/+8OwcpFcdQWQpgTPJ35eJkRQjhk//a5KcoQXAvCVEnRH7gpIX79ci4kWDCkWmpPew+dj4ItUvpCLAO6Hls8n/l60bSJyNdUXjuXDP/4uOgP9cZ2i3f8+zgbB3dWHAGKOBlLW89uLIqdEBfdpn4gcDPykZPepWKEPAYQWDXz9Ml5NqyuDRkcbd9p9v9JN07GzQfRr+wjA5YyU5UJIZPD7z7XdF2n2/IX4X3M+og6DACzYrekM1R3l+/9dz1UEq1n5Z6xGRwd7s+c/vP+a5Uxn/c2KdxkBZEwLfK0/P/RFXs1Eruf665BnsmZXpHGoA77Vyy+CItxHALm83L7Wo01f8GSpUkiWIptl/i97o6MhfONQf+otty25NmwTbeih/wIBeBeB6x50l9GCiMoh5f6v70vkfmj8rbMQG4d3M3j663orv9zdZOBfjMnzEUDOtE9EngyLjwiqCgMfAZAaVBBarRFAkKTr2i63HMN/pzefx5Xv4EMAobNbUwkcDcPLl8sY5l9NdcZnOQ8BlDI96Azy6XaLbbZfTGiZRgARRQXtvv4U1U8QOuv53aBntkcAlZBBUc0yDHoEgAACoX1y1y4bYm+Bj5x+OSO8RwDwP9SadyKIQQjJUmf51ey2nZnzEBAAmKULqQxCabn93mBPW5Sv5zrwCesRAHjgfi9+vSVSa+XTprtNdGBvEx3k6V6E9ZxwHgFAMNzv7a9ZiuH+HgIGOAIAgHjY4REAIAAAQAAAgAAAAAEAAAIAAAQAAAgAABAAACAAAEAAAIAAAAABAAACAAAEAACh8h/f0FeRbf09+gAAAABJRU5ErkJggg==', 'Africa/Abidjan', '147ad348-9721-4e29-8a84-dd6c602c5d56', '2022-01-15 18:04:18.527109', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.527109', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CINETPAY');
     </sql>
     <sql>
-      INSERT INTO public.base_person (id, guid, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, '4788fb05-d7ac-4739-9b64-70a80f5e7af4', 'Minlessika', 2, 1, 1, true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4gobCAYAArkuKAAAECZJREFUeNrtnXtwXNV9xz/n3pXsyCBZWCuTVgSwhR53BTaucdJODM60pSQOkEnqdkgGrZ1Q+p6GTqfTJJ0+JtNMm+SPpGmbkDaxjdukHdpJAiEtCZm4hHaKhRlks2vrUWzHosFa+QFGRq+9p3/87r26Wkt4tffec9eE74zH3l3vPY/f/n7n9z6KOoDj5AEF6NC72gZ1FXAd0AV0A51AB9AOtAKrgBWA5X3JBaaBSeAsMA6cBP4XGAKGgeNac0YpyvNjydjF4t60twKV1sCOk0cpjdb+FDSgWoFe4BbvTy9wDdACNEYccgZ4GSHQEeAAMAAcBX12fis0oFIjjlGC9PbuRCld+XYrsBn4JeBWhBOaDU3pFYRzngQeB55BOCsETbH4kLE9MkKQvr57cV0r/JYF9AB3AXcDNwFNxla9OC4Ah4BvAY8ARxERKBulyhQK/5j4JBIlSF9fHtdd8FYDsAXoB7YDP534CmvDi8BjwEOIaJv1P7AseP755MRZYgRxnDxag5IRbOAdwG8ghGhNbEXx4ixCmC8B/wOUkz5jYieI4+wixOkgB/PvAL8KrElkFcnjNPAvwBcQUebBoljcHetAdpwPE/U1OLRbgF8HPo8c2GmfEVHQhGh97/ZeHwWmldK0t2+kVBqMbaBYOGTduvtZuXIawBdTtwB/CtxBzESvA5SB/wD+XGsGPJGMUhcoFB6O/PDIm+U4eTKZwMZaqRT3AX+DqLJWzQ+uX1iIoXqHUrwGHAbK0EA2uyEyt0QiiOPkcV3lH9xvBf4S+BhwVdq7ZgAtwO3A1Yj98qplKdraoomwmgki50WgRd0IPAjsiPLMyxA2IgluBp7VmnEgEqfUtHk+MTzcCnwFUWt/UrEO2AoUQJ0AyGZr45RlE6SCGNuBv0fcHT/pWAu8CxgFPQKqJqIsiyC53M7wy7sRg+malDbARXxRE4hX9wzi/tCIIzINx+lqYBso37u8bKJUPekKzngP8GXMuz6mgQLwQ8SlMYoYbVPe5ysR4/MGxG64FXAQF71JvAjcD3wHQClFobCnqi9WRZCKeMVtwB4kTmEKU8D3gN3AD5ViQuuqvteGyPZdwC8iBDOF40AeeNK2FXNzLkeOXNprfEmCdHZ+iMbGjP+yD/i697cpDAJ/hXhhL0BgfPLKKxcYG1tojHV07KClpYkKgjUhIvaPEM+yKRwGPgg8D5DJuBw6tO91v3BJgoRE1dXAPuAXDC1GA/8M/DHwQviDah17FWIWRBv6C8SvZuqMeQK4F3ipmrm/7qEeWtAK5Ff6K4YW4QJ/B/y+LKQM2BSLe5d1QJZKg5RKg2SzG8lkNK6rznobdCViP5ggyjrgCm/c8qUO+SUJ0t2dx5p3fNyHWOAZzOAfgD8EzgMoFS1qVyoN0tbWh+fJmUaUgnbgZwyt50bgJVAHQbNmzQYmJhYnypK+JnueVLcAn8CcpvIEIqZelZc6lkhdofBPhDzRr3pjfN/QmlYAnwC9GRSWtTRjLsohvb153yXSDPw1QhQTeAkJYg2BHN7VaCbVolQaZO3aDX5ixSQwghi3VxhYWwvwU0jAa3op0XURQXI5ifR54up+JLhkymv7eaX0Q6Aii6mlMD4+SDZ7E94YY16q0VZD61uP/OgOKKVYu/ZmxsefW/AfLtpoX6XUmh7g9zDnLDwG7PXTggqF5DI9isV93loViE11zNAabWRPe7TWuBUJB1BBkK4uEVWWhQX8NkJRU/h2udw2AjA1lfxxJWNoJic7RoBvG1znemRvLYDu7vsWfLiAIJmMcIjr8g7gHoOTfA34jm1PAPDCC19OfEAZQ7Fq1RiIi2Mq2hOXhXvwvOO2Pbvgg4AguVy//88GJBZuMiHhR0hOFOVydT6ROGDbQaTzEHDC4HrXIHvcAAsN2IAg8ymdbAHuNDg5EG1nAmBoyFyW4OHDvjqtJ7w5mMSdyF4vgLXI637M500dR3JvU4I1483BJFqBe0FflNIZZpkeRC83jQkA1zUnrnzImDqYg2FsB9UD8zTwqBOIq7tIJ71zBsC2zceUQmOmwaEdyJ7jujIPjyAaJNp1dwqTAs8tU2WMI1aExjQdxPJxF7DasmQiVm9vIK42YzZWEEZbKA/YKEI1Km0prf0mPCen4+SFQ7yNSDPd8zqlaEyHQxRK6UbMRkDDWIXsPQCW5yZpRUKzaaELyAL09vZHfFT1CI2V9eaQFm5DjoxA7e1OeULXABtAEgJMITTWBtLLngHZ/x6YJ8gWxD2cFlYC231NY5HQa+zwucMTk9sxmwBRiRa8EIelNTbm4h2vh+2WpY0l3PncoRTdpGN7VWKLUliWUqwBcmnPBrgW2KW1+JcqkvJiheMIdzQ0zIKkCF2b9uIBR2vWWMDbqJ9av11K2VsBtNZ0d3849gHkmcIds7MNfs5WPaADuNavdUjz/AijHfgkUtqAbZfp6NgR34o7doQ9vG/1xmpPe9EeWoAuvzw5LSt1MdwGfAqvVr25uYmuruiHfFdXnubmwMxq9sZIU9WvxAqg28JsVLBa9AOfwfM623Y0zSuXy9PYGKi4rd6zzRk81WN9hnT176VgIQkWbcDHlGIY/FJrXXUmiuPsBDRay5mE6PufAt6f9gKXwNuU4+SHSNcovBSKwKeBfyPI1QI/M6VQWJiaKRrURcbllcAHkOS73rQX9DoYUo6TP0X9HGxLYQbYj2S/73dd9ZLvHV0KWtsoVb4aKaLZCWwjegObpHEqw+VRP96IFFi+CxiyLP0U8DTSbuk0kiQB8BYkXt2lVPntwDsRMdWQ9gKqxCrlOPmZy2jCYWgk+/A8kq8LoqlciXhQU2s9FQGzGcwlUMcNhaSAmkgDNYXMG7Gw/7KGBcylPYk3EWDOYl7+von0MW3h1e29ibrApMVFPQbfRIo4l0GK7uutE4OLJD9PQbidayywkejgSuqvW9GpDNI2tR5wBimBPoCUE59EbIy4E9gaEVulA0nB2YLE1Ouhg9HJDNINIU0cAx4G/hXxW00aHPtriBHpAL+MdDO6PsW9GM0g9XzTmI+JnAf2Is3Ohio/bG8/wf79+xMZeNu2bYyPX+dViulJYEBrNaCU3o2U8PUjXGQS03jOxc1IIaJJB+MI8HGt9TeUUsEZMTPTzOjoF4zuQmfn77JixStBSqlS2FrzfsRN32lwKuPA9gxSqDKGOYIcBH4TGJjP/DDTpHgx+D8Av+u21pQREXoC+CKwydBUxoATGa31aaVU0dDAh4CPAINp91ivxJEjewC/Jz1ozQFvrg8hhf9JowD6tKWUchHNJmn8GPgooklRT8QIw5+T16P+OeABvD4lCeMAqKAh+wByc0BSKAOfVoofVC68HlEo7A3OFK35PvBZ4reHwngZoUFgGB1lEU0nRvwA2O0vsp6J4cNvWuAdc19FblBICsH+W1prlFLnkBBpEphCDseXZaH1TwwfxWLAKWe9NSTliP1PrfU5pRSWUsrPyPguyRhlzxA0eUmhACQiQh2RngCeTWCISeBx0Tg1VugXe5DgwI0VjwEvu65t9GKUuCBZLRqES/49gSEG8QhdKOz1zxAX4BxykUmcOI/0psKykjwTk0YQnn+S+KXIt5C9B4JDPeDLRxADJS68iFzIdVmdHZUIzX0U+L8YHz0GPBp+wwoPqBRDxNuI5SQh6r8BcBb5kcWFR0EdhXkaLIgHaI2LWKZnYhpwglQ7NMQHSUdlGijF9MgzwL7KYvCAIErJLQdKMUAFG0XAhWJxrxv9MelD2lYpl/mkvKh4BM8YDKeQBQTxOy9rzRxy00EcrSaaHCdfb1G5mqG1togn03MC2eM5gGJxT/DBwsYnls8l6mmkYXJUrMeLK0gm+uWJnp6gcqGFeAJYX8PzH1ZWHS8gyOHDe/zUfRf4W6JHE3sJWrFefkahj1AX0c145csRMILsrQtc1BN+EXESiPwh4HNEc6pdCfwWEib1im7+LJldSwAdHTvChUJXhNdSI+aQPR0GvWhN/kUNLkulQ2SzG/2XR5FYQJSslC7kYsb/Btxs9hzt7ZsolZ5LcCujo68vT2NjkIPeCHwc+DDRMlUeRX6RM7C4bbZox1G/Pbf3xWHktrXVNU7CAn4OqesbAKZcF9rbo1+glRTkbq3gF3wVUhz6UaJVCZxAOOwEsKQbackWsG1tG33X848Rd8Ht1J4pnwF+FsnuOKyU6PLZ7EZaWzdx+vRziWzscpHL9QfSwSPGjYi87ydau9xp5GaGx0Asj6VajS85yMTEYFh0FZCYe5SODwoRfT+PWO9DQNmydM33NcWFXG4H2ay/NAWSRPchJCMmjru1HkTK8soAR44s7UZaznUVaxEr/vYYJvgaUjP4WaUYDNuqZn1eO8jlmpDCUIVlNeC6szcDf4AUhsbR/+S7CIedqmZ9lySI5DAFnSdyiA4dV6OzMSQat5eKO0Lm5mB4OBni5HK7EM1e4PXMWo90ddhJfJ0tBpELXYoAxeL1XErLrPLKowWVre/0NnBdjHs0jBD6YVBDoBeo2lqrICukVuRyO/1AXHj5Nuge5F6UDxJvHtYLyJVHTyl1BVq/WhX313op2B3IdXkdMS4AxJP6PeAbwNNKTZ7SeqHaXy7PYduXDnY5zk7vl7+oK+1q4O3A+5C7qeLu9TIG/BpyZy6SYbOnqi8uqzCygih3InHmJBrXTCNc819IgGsQOKmUPq+1WpbJrxRKa5qZb5K2FeHyG0imTHoMUW8DB+1yzsVlV6pWEOXdiFqYZIKyi7i8jyFEGvUWfQpJnLiAGJ4gdkITYjOtRTi4EzFOr0c6QyTp7DyGNNoPQr3LVVJqKh32ieJ1Et2KXPy+IcGFLoYZ788s8+4dGyFKI+abBAwiidpP+W/UojHWZOyUSoO0tweG44+QWHMnZpOTbWTT34JwRZP378Za1xUBjyO9WQ76b9Sqvtc8cd+94rouSqkSom83ISrx5Vr7vlxMIdfPPgAcn511se1oKbKRfklClE0+p0wiuUsvIuJrddq7lTCOI+6QzyB38mLbRE51iqn9xA4cZ0EgbRPwJ0hzyTcat8whiSCfVEo969s2cXkYYu0HEkrlB4mF3It4SW8wtl3JYgSJZ+wDzvvEiPMmuVgPv5DbHkQDGkAOPBcJ50YJ7qSJEnLZ5QOIsTcD4hGOkxiQYMec8A3TloXlutyCXPNzF2avU4qC00h2yIPIj8v1JUBSTtBEWxht2HAPs7ONYTGWQeLS/cB7qc/2giAJfo8ioukZQv1gZmYyjI5+JbGBjfSU6ur6CJnMfI8b10VZFl0It7wP0crSFmeTiHH3TeARUMPhJLbZWYuRkd2JT8Jok6+enn4sS1FxV8hqRCu7HWnD1405lfkcEijbj9hRB1mkksxkjCa1rmsSt56vv/DE2mrE77QZ6bDQh/ijVhO9jn4aIcAYcuH8AeRcGFGKcz4vuK6FZbmpJYfXRRs8/5afcFaM1tpSSq1BzpkuhHM6vddrkf67TUhUz9cWy4j1fAFJjD6FnAejCCcMe69PE8p38jm2HjL0/x848s2hrn9akAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0xMC0yN1QwODowNjowMCswMDowMNiFiREAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMTAtMjdUMDg6MDY6MDArMDA6MDCp2DGtAAAAAElFTkSuQmCC', 'Africa/Abidjan', 1, '2022-01-15 18:04:18.501476', 2, '2022-01-15 18:04:18.501476', 2, 2, 'ADMIN');
-      INSERT INTO public.base_person (id, guid, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, '71078f08-0531-4ffc-bd29-a11fc633c4c7', 'Anonyme', 2, 2, 1, false, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4gobCAYAArkuKAAAECZJREFUeNrtnXtwXNV9xz/n3pXsyCBZWCuTVgSwhR53BTaucdJODM60pSQOkEnqdkgGrZ1Q+p6GTqfTJJ0+JtNMm+SPpGmbkDaxjdukHdpJAiEtCZm4hHaKhRlks2vrUWzHosFa+QFGRq+9p3/87r26Wkt4tffec9eE74zH3l3vPY/f/n7n9z6KOoDj5AEF6NC72gZ1FXAd0AV0A51AB9AOtAKrgBWA5X3JBaaBSeAsMA6cBP4XGAKGgeNac0YpyvNjydjF4t60twKV1sCOk0cpjdb+FDSgWoFe4BbvTy9wDdACNEYccgZ4GSHQEeAAMAAcBX12fis0oFIjjlGC9PbuRCld+XYrsBn4JeBWhBOaDU3pFYRzngQeB55BOCsETbH4kLE9MkKQvr57cV0r/JYF9AB3AXcDNwFNxla9OC4Ah4BvAY8ARxERKBulyhQK/5j4JBIlSF9fHtdd8FYDsAXoB7YDP534CmvDi8BjwEOIaJv1P7AseP755MRZYgRxnDxag5IRbOAdwG8ghGhNbEXx4ixCmC8B/wOUkz5jYieI4+wixOkgB/PvAL8KrElkFcnjNPAvwBcQUebBoljcHetAdpwPE/U1OLRbgF8HPo8c2GmfEVHQhGh97/ZeHwWmldK0t2+kVBqMbaBYOGTduvtZuXIawBdTtwB/CtxBzESvA5SB/wD+XGsGPJGMUhcoFB6O/PDIm+U4eTKZwMZaqRT3AX+DqLJWzQ+uX1iIoXqHUrwGHAbK0EA2uyEyt0QiiOPkcV3lH9xvBf4S+BhwVdq7ZgAtwO3A1Yj98qplKdraoomwmgki50WgRd0IPAjsiPLMyxA2IgluBp7VmnEgEqfUtHk+MTzcCnwFUWt/UrEO2AoUQJ0AyGZr45RlE6SCGNuBv0fcHT/pWAu8CxgFPQKqJqIsiyC53M7wy7sRg+malDbARXxRE4hX9wzi/tCIIzINx+lqYBso37u8bKJUPekKzngP8GXMuz6mgQLwQ8SlMYoYbVPe5ysR4/MGxG64FXAQF71JvAjcD3wHQClFobCnqi9WRZCKeMVtwB4kTmEKU8D3gN3AD5ViQuuqvteGyPZdwC8iBDOF40AeeNK2FXNzLkeOXNprfEmCdHZ+iMbGjP+yD/i697cpDAJ/hXhhL0BgfPLKKxcYG1tojHV07KClpYkKgjUhIvaPEM+yKRwGPgg8D5DJuBw6tO91v3BJgoRE1dXAPuAXDC1GA/8M/DHwQviDah17FWIWRBv6C8SvZuqMeQK4F3ipmrm/7qEeWtAK5Ff6K4YW4QJ/B/y+LKQM2BSLe5d1QJZKg5RKg2SzG8lkNK6rznobdCViP5ggyjrgCm/c8qUO+SUJ0t2dx5p3fNyHWOAZzOAfgD8EzgMoFS1qVyoN0tbWh+fJmUaUgnbgZwyt50bgJVAHQbNmzQYmJhYnypK+JnueVLcAn8CcpvIEIqZelZc6lkhdofBPhDzRr3pjfN/QmlYAnwC9GRSWtTRjLsohvb153yXSDPw1QhQTeAkJYg2BHN7VaCbVolQaZO3aDX5ixSQwghi3VxhYWwvwU0jAa3op0XURQXI5ifR54up+JLhkymv7eaX0Q6Aii6mlMD4+SDZ7E94YY16q0VZD61uP/OgOKKVYu/ZmxsefW/AfLtpoX6XUmh7g9zDnLDwG7PXTggqF5DI9isV93loViE11zNAabWRPe7TWuBUJB1BBkK4uEVWWhQX8NkJRU/h2udw2AjA1lfxxJWNoJic7RoBvG1znemRvLYDu7vsWfLiAIJmMcIjr8g7gHoOTfA34jm1PAPDCC19OfEAZQ7Fq1RiIi2Mq2hOXhXvwvOO2Pbvgg4AguVy//88GJBZuMiHhR0hOFOVydT6ROGDbQaTzEHDC4HrXIHvcAAsN2IAg8ymdbAHuNDg5EG1nAmBoyFyW4OHDvjqtJ7w5mMSdyF4vgLXI637M500dR3JvU4I1483BJFqBe0FflNIZZpkeRC83jQkA1zUnrnzImDqYg2FsB9UD8zTwqBOIq7tIJ71zBsC2zceUQmOmwaEdyJ7jujIPjyAaJNp1dwqTAs8tU2WMI1aExjQdxPJxF7DasmQiVm9vIK42YzZWEEZbKA/YKEI1Km0prf0mPCen4+SFQ7yNSDPd8zqlaEyHQxRK6UbMRkDDWIXsPQCW5yZpRUKzaaELyAL09vZHfFT1CI2V9eaQFm5DjoxA7e1OeULXABtAEgJMITTWBtLLngHZ/x6YJ8gWxD2cFlYC231NY5HQa+zwucMTk9sxmwBRiRa8EIelNTbm4h2vh+2WpY0l3PncoRTdpGN7VWKLUliWUqwBcmnPBrgW2KW1+JcqkvJiheMIdzQ0zIKkCF2b9uIBR2vWWMDbqJ9av11K2VsBtNZ0d3849gHkmcIds7MNfs5WPaADuNavdUjz/AijHfgkUtqAbZfp6NgR34o7doQ9vG/1xmpPe9EeWoAuvzw5LSt1MdwGfAqvVr25uYmuruiHfFdXnubmwMxq9sZIU9WvxAqg28JsVLBa9AOfwfM623Y0zSuXy9PYGKi4rd6zzRk81WN9hnT176VgIQkWbcDHlGIY/FJrXXUmiuPsBDRay5mE6PufAt6f9gKXwNuU4+SHSNcovBSKwKeBfyPI1QI/M6VQWJiaKRrURcbllcAHkOS73rQX9DoYUo6TP0X9HGxLYQbYj2S/73dd9ZLvHV0KWtsoVb4aKaLZCWwjegObpHEqw+VRP96IFFi+CxiyLP0U8DTSbuk0kiQB8BYkXt2lVPntwDsRMdWQ9gKqxCrlOPmZy2jCYWgk+/A8kq8LoqlciXhQU2s9FQGzGcwlUMcNhaSAmkgDNYXMG7Gw/7KGBcylPYk3EWDOYl7+von0MW3h1e29ibrApMVFPQbfRIo4l0GK7uutE4OLJD9PQbidayywkejgSuqvW9GpDNI2tR5wBimBPoCUE59EbIy4E9gaEVulA0nB2YLE1Ouhg9HJDNINIU0cAx4G/hXxW00aHPtriBHpAL+MdDO6PsW9GM0g9XzTmI+JnAf2Is3Ohio/bG8/wf79+xMZeNu2bYyPX+dViulJYEBrNaCU3o2U8PUjXGQS03jOxc1IIaJJB+MI8HGt9TeUUsEZMTPTzOjoF4zuQmfn77JixStBSqlS2FrzfsRN32lwKuPA9gxSqDKGOYIcBH4TGJjP/DDTpHgx+D8Av+u21pQREXoC+CKwydBUxoATGa31aaVU0dDAh4CPAINp91ivxJEjewC/Jz1ozQFvrg8hhf9JowD6tKWUchHNJmn8GPgooklRT8QIw5+T16P+OeABvD4lCeMAqKAh+wByc0BSKAOfVoofVC68HlEo7A3OFK35PvBZ4reHwngZoUFgGB1lEU0nRvwA2O0vsp6J4cNvWuAdc19FblBICsH+W1prlFLnkBBpEphCDseXZaH1TwwfxWLAKWe9NSTliP1PrfU5pRSWUsrPyPguyRhlzxA0eUmhACQiQh2RngCeTWCISeBx0Tg1VugXe5DgwI0VjwEvu65t9GKUuCBZLRqES/49gSEG8QhdKOz1zxAX4BxykUmcOI/0psKykjwTk0YQnn+S+KXIt5C9B4JDPeDLRxADJS68iFzIdVmdHZUIzX0U+L8YHz0GPBp+wwoPqBRDxNuI5SQh6r8BcBb5kcWFR0EdhXkaLIgHaI2LWKZnYhpwglQ7NMQHSUdlGijF9MgzwL7KYvCAIErJLQdKMUAFG0XAhWJxrxv9MelD2lYpl/mkvKh4BM8YDKeQBQTxOy9rzRxy00EcrSaaHCdfb1G5mqG1togn03MC2eM5gGJxT/DBwsYnls8l6mmkYXJUrMeLK0gm+uWJnp6gcqGFeAJYX8PzH1ZWHS8gyOHDe/zUfRf4W6JHE3sJWrFefkahj1AX0c145csRMILsrQtc1BN+EXESiPwh4HNEc6pdCfwWEib1im7+LJldSwAdHTvChUJXhNdSI+aQPR0GvWhN/kUNLkulQ2SzG/2XR5FYQJSslC7kYsb/Btxs9hzt7ZsolZ5LcCujo68vT2NjkIPeCHwc+DDRMlUeRX6RM7C4bbZox1G/Pbf3xWHktrXVNU7CAn4OqesbAKZcF9rbo1+glRTkbq3gF3wVUhz6UaJVCZxAOOwEsKQbackWsG1tG33X848Rd8Ht1J4pnwF+FsnuOKyU6PLZ7EZaWzdx+vRziWzscpHL9QfSwSPGjYi87ydau9xp5GaGx0Asj6VajS85yMTEYFh0FZCYe5SODwoRfT+PWO9DQNmydM33NcWFXG4H2ay/NAWSRPchJCMmjru1HkTK8soAR44s7UZaznUVaxEr/vYYJvgaUjP4WaUYDNuqZn1eO8jlmpDCUIVlNeC6szcDf4AUhsbR/+S7CIedqmZ9lySI5DAFnSdyiA4dV6OzMSQat5eKO0Lm5mB4OBni5HK7EM1e4PXMWo90ddhJfJ0tBpELXYoAxeL1XErLrPLKowWVre/0NnBdjHs0jBD6YVBDoBeo2lqrICukVuRyO/1AXHj5Nuge5F6UDxJvHtYLyJVHTyl1BVq/WhX313op2B3IdXkdMS4AxJP6PeAbwNNKTZ7SeqHaXy7PYduXDnY5zk7vl7+oK+1q4O3A+5C7qeLu9TIG/BpyZy6SYbOnqi8uqzCygih3InHmJBrXTCNc819IgGsQOKmUPq+1WpbJrxRKa5qZb5K2FeHyG0imTHoMUW8DB+1yzsVlV6pWEOXdiFqYZIKyi7i8jyFEGvUWfQpJnLiAGJ4gdkITYjOtRTi4EzFOr0c6QyTp7DyGNNoPQr3LVVJqKh32ieJ1Et2KXPy+IcGFLoYZ788s8+4dGyFKI+abBAwiidpP+W/UojHWZOyUSoO0tweG44+QWHMnZpOTbWTT34JwRZP378Za1xUBjyO9WQ76b9Sqvtc8cd+94rouSqkSom83ISrx5Vr7vlxMIdfPPgAcn511se1oKbKRfklClE0+p0wiuUsvIuJrddq7lTCOI+6QzyB38mLbRE51iqn9xA4cZ0EgbRPwJ0hzyTcat8whiSCfVEo969s2cXkYYu0HEkrlB4mF3It4SW8wtl3JYgSJZ+wDzvvEiPMmuVgPv5DbHkQDGkAOPBcJ50YJ7qSJEnLZ5QOIsTcD4hGOkxiQYMec8A3TloXlutyCXPNzF2avU4qC00h2yIPIj8v1JUBSTtBEWxht2HAPs7ONYTGWQeLS/cB7qc/2giAJfo8ioukZQv1gZmYyjI5+JbGBjfSU6ur6CJnMfI8b10VZFl0It7wP0crSFmeTiHH3TeARUMPhJLbZWYuRkd2JT8Jok6+enn4sS1FxV8hqRCu7HWnD1405lfkcEijbj9hRB1mkksxkjCa1rmsSt56vv/DE2mrE77QZ6bDQh/ijVhO9jn4aIcAYcuH8AeRcGFGKcz4vuK6FZbmpJYfXRRs8/5afcFaM1tpSSq1BzpkuhHM6vddrkf67TUhUz9cWy4j1fAFJjD6FnAejCCcMe69PE8p38jm2HjL0/x848s2hrn9akAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0xMC0yN1QwODowNjowMCswMDowMNiFiREAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMTAtMjdUMDg6MDY6MDArMDA6MDCp2DGtAAAAAElFTkSuQmCC', 'Africa/Abidjan', 2, '2022-01-15 18:04:18.507821', 2, '2022-01-15 18:04:18.507821', 2, 2, 'ANONYMOUS');
-      INSERT INTO public.base_person (id, guid, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (3, '83cb0342-a471-407e-9e84-969ccb80623d', 'MTN', 2, 3, 1, true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4gobCAYAArkuKAAAECZJREFUeNrtnXtwXNV9xz/n3pXsyCBZWCuTVgSwhR53BTaucdJODM60pSQOkEnqdkgGrZ1Q+p6GTqfTJJ0+JtNMm+SPpGmbkDaxjdukHdpJAiEtCZm4hHaKhRlks2vrUWzHosFa+QFGRq+9p3/87r26Wkt4tffec9eE74zH3l3vPY/f/n7n9z6KOoDj5AEF6NC72gZ1FXAd0AV0A51AB9AOtAKrgBWA5X3JBaaBSeAsMA6cBP4XGAKGgeNac0YpyvNjydjF4t60twKV1sCOk0cpjdb+FDSgWoFe4BbvTy9wDdACNEYccgZ4GSHQEeAAMAAcBX12fis0oFIjjlGC9PbuRCld+XYrsBn4JeBWhBOaDU3pFYRzngQeB55BOCsETbH4kLE9MkKQvr57cV0r/JYF9AB3AXcDNwFNxla9OC4Ah4BvAY8ARxERKBulyhQK/5j4JBIlSF9fHtdd8FYDsAXoB7YDP534CmvDi8BjwEOIaJv1P7AseP755MRZYgRxnDxag5IRbOAdwG8ghGhNbEXx4ixCmC8B/wOUkz5jYieI4+wixOkgB/PvAL8KrElkFcnjNPAvwBcQUebBoljcHetAdpwPE/U1OLRbgF8HPo8c2GmfEVHQhGh97/ZeHwWmldK0t2+kVBqMbaBYOGTduvtZuXIawBdTtwB/CtxBzESvA5SB/wD+XGsGPJGMUhcoFB6O/PDIm+U4eTKZwMZaqRT3AX+DqLJWzQ+uX1iIoXqHUrwGHAbK0EA2uyEyt0QiiOPkcV3lH9xvBf4S+BhwVdq7ZgAtwO3A1Yj98qplKdraoomwmgki50WgRd0IPAjsiPLMyxA2IgluBp7VmnEgEqfUtHk+MTzcCnwFUWt/UrEO2AoUQJ0AyGZr45RlE6SCGNuBv0fcHT/pWAu8CxgFPQKqJqIsiyC53M7wy7sRg+malDbARXxRE4hX9wzi/tCIIzINx+lqYBso37u8bKJUPekKzngP8GXMuz6mgQLwQ8SlMYoYbVPe5ysR4/MGxG64FXAQF71JvAjcD3wHQClFobCnqi9WRZCKeMVtwB4kTmEKU8D3gN3AD5ViQuuqvteGyPZdwC8iBDOF40AeeNK2FXNzLkeOXNprfEmCdHZ+iMbGjP+yD/i697cpDAJ/hXhhL0BgfPLKKxcYG1tojHV07KClpYkKgjUhIvaPEM+yKRwGPgg8D5DJuBw6tO91v3BJgoRE1dXAPuAXDC1GA/8M/DHwQviDah17FWIWRBv6C8SvZuqMeQK4F3ipmrm/7qEeWtAK5Ff6K4YW4QJ/B/y+LKQM2BSLe5d1QJZKg5RKg2SzG8lkNK6rznobdCViP5ggyjrgCm/c8qUO+SUJ0t2dx5p3fNyHWOAZzOAfgD8EzgMoFS1qVyoN0tbWh+fJmUaUgnbgZwyt50bgJVAHQbNmzQYmJhYnypK+JnueVLcAn8CcpvIEIqZelZc6lkhdofBPhDzRr3pjfN/QmlYAnwC9GRSWtTRjLsohvb153yXSDPw1QhQTeAkJYg2BHN7VaCbVolQaZO3aDX5ixSQwghi3VxhYWwvwU0jAa3op0XURQXI5ifR54up+JLhkymv7eaX0Q6Aii6mlMD4+SDZ7E94YY16q0VZD61uP/OgOKKVYu/ZmxsefW/AfLtpoX6XUmh7g9zDnLDwG7PXTggqF5DI9isV93loViE11zNAabWRPe7TWuBUJB1BBkK4uEVWWhQX8NkJRU/h2udw2AjA1lfxxJWNoJic7RoBvG1znemRvLYDu7vsWfLiAIJmMcIjr8g7gHoOTfA34jm1PAPDCC19OfEAZQ7Fq1RiIi2Mq2hOXhXvwvOO2Pbvgg4AguVy//88GJBZuMiHhR0hOFOVydT6ROGDbQaTzEHDC4HrXIHvcAAsN2IAg8ymdbAHuNDg5EG1nAmBoyFyW4OHDvjqtJ7w5mMSdyF4vgLXI637M500dR3JvU4I1483BJFqBe0FflNIZZpkeRC83jQkA1zUnrnzImDqYg2FsB9UD8zTwqBOIq7tIJ71zBsC2zceUQmOmwaEdyJ7jujIPjyAaJNp1dwqTAs8tU2WMI1aExjQdxPJxF7DasmQiVm9vIK42YzZWEEZbKA/YKEI1Km0prf0mPCen4+SFQ7yNSDPd8zqlaEyHQxRK6UbMRkDDWIXsPQCW5yZpRUKzaaELyAL09vZHfFT1CI2V9eaQFm5DjoxA7e1OeULXABtAEgJMITTWBtLLngHZ/x6YJ8gWxD2cFlYC231NY5HQa+zwucMTk9sxmwBRiRa8EIelNTbm4h2vh+2WpY0l3PncoRTdpGN7VWKLUliWUqwBcmnPBrgW2KW1+JcqkvJiheMIdzQ0zIKkCF2b9uIBR2vWWMDbqJ9av11K2VsBtNZ0d3849gHkmcIds7MNfs5WPaADuNavdUjz/AijHfgkUtqAbZfp6NgR34o7doQ9vG/1xmpPe9EeWoAuvzw5LSt1MdwGfAqvVr25uYmuruiHfFdXnubmwMxq9sZIU9WvxAqg28JsVLBa9AOfwfM623Y0zSuXy9PYGKi4rd6zzRk81WN9hnT176VgIQkWbcDHlGIY/FJrXXUmiuPsBDRay5mE6PufAt6f9gKXwNuU4+SHSNcovBSKwKeBfyPI1QI/M6VQWJiaKRrURcbllcAHkOS73rQX9DoYUo6TP0X9HGxLYQbYj2S/73dd9ZLvHV0KWtsoVb4aKaLZCWwjegObpHEqw+VRP96IFFi+CxiyLP0U8DTSbuk0kiQB8BYkXt2lVPntwDsRMdWQ9gKqxCrlOPmZy2jCYWgk+/A8kq8LoqlciXhQU2s9FQGzGcwlUMcNhaSAmkgDNYXMG7Gw/7KGBcylPYk3EWDOYl7+von0MW3h1e29ibrApMVFPQbfRIo4l0GK7uutE4OLJD9PQbidayywkejgSuqvW9GpDNI2tR5wBimBPoCUE59EbIy4E9gaEVulA0nB2YLE1Ouhg9HJDNINIU0cAx4G/hXxW00aHPtriBHpAL+MdDO6PsW9GM0g9XzTmI+JnAf2Is3Ohio/bG8/wf79+xMZeNu2bYyPX+dViulJYEBrNaCU3o2U8PUjXGQS03jOxc1IIaJJB+MI8HGt9TeUUsEZMTPTzOjoF4zuQmfn77JixStBSqlS2FrzfsRN32lwKuPA9gxSqDKGOYIcBH4TGJjP/DDTpHgx+D8Av+u21pQREXoC+CKwydBUxoATGa31aaVU0dDAh4CPAINp91ivxJEjewC/Jz1ozQFvrg8hhf9JowD6tKWUchHNJmn8GPgooklRT8QIw5+T16P+OeABvD4lCeMAqKAh+wByc0BSKAOfVoofVC68HlEo7A3OFK35PvBZ4reHwngZoUFgGB1lEU0nRvwA2O0vsp6J4cNvWuAdc19FblBICsH+W1prlFLnkBBpEphCDseXZaH1TwwfxWLAKWe9NSTliP1PrfU5pRSWUsrPyPguyRhlzxA0eUmhACQiQh2RngCeTWCISeBx0Tg1VugXe5DgwI0VjwEvu65t9GKUuCBZLRqES/49gSEG8QhdKOz1zxAX4BxykUmcOI/0psKykjwTk0YQnn+S+KXIt5C9B4JDPeDLRxADJS68iFzIdVmdHZUIzX0U+L8YHz0GPBp+wwoPqBRDxNuI5SQh6r8BcBb5kcWFR0EdhXkaLIgHaI2LWKZnYhpwglQ7NMQHSUdlGijF9MgzwL7KYvCAIErJLQdKMUAFG0XAhWJxrxv9MelD2lYpl/mkvKh4BM8YDKeQBQTxOy9rzRxy00EcrSaaHCdfb1G5mqG1togn03MC2eM5gGJxT/DBwsYnls8l6mmkYXJUrMeLK0gm+uWJnp6gcqGFeAJYX8PzH1ZWHS8gyOHDe/zUfRf4W6JHE3sJWrFefkahj1AX0c145csRMILsrQtc1BN+EXESiPwh4HNEc6pdCfwWEib1im7+LJldSwAdHTvChUJXhNdSI+aQPR0GvWhN/kUNLkulQ2SzG/2XR5FYQJSslC7kYsb/Btxs9hzt7ZsolZ5LcCujo68vT2NjkIPeCHwc+DDRMlUeRX6RM7C4bbZox1G/Pbf3xWHktrXVNU7CAn4OqesbAKZcF9rbo1+glRTkbq3gF3wVUhz6UaJVCZxAOOwEsKQbackWsG1tG33X848Rd8Ht1J4pnwF+FsnuOKyU6PLZ7EZaWzdx+vRziWzscpHL9QfSwSPGjYi87ydau9xp5GaGx0Asj6VajS85yMTEYFh0FZCYe5SODwoRfT+PWO9DQNmydM33NcWFXG4H2ay/NAWSRPchJCMmjru1HkTK8soAR44s7UZaznUVaxEr/vYYJvgaUjP4WaUYDNuqZn1eO8jlmpDCUIVlNeC6szcDf4AUhsbR/+S7CIedqmZ9lySI5DAFnSdyiA4dV6OzMSQat5eKO0Lm5mB4OBni5HK7EM1e4PXMWo90ddhJfJ0tBpELXYoAxeL1XErLrPLKowWVre/0NnBdjHs0jBD6YVBDoBeo2lqrICukVuRyO/1AXHj5Nuge5F6UDxJvHtYLyJVHTyl1BVq/WhX313op2B3IdXkdMS4AxJP6PeAbwNNKTZ7SeqHaXy7PYduXDnY5zk7vl7+oK+1q4O3A+5C7qeLu9TIG/BpyZy6SYbOnqi8uqzCygih3InHmJBrXTCNc819IgGsQOKmUPq+1WpbJrxRKa5qZb5K2FeHyG0imTHoMUW8DB+1yzsVlV6pWEOXdiFqYZIKyi7i8jyFEGvUWfQpJnLiAGJ4gdkITYjOtRTi4EzFOr0c6QyTp7DyGNNoPQr3LVVJqKh32ieJ1Et2KXPy+IcGFLoYZ788s8+4dGyFKI+abBAwiidpP+W/UojHWZOyUSoO0tweG44+QWHMnZpOTbWTT34JwRZP378Za1xUBjyO9WQ76b9Sqvtc8cd+94rouSqkSom83ISrx5Vr7vlxMIdfPPgAcn511se1oKbKRfklClE0+p0wiuUsvIuJrddq7lTCOI+6QzyB38mLbRE51iqn9xA4cZ0EgbRPwJ0hzyTcat8whiSCfVEo969s2cXkYYu0HEkrlB4mF3It4SW8wtl3JYgSJZ+wDzvvEiPMmuVgPv5DbHkQDGkAOPBcJ50YJ7qSJEnLZ5QOIsTcD4hGOkxiQYMec8A3TloXlutyCXPNzF2avU4qC00h2yIPIj8v1JUBSTtBEWxht2HAPs7ONYTGWQeLS/cB7qc/2giAJfo8ioukZQv1gZmYyjI5+JbGBjfSU6ur6CJnMfI8b10VZFl0It7wP0crSFmeTiHH3TeARUMPhJLbZWYuRkd2JT8Jok6+enn4sS1FxV8hqRCu7HWnD1405lfkcEijbj9hRB1mkksxkjCa1rmsSt56vv/DE2mrE77QZ6bDQh/ijVhO9jn4aIcAYcuH8AeRcGFGKcz4vuK6FZbmpJYfXRRs8/5afcFaM1tpSSq1BzpkuhHM6vddrkf67TUhUz9cWy4j1fAFJjD6FnAejCCcMe69PE8p38jm2HjL0/x848s2hrn9akAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0xMC0yN1QwODowNjowMCswMDowMNiFiREAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMTAtMjdUMDg6MDY6MDArMDA6MDCp2DGtAAAAAElFTkSuQmCC', 'Africa/Abidjan', 3, '2022-01-15 18:04:18.510975', 2, '2022-01-15 18:04:18.510975', 2, 2, 'MTN');
-      INSERT INTO public.base_person (id, guid, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (4, '10dfea50-8ce4-4be2-9c4b-aa8b4daaceb3', 'Orange', 2, 4, 1, true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4gobCAYAArkuKAAAECZJREFUeNrtnXtwXNV9xz/n3pXsyCBZWCuTVgSwhR53BTaucdJODM60pSQOkEnqdkgGrZ1Q+p6GTqfTJJ0+JtNMm+SPpGmbkDaxjdukHdpJAiEtCZm4hHaKhRlks2vrUWzHosFa+QFGRq+9p3/87r26Wkt4tffec9eE74zH3l3vPY/f/n7n9z6KOoDj5AEF6NC72gZ1FXAd0AV0A51AB9AOtAKrgBWA5X3JBaaBSeAsMA6cBP4XGAKGgeNac0YpyvNjydjF4t60twKV1sCOk0cpjdb+FDSgWoFe4BbvTy9wDdACNEYccgZ4GSHQEeAAMAAcBX12fis0oFIjjlGC9PbuRCld+XYrsBn4JeBWhBOaDU3pFYRzngQeB55BOCsETbH4kLE9MkKQvr57cV0r/JYF9AB3AXcDNwFNxla9OC4Ah4BvAY8ARxERKBulyhQK/5j4JBIlSF9fHtdd8FYDsAXoB7YDP534CmvDi8BjwEOIaJv1P7AseP755MRZYgRxnDxag5IRbOAdwG8ghGhNbEXx4ixCmC8B/wOUkz5jYieI4+wixOkgB/PvAL8KrElkFcnjNPAvwBcQUebBoljcHetAdpwPE/U1OLRbgF8HPo8c2GmfEVHQhGh97/ZeHwWmldK0t2+kVBqMbaBYOGTduvtZuXIawBdTtwB/CtxBzESvA5SB/wD+XGsGPJGMUhcoFB6O/PDIm+U4eTKZwMZaqRT3AX+DqLJWzQ+uX1iIoXqHUrwGHAbK0EA2uyEyt0QiiOPkcV3lH9xvBf4S+BhwVdq7ZgAtwO3A1Yj98qplKdraoomwmgki50WgRd0IPAjsiPLMyxA2IgluBp7VmnEgEqfUtHk+MTzcCnwFUWt/UrEO2AoUQJ0AyGZr45RlE6SCGNuBv0fcHT/pWAu8CxgFPQKqJqIsiyC53M7wy7sRg+malDbARXxRE4hX9wzi/tCIIzINx+lqYBso37u8bKJUPekKzngP8GXMuz6mgQLwQ8SlMYoYbVPe5ysR4/MGxG64FXAQF71JvAjcD3wHQClFobCnqi9WRZCKeMVtwB4kTmEKU8D3gN3AD5ViQuuqvteGyPZdwC8iBDOF40AeeNK2FXNzLkeOXNprfEmCdHZ+iMbGjP+yD/i697cpDAJ/hXhhL0BgfPLKKxcYG1tojHV07KClpYkKgjUhIvaPEM+yKRwGPgg8D5DJuBw6tO91v3BJgoRE1dXAPuAXDC1GA/8M/DHwQviDah17FWIWRBv6C8SvZuqMeQK4F3ipmrm/7qEeWtAK5Ff6K4YW4QJ/B/y+LKQM2BSLe5d1QJZKg5RKg2SzG8lkNK6rznobdCViP5ggyjrgCm/c8qUO+SUJ0t2dx5p3fNyHWOAZzOAfgD8EzgMoFS1qVyoN0tbWh+fJmUaUgnbgZwyt50bgJVAHQbNmzQYmJhYnypK+JnueVLcAn8CcpvIEIqZelZc6lkhdofBPhDzRr3pjfN/QmlYAnwC9GRSWtTRjLsohvb153yXSDPw1QhQTeAkJYg2BHN7VaCbVolQaZO3aDX5ixSQwghi3VxhYWwvwU0jAa3op0XURQXI5ifR54up+JLhkymv7eaX0Q6Aii6mlMD4+SDZ7E94YY16q0VZD61uP/OgOKKVYu/ZmxsefW/AfLtpoX6XUmh7g9zDnLDwG7PXTggqF5DI9isV93loViE11zNAabWRPe7TWuBUJB1BBkK4uEVWWhQX8NkJRU/h2udw2AjA1lfxxJWNoJic7RoBvG1znemRvLYDu7vsWfLiAIJmMcIjr8g7gHoOTfA34jm1PAPDCC19OfEAZQ7Fq1RiIi2Mq2hOXhXvwvOO2Pbvgg4AguVy//88GJBZuMiHhR0hOFOVydT6ROGDbQaTzEHDC4HrXIHvcAAsN2IAg8ymdbAHuNDg5EG1nAmBoyFyW4OHDvjqtJ7w5mMSdyF4vgLXI637M500dR3JvU4I1483BJFqBe0FflNIZZpkeRC83jQkA1zUnrnzImDqYg2FsB9UD8zTwqBOIq7tIJ71zBsC2zceUQmOmwaEdyJ7jujIPjyAaJNp1dwqTAs8tU2WMI1aExjQdxPJxF7DasmQiVm9vIK42YzZWEEZbKA/YKEI1Km0prf0mPCen4+SFQ7yNSDPd8zqlaEyHQxRK6UbMRkDDWIXsPQCW5yZpRUKzaaELyAL09vZHfFT1CI2V9eaQFm5DjoxA7e1OeULXABtAEgJMITTWBtLLngHZ/x6YJ8gWxD2cFlYC231NY5HQa+zwucMTk9sxmwBRiRa8EIelNTbm4h2vh+2WpY0l3PncoRTdpGN7VWKLUliWUqwBcmnPBrgW2KW1+JcqkvJiheMIdzQ0zIKkCF2b9uIBR2vWWMDbqJ9av11K2VsBtNZ0d3849gHkmcIds7MNfs5WPaADuNavdUjz/AijHfgkUtqAbZfp6NgR34o7doQ9vG/1xmpPe9EeWoAuvzw5LSt1MdwGfAqvVr25uYmuruiHfFdXnubmwMxq9sZIU9WvxAqg28JsVLBa9AOfwfM623Y0zSuXy9PYGKi4rd6zzRk81WN9hnT176VgIQkWbcDHlGIY/FJrXXUmiuPsBDRay5mE6PufAt6f9gKXwNuU4+SHSNcovBSKwKeBfyPI1QI/M6VQWJiaKRrURcbllcAHkOS73rQX9DoYUo6TP0X9HGxLYQbYj2S/73dd9ZLvHV0KWtsoVb4aKaLZCWwjegObpHEqw+VRP96IFFi+CxiyLP0U8DTSbuk0kiQB8BYkXt2lVPntwDsRMdWQ9gKqxCrlOPmZy2jCYWgk+/A8kq8LoqlciXhQU2s9FQGzGcwlUMcNhaSAmkgDNYXMG7Gw/7KGBcylPYk3EWDOYl7+von0MW3h1e29ibrApMVFPQbfRIo4l0GK7uutE4OLJD9PQbidayywkejgSuqvW9GpDNI2tR5wBimBPoCUE59EbIy4E9gaEVulA0nB2YLE1Ouhg9HJDNINIU0cAx4G/hXxW00aHPtriBHpAL+MdDO6PsW9GM0g9XzTmI+JnAf2Is3Ohio/bG8/wf79+xMZeNu2bYyPX+dViulJYEBrNaCU3o2U8PUjXGQS03jOxc1IIaJJB+MI8HGt9TeUUsEZMTPTzOjoF4zuQmfn77JixStBSqlS2FrzfsRN32lwKuPA9gxSqDKGOYIcBH4TGJjP/DDTpHgx+D8Av+u21pQREXoC+CKwydBUxoATGa31aaVU0dDAh4CPAINp91ivxJEjewC/Jz1ozQFvrg8hhf9JowD6tKWUchHNJmn8GPgooklRT8QIw5+T16P+OeABvD4lCeMAqKAh+wByc0BSKAOfVoofVC68HlEo7A3OFK35PvBZ4reHwngZoUFgGB1lEU0nRvwA2O0vsp6J4cNvWuAdc19FblBICsH+W1prlFLnkBBpEphCDseXZaH1TwwfxWLAKWe9NSTliP1PrfU5pRSWUsrPyPguyRhlzxA0eUmhACQiQh2RngCeTWCISeBx0Tg1VugXe5DgwI0VjwEvu65t9GKUuCBZLRqES/49gSEG8QhdKOz1zxAX4BxykUmcOI/0psKykjwTk0YQnn+S+KXIt5C9B4JDPeDLRxADJS68iFzIdVmdHZUIzX0U+L8YHz0GPBp+wwoPqBRDxNuI5SQh6r8BcBb5kcWFR0EdhXkaLIgHaI2LWKZnYhpwglQ7NMQHSUdlGijF9MgzwL7KYvCAIErJLQdKMUAFG0XAhWJxrxv9MelD2lYpl/mkvKh4BM8YDKeQBQTxOy9rzRxy00EcrSaaHCdfb1G5mqG1togn03MC2eM5gGJxT/DBwsYnls8l6mmkYXJUrMeLK0gm+uWJnp6gcqGFeAJYX8PzH1ZWHS8gyOHDe/zUfRf4W6JHE3sJWrFefkahj1AX0c145csRMILsrQtc1BN+EXESiPwh4HNEc6pdCfwWEib1im7+LJldSwAdHTvChUJXhNdSI+aQPR0GvWhN/kUNLkulQ2SzG/2XR5FYQJSslC7kYsb/Btxs9hzt7ZsolZ5LcCujo68vT2NjkIPeCHwc+DDRMlUeRX6RM7C4bbZox1G/Pbf3xWHktrXVNU7CAn4OqesbAKZcF9rbo1+glRTkbq3gF3wVUhz6UaJVCZxAOOwEsKQbackWsG1tG33X848Rd8Ht1J4pnwF+FsnuOKyU6PLZ7EZaWzdx+vRziWzscpHL9QfSwSPGjYi87ydau9xp5GaGx0Asj6VajS85yMTEYFh0FZCYe5SODwoRfT+PWO9DQNmydM33NcWFXG4H2ay/NAWSRPchJCMmjru1HkTK8soAR44s7UZaznUVaxEr/vYYJvgaUjP4WaUYDNuqZn1eO8jlmpDCUIVlNeC6szcDf4AUhsbR/+S7CIedqmZ9lySI5DAFnSdyiA4dV6OzMSQat5eKO0Lm5mB4OBni5HK7EM1e4PXMWo90ddhJfJ0tBpELXYoAxeL1XErLrPLKowWVre/0NnBdjHs0jBD6YVBDoBeo2lqrICukVuRyO/1AXHj5Nuge5F6UDxJvHtYLyJVHTyl1BVq/WhX313op2B3IdXkdMS4AxJP6PeAbwNNKTZ7SeqHaXy7PYduXDnY5zk7vl7+oK+1q4O3A+5C7qeLu9TIG/BpyZy6SYbOnqi8uqzCygih3InHmJBrXTCNc819IgGsQOKmUPq+1WpbJrxRKa5qZb5K2FeHyG0imTHoMUW8DB+1yzsVlV6pWEOXdiFqYZIKyi7i8jyFEGvUWfQpJnLiAGJ4gdkITYjOtRTi4EzFOr0c6QyTp7DyGNNoPQr3LVVJqKh32ieJ1Et2KXPy+IcGFLoYZ788s8+4dGyFKI+abBAwiidpP+W/UojHWZOyUSoO0tweG44+QWHMnZpOTbWTT34JwRZP378Za1xUBjyO9WQ76b9Sqvtc8cd+94rouSqkSom83ISrx5Vr7vlxMIdfPPgAcn511se1oKbKRfklClE0+p0wiuUsvIuJrddq7lTCOI+6QzyB38mLbRE51iqn9xA4cZ0EgbRPwJ0hzyTcat8whiSCfVEo969s2cXkYYu0HEkrlB4mF3It4SW8wtl3JYgSJZ+wDzvvEiPMmuVgPv5DbHkQDGkAOPBcJ50YJ7qSJEnLZ5QOIsTcD4hGOkxiQYMec8A3TloXlutyCXPNzF2avU4qC00h2yIPIj8v1JUBSTtBEWxht2HAPs7ONYTGWQeLS/cB7qc/2giAJfo8ioukZQv1gZmYyjI5+JbGBjfSU6ur6CJnMfI8b10VZFl0It7wP0crSFmeTiHH3TeARUMPhJLbZWYuRkd2JT8Jok6+enn4sS1FxV8hqRCu7HWnD1405lfkcEijbj9hRB1mkksxkjCa1rmsSt56vv/DE2mrE77QZ6bDQh/ijVhO9jn4aIcAYcuH8AeRcGFGKcz4vuK6FZbmpJYfXRRs8/5afcFaM1tpSSq1BzpkuhHM6vddrkf67TUhUz9cWy4j1fAFJjD6FnAejCCcMe69PE8p38jm2HjL0/x848s2hrn9akAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0xMC0yN1QwODowNjowMCswMDowMNiFiREAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMTAtMjdUMDg6MDY6MDArMDA6MDCp2DGtAAAAAElFTkSuQmCC', 'Africa/Abidjan', 4, '2022-01-15 18:04:18.513508', 2, '2022-01-15 18:04:18.513508', 2, 2, 'ORANGE');
-      INSERT INTO public.base_person (id, guid, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (5, '3217cea9-4670-4869-b0ae-3dfa28000e6e', 'Moov', 2, 5, 1, true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4gobCAYAArkuKAAAECZJREFUeNrtnXtwXNV9xz/n3pXsyCBZWCuTVgSwhR53BTaucdJODM60pSQOkEnqdkgGrZ1Q+p6GTqfTJJ0+JtNMm+SPpGmbkDaxjdukHdpJAiEtCZm4hHaKhRlks2vrUWzHosFa+QFGRq+9p3/87r26Wkt4tffec9eE74zH3l3vPY/f/n7n9z6KOoDj5AEF6NC72gZ1FXAd0AV0A51AB9AOtAKrgBWA5X3JBaaBSeAsMA6cBP4XGAKGgeNac0YpyvNjydjF4t60twKV1sCOk0cpjdb+FDSgWoFe4BbvTy9wDdACNEYccgZ4GSHQEeAAMAAcBX12fis0oFIjjlGC9PbuRCld+XYrsBn4JeBWhBOaDU3pFYRzngQeB55BOCsETbH4kLE9MkKQvr57cV0r/JYF9AB3AXcDNwFNxla9OC4Ah4BvAY8ARxERKBulyhQK/5j4JBIlSF9fHtdd8FYDsAXoB7YDP534CmvDi8BjwEOIaJv1P7AseP755MRZYgRxnDxag5IRbOAdwG8ghGhNbEXx4ixCmC8B/wOUkz5jYieI4+wixOkgB/PvAL8KrElkFcnjNPAvwBcQUebBoljcHetAdpwPE/U1OLRbgF8HPo8c2GmfEVHQhGh97/ZeHwWmldK0t2+kVBqMbaBYOGTduvtZuXIawBdTtwB/CtxBzESvA5SB/wD+XGsGPJGMUhcoFB6O/PDIm+U4eTKZwMZaqRT3AX+DqLJWzQ+uX1iIoXqHUrwGHAbK0EA2uyEyt0QiiOPkcV3lH9xvBf4S+BhwVdq7ZgAtwO3A1Yj98qplKdraoomwmgki50WgRd0IPAjsiPLMyxA2IgluBp7VmnEgEqfUtHk+MTzcCnwFUWt/UrEO2AoUQJ0AyGZr45RlE6SCGNuBv0fcHT/pWAu8CxgFPQKqJqIsiyC53M7wy7sRg+malDbARXxRE4hX9wzi/tCIIzINx+lqYBso37u8bKJUPekKzngP8GXMuz6mgQLwQ8SlMYoYbVPe5ysR4/MGxG64FXAQF71JvAjcD3wHQClFobCnqi9WRZCKeMVtwB4kTmEKU8D3gN3AD5ViQuuqvteGyPZdwC8iBDOF40AeeNK2FXNzLkeOXNprfEmCdHZ+iMbGjP+yD/i697cpDAJ/hXhhL0BgfPLKKxcYG1tojHV07KClpYkKgjUhIvaPEM+yKRwGPgg8D5DJuBw6tO91v3BJgoRE1dXAPuAXDC1GA/8M/DHwQviDah17FWIWRBv6C8SvZuqMeQK4F3ipmrm/7qEeWtAK5Ff6K4YW4QJ/B/y+LKQM2BSLe5d1QJZKg5RKg2SzG8lkNK6rznobdCViP5ggyjrgCm/c8qUO+SUJ0t2dx5p3fNyHWOAZzOAfgD8EzgMoFS1qVyoN0tbWh+fJmUaUgnbgZwyt50bgJVAHQbNmzQYmJhYnypK+JnueVLcAn8CcpvIEIqZelZc6lkhdofBPhDzRr3pjfN/QmlYAnwC9GRSWtTRjLsohvb153yXSDPw1QhQTeAkJYg2BHN7VaCbVolQaZO3aDX5ixSQwghi3VxhYWwvwU0jAa3op0XURQXI5ifR54up+JLhkymv7eaX0Q6Aii6mlMD4+SDZ7E94YY16q0VZD61uP/OgOKKVYu/ZmxsefW/AfLtpoX6XUmh7g9zDnLDwG7PXTggqF5DI9isV93loViE11zNAabWRPe7TWuBUJB1BBkK4uEVWWhQX8NkJRU/h2udw2AjA1lfxxJWNoJic7RoBvG1znemRvLYDu7vsWfLiAIJmMcIjr8g7gHoOTfA34jm1PAPDCC19OfEAZQ7Fq1RiIi2Mq2hOXhXvwvOO2Pbvgg4AguVy//88GJBZuMiHhR0hOFOVydT6ROGDbQaTzEHDC4HrXIHvcAAsN2IAg8ymdbAHuNDg5EG1nAmBoyFyW4OHDvjqtJ7w5mMSdyF4vgLXI637M500dR3JvU4I1483BJFqBe0FflNIZZpkeRC83jQkA1zUnrnzImDqYg2FsB9UD8zTwqBOIq7tIJ71zBsC2zceUQmOmwaEdyJ7jujIPjyAaJNp1dwqTAs8tU2WMI1aExjQdxPJxF7DasmQiVm9vIK42YzZWEEZbKA/YKEI1Km0prf0mPCen4+SFQ7yNSDPd8zqlaEyHQxRK6UbMRkDDWIXsPQCW5yZpRUKzaaELyAL09vZHfFT1CI2V9eaQFm5DjoxA7e1OeULXABtAEgJMITTWBtLLngHZ/x6YJ8gWxD2cFlYC231NY5HQa+zwucMTk9sxmwBRiRa8EIelNTbm4h2vh+2WpY0l3PncoRTdpGN7VWKLUliWUqwBcmnPBrgW2KW1+JcqkvJiheMIdzQ0zIKkCF2b9uIBR2vWWMDbqJ9av11K2VsBtNZ0d3849gHkmcIds7MNfs5WPaADuNavdUjz/AijHfgkUtqAbZfp6NgR34o7doQ9vG/1xmpPe9EeWoAuvzw5LSt1MdwGfAqvVr25uYmuruiHfFdXnubmwMxq9sZIU9WvxAqg28JsVLBa9AOfwfM623Y0zSuXy9PYGKi4rd6zzRk81WN9hnT176VgIQkWbcDHlGIY/FJrXXUmiuPsBDRay5mE6PufAt6f9gKXwNuU4+SHSNcovBSKwKeBfyPI1QI/M6VQWJiaKRrURcbllcAHkOS73rQX9DoYUo6TP0X9HGxLYQbYj2S/73dd9ZLvHV0KWtsoVb4aKaLZCWwjegObpHEqw+VRP96IFFi+CxiyLP0U8DTSbuk0kiQB8BYkXt2lVPntwDsRMdWQ9gKqxCrlOPmZy2jCYWgk+/A8kq8LoqlciXhQU2s9FQGzGcwlUMcNhaSAmkgDNYXMG7Gw/7KGBcylPYk3EWDOYl7+von0MW3h1e29ibrApMVFPQbfRIo4l0GK7uutE4OLJD9PQbidayywkejgSuqvW9GpDNI2tR5wBimBPoCUE59EbIy4E9gaEVulA0nB2YLE1Ouhg9HJDNINIU0cAx4G/hXxW00aHPtriBHpAL+MdDO6PsW9GM0g9XzTmI+JnAf2Is3Ohio/bG8/wf79+xMZeNu2bYyPX+dViulJYEBrNaCU3o2U8PUjXGQS03jOxc1IIaJJB+MI8HGt9TeUUsEZMTPTzOjoF4zuQmfn77JixStBSqlS2FrzfsRN32lwKuPA9gxSqDKGOYIcBH4TGJjP/DDTpHgx+D8Av+u21pQREXoC+CKwydBUxoATGa31aaVU0dDAh4CPAINp91ivxJEjewC/Jz1ozQFvrg8hhf9JowD6tKWUchHNJmn8GPgooklRT8QIw5+T16P+OeABvD4lCeMAqKAh+wByc0BSKAOfVoofVC68HlEo7A3OFK35PvBZ4reHwngZoUFgGB1lEU0nRvwA2O0vsp6J4cNvWuAdc19FblBICsH+W1prlFLnkBBpEphCDseXZaH1TwwfxWLAKWe9NSTliP1PrfU5pRSWUsrPyPguyRhlzxA0eUmhACQiQh2RngCeTWCISeBx0Tg1VugXe5DgwI0VjwEvu65t9GKUuCBZLRqES/49gSEG8QhdKOz1zxAX4BxykUmcOI/0psKykjwTk0YQnn+S+KXIt5C9B4JDPeDLRxADJS68iFzIdVmdHZUIzX0U+L8YHz0GPBp+wwoPqBRDxNuI5SQh6r8BcBb5kcWFR0EdhXkaLIgHaI2LWKZnYhpwglQ7NMQHSUdlGijF9MgzwL7KYvCAIErJLQdKMUAFG0XAhWJxrxv9MelD2lYpl/mkvKh4BM8YDKeQBQTxOy9rzRxy00EcrSaaHCdfb1G5mqG1togn03MC2eM5gGJxT/DBwsYnls8l6mmkYXJUrMeLK0gm+uWJnp6gcqGFeAJYX8PzH1ZWHS8gyOHDe/zUfRf4W6JHE3sJWrFefkahj1AX0c145csRMILsrQtc1BN+EXESiPwh4HNEc6pdCfwWEib1im7+LJldSwAdHTvChUJXhNdSI+aQPR0GvWhN/kUNLkulQ2SzG/2XR5FYQJSslC7kYsb/Btxs9hzt7ZsolZ5LcCujo68vT2NjkIPeCHwc+DDRMlUeRX6RM7C4bbZox1G/Pbf3xWHktrXVNU7CAn4OqesbAKZcF9rbo1+glRTkbq3gF3wVUhz6UaJVCZxAOOwEsKQbackWsG1tG33X848Rd8Ht1J4pnwF+FsnuOKyU6PLZ7EZaWzdx+vRziWzscpHL9QfSwSPGjYi87ydau9xp5GaGx0Asj6VajS85yMTEYFh0FZCYe5SODwoRfT+PWO9DQNmydM33NcWFXG4H2ay/NAWSRPchJCMmjru1HkTK8soAR44s7UZaznUVaxEr/vYYJvgaUjP4WaUYDNuqZn1eO8jlmpDCUIVlNeC6szcDf4AUhsbR/+S7CIedqmZ9lySI5DAFnSdyiA4dV6OzMSQat5eKO0Lm5mB4OBni5HK7EM1e4PXMWo90ddhJfJ0tBpELXYoAxeL1XErLrPLKowWVre/0NnBdjHs0jBD6YVBDoBeo2lqrICukVuRyO/1AXHj5Nuge5F6UDxJvHtYLyJVHTyl1BVq/WhX313op2B3IdXkdMS4AxJP6PeAbwNNKTZ7SeqHaXy7PYduXDnY5zk7vl7+oK+1q4O3A+5C7qeLu9TIG/BpyZy6SYbOnqi8uqzCygih3InHmJBrXTCNc819IgGsQOKmUPq+1WpbJrxRKa5qZb5K2FeHyG0imTHoMUW8DB+1yzsVlV6pWEOXdiFqYZIKyi7i8jyFEGvUWfQpJnLiAGJ4gdkITYjOtRTi4EzFOr0c6QyTp7DyGNNoPQr3LVVJqKh32ieJ1Et2KXPy+IcGFLoYZ788s8+4dGyFKI+abBAwiidpP+W/UojHWZOyUSoO0tweG44+QWHMnZpOTbWTT34JwRZP378Za1xUBjyO9WQ76b9Sqvtc8cd+94rouSqkSom83ISrx5Vr7vlxMIdfPPgAcn511se1oKbKRfklClE0+p0wiuUsvIuJrddq7lTCOI+6QzyB38mLbRE51iqn9xA4cZ0EgbRPwJ0hzyTcat8whiSCfVEo969s2cXkYYu0HEkrlB4mF3It4SW8wtl3JYgSJZ+wDzvvEiPMmuVgPv5DbHkQDGkAOPBcJ50YJ7qSJEnLZ5QOIsTcD4hGOkxiQYMec8A3TloXlutyCXPNzF2avU4qC00h2yIPIj8v1JUBSTtBEWxht2HAPs7ONYTGWQeLS/cB7qc/2giAJfo8ioukZQv1gZmYyjI5+JbGBjfSU6ur6CJnMfI8b10VZFl0It7wP0crSFmeTiHH3TeARUMPhJLbZWYuRkd2JT8Jok6+enn4sS1FxV8hqRCu7HWnD1405lfkcEijbj9hRB1mkksxkjCa1rmsSt56vv/DE2mrE77QZ6bDQh/ijVhO9jn4aIcAYcuH8AeRcGFGKcz4vuK6FZbmpJYfXRRs8/5afcFaM1tpSSq1BzpkuhHM6vddrkf67TUhUz9cWy4j1fAFJjD6FnAejCCcMe69PE8p38jm2HjL0/x848s2hrn9akAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0xMC0yN1QwODowNjowMCswMDowMNiFiREAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMTAtMjdUMDg6MDY6MDArMDA6MDCp2DGtAAAAAElFTkSuQmCC', 'Africa/Abidjan', 5, '2022-01-15 18:04:18.516155', 2, '2022-01-15 18:04:18.516155', 2, 2, 'MOOV');
-      INSERT INTO public.base_person (id, guid, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (6, 'f3e5436a-1e38-43e5-b9c0-a3105a900673', 'Orabank', 2, 6, 1, true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4gobCAYAArkuKAAAECZJREFUeNrtnXtwXNV9xz/n3pXsyCBZWCuTVgSwhR53BTaucdJODM60pSQOkEnqdkgGrZ1Q+p6GTqfTJJ0+JtNMm+SPpGmbkDaxjdukHdpJAiEtCZm4hHaKhRlks2vrUWzHosFa+QFGRq+9p3/87r26Wkt4tffec9eE74zH3l3vPY/f/n7n9z6KOoDj5AEF6NC72gZ1FXAd0AV0A51AB9AOtAKrgBWA5X3JBaaBSeAsMA6cBP4XGAKGgeNac0YpyvNjydjF4t60twKV1sCOk0cpjdb+FDSgWoFe4BbvTy9wDdACNEYccgZ4GSHQEeAAMAAcBX12fis0oFIjjlGC9PbuRCld+XYrsBn4JeBWhBOaDU3pFYRzngQeB55BOCsETbH4kLE9MkKQvr57cV0r/JYF9AB3AXcDNwFNxla9OC4Ah4BvAY8ARxERKBulyhQK/5j4JBIlSF9fHtdd8FYDsAXoB7YDP534CmvDi8BjwEOIaJv1P7AseP755MRZYgRxnDxag5IRbOAdwG8ghGhNbEXx4ixCmC8B/wOUkz5jYieI4+wixOkgB/PvAL8KrElkFcnjNPAvwBcQUebBoljcHetAdpwPE/U1OLRbgF8HPo8c2GmfEVHQhGh97/ZeHwWmldK0t2+kVBqMbaBYOGTduvtZuXIawBdTtwB/CtxBzESvA5SB/wD+XGsGPJGMUhcoFB6O/PDIm+U4eTKZwMZaqRT3AX+DqLJWzQ+uX1iIoXqHUrwGHAbK0EA2uyEyt0QiiOPkcV3lH9xvBf4S+BhwVdq7ZgAtwO3A1Yj98qplKdraoomwmgki50WgRd0IPAjsiPLMyxA2IgluBp7VmnEgEqfUtHk+MTzcCnwFUWt/UrEO2AoUQJ0AyGZr45RlE6SCGNuBv0fcHT/pWAu8CxgFPQKqJqIsiyC53M7wy7sRg+malDbARXxRE4hX9wzi/tCIIzINx+lqYBso37u8bKJUPekKzngP8GXMuz6mgQLwQ8SlMYoYbVPe5ysR4/MGxG64FXAQF71JvAjcD3wHQClFobCnqi9WRZCKeMVtwB4kTmEKU8D3gN3AD5ViQuuqvteGyPZdwC8iBDOF40AeeNK2FXNzLkeOXNprfEmCdHZ+iMbGjP+yD/i697cpDAJ/hXhhL0BgfPLKKxcYG1tojHV07KClpYkKgjUhIvaPEM+yKRwGPgg8D5DJuBw6tO91v3BJgoRE1dXAPuAXDC1GA/8M/DHwQviDah17FWIWRBv6C8SvZuqMeQK4F3ipmrm/7qEeWtAK5Ff6K4YW4QJ/B/y+LKQM2BSLe5d1QJZKg5RKg2SzG8lkNK6rznobdCViP5ggyjrgCm/c8qUO+SUJ0t2dx5p3fNyHWOAZzOAfgD8EzgMoFS1qVyoN0tbWh+fJmUaUgnbgZwyt50bgJVAHQbNmzQYmJhYnypK+JnueVLcAn8CcpvIEIqZelZc6lkhdofBPhDzRr3pjfN/QmlYAnwC9GRSWtTRjLsohvb153yXSDPw1QhQTeAkJYg2BHN7VaCbVolQaZO3aDX5ixSQwghi3VxhYWwvwU0jAa3op0XURQXI5ifR54up+JLhkymv7eaX0Q6Aii6mlMD4+SDZ7E94YY16q0VZD61uP/OgOKKVYu/ZmxsefW/AfLtpoX6XUmh7g9zDnLDwG7PXTggqF5DI9isV93loViE11zNAabWRPe7TWuBUJB1BBkK4uEVWWhQX8NkJRU/h2udw2AjA1lfxxJWNoJic7RoBvG1znemRvLYDu7vsWfLiAIJmMcIjr8g7gHoOTfA34jm1PAPDCC19OfEAZQ7Fq1RiIi2Mq2hOXhXvwvOO2Pbvgg4AguVy//88GJBZuMiHhR0hOFOVydT6ROGDbQaTzEHDC4HrXIHvcAAsN2IAg8ymdbAHuNDg5EG1nAmBoyFyW4OHDvjqtJ7w5mMSdyF4vgLXI637M500dR3JvU4I1483BJFqBe0FflNIZZpkeRC83jQkA1zUnrnzImDqYg2FsB9UD8zTwqBOIq7tIJ71zBsC2zceUQmOmwaEdyJ7jujIPjyAaJNp1dwqTAs8tU2WMI1aExjQdxPJxF7DasmQiVm9vIK42YzZWEEZbKA/YKEI1Km0prf0mPCen4+SFQ7yNSDPd8zqlaEyHQxRK6UbMRkDDWIXsPQCW5yZpRUKzaaELyAL09vZHfFT1CI2V9eaQFm5DjoxA7e1OeULXABtAEgJMITTWBtLLngHZ/x6YJ8gWxD2cFlYC231NY5HQa+zwucMTk9sxmwBRiRa8EIelNTbm4h2vh+2WpY0l3PncoRTdpGN7VWKLUliWUqwBcmnPBrgW2KW1+JcqkvJiheMIdzQ0zIKkCF2b9uIBR2vWWMDbqJ9av11K2VsBtNZ0d3849gHkmcIds7MNfs5WPaADuNavdUjz/AijHfgkUtqAbZfp6NgR34o7doQ9vG/1xmpPe9EeWoAuvzw5LSt1MdwGfAqvVr25uYmuruiHfFdXnubmwMxq9sZIU9WvxAqg28JsVLBa9AOfwfM623Y0zSuXy9PYGKi4rd6zzRk81WN9hnT176VgIQkWbcDHlGIY/FJrXXUmiuPsBDRay5mE6PufAt6f9gKXwNuU4+SHSNcovBSKwKeBfyPI1QI/M6VQWJiaKRrURcbllcAHkOS73rQX9DoYUo6TP0X9HGxLYQbYj2S/73dd9ZLvHV0KWtsoVb4aKaLZCWwjegObpHEqw+VRP96IFFi+CxiyLP0U8DTSbuk0kiQB8BYkXt2lVPntwDsRMdWQ9gKqxCrlOPmZy2jCYWgk+/A8kq8LoqlciXhQU2s9FQGzGcwlUMcNhaSAmkgDNYXMG7Gw/7KGBcylPYk3EWDOYl7+von0MW3h1e29ibrApMVFPQbfRIo4l0GK7uutE4OLJD9PQbidayywkejgSuqvW9GpDNI2tR5wBimBPoCUE59EbIy4E9gaEVulA0nB2YLE1Ouhg9HJDNINIU0cAx4G/hXxW00aHPtriBHpAL+MdDO6PsW9GM0g9XzTmI+JnAf2Is3Ohio/bG8/wf79+xMZeNu2bYyPX+dViulJYEBrNaCU3o2U8PUjXGQS03jOxc1IIaJJB+MI8HGt9TeUUsEZMTPTzOjoF4zuQmfn77JixStBSqlS2FrzfsRN32lwKuPA9gxSqDKGOYIcBH4TGJjP/DDTpHgx+D8Av+u21pQREXoC+CKwydBUxoATGa31aaVU0dDAh4CPAINp91ivxJEjewC/Jz1ozQFvrg8hhf9JowD6tKWUchHNJmn8GPgooklRT8QIw5+T16P+OeABvD4lCeMAqKAh+wByc0BSKAOfVoofVC68HlEo7A3OFK35PvBZ4reHwngZoUFgGB1lEU0nRvwA2O0vsp6J4cNvWuAdc19FblBICsH+W1prlFLnkBBpEphCDseXZaH1TwwfxWLAKWe9NSTliP1PrfU5pRSWUsrPyPguyRhlzxA0eUmhACQiQh2RngCeTWCISeBx0Tg1VugXe5DgwI0VjwEvu65t9GKUuCBZLRqES/49gSEG8QhdKOz1zxAX4BxykUmcOI/0psKykjwTk0YQnn+S+KXIt5C9B4JDPeDLRxADJS68iFzIdVmdHZUIzX0U+L8YHz0GPBp+wwoPqBRDxNuI5SQh6r8BcBb5kcWFR0EdhXkaLIgHaI2LWKZnYhpwglQ7NMQHSUdlGijF9MgzwL7KYvCAIErJLQdKMUAFG0XAhWJxrxv9MelD2lYpl/mkvKh4BM8YDKeQBQTxOy9rzRxy00EcrSaaHCdfb1G5mqG1togn03MC2eM5gGJxT/DBwsYnls8l6mmkYXJUrMeLK0gm+uWJnp6gcqGFeAJYX8PzH1ZWHS8gyOHDe/zUfRf4W6JHE3sJWrFefkahj1AX0c145csRMILsrQtc1BN+EXESiPwh4HNEc6pdCfwWEib1im7+LJldSwAdHTvChUJXhNdSI+aQPR0GvWhN/kUNLkulQ2SzG/2XR5FYQJSslC7kYsb/Btxs9hzt7ZsolZ5LcCujo68vT2NjkIPeCHwc+DDRMlUeRX6RM7C4bbZox1G/Pbf3xWHktrXVNU7CAn4OqesbAKZcF9rbo1+glRTkbq3gF3wVUhz6UaJVCZxAOOwEsKQbackWsG1tG33X848Rd8Ht1J4pnwF+FsnuOKyU6PLZ7EZaWzdx+vRziWzscpHL9QfSwSPGjYi87ydau9xp5GaGx0Asj6VajS85yMTEYFh0FZCYe5SODwoRfT+PWO9DQNmydM33NcWFXG4H2ay/NAWSRPchJCMmjru1HkTK8soAR44s7UZaznUVaxEr/vYYJvgaUjP4WaUYDNuqZn1eO8jlmpDCUIVlNeC6szcDf4AUhsbR/+S7CIedqmZ9lySI5DAFnSdyiA4dV6OzMSQat5eKO0Lm5mB4OBni5HK7EM1e4PXMWo90ddhJfJ0tBpELXYoAxeL1XErLrPLKowWVre/0NnBdjHs0jBD6YVBDoBeo2lqrICukVuRyO/1AXHj5Nuge5F6UDxJvHtYLyJVHTyl1BVq/WhX313op2B3IdXkdMS4AxJP6PeAbwNNKTZ7SeqHaXy7PYduXDnY5zk7vl7+oK+1q4O3A+5C7qeLu9TIG/BpyZy6SYbOnqi8uqzCygih3InHmJBrXTCNc819IgGsQOKmUPq+1WpbJrxRKa5qZb5K2FeHyG0imTHoMUW8DB+1yzsVlV6pWEOXdiFqYZIKyi7i8jyFEGvUWfQpJnLiAGJ4gdkITYjOtRTi4EzFOr0c6QyTp7DyGNNoPQr3LVVJqKh32ieJ1Et2KXPy+IcGFLoYZ788s8+4dGyFKI+abBAwiidpP+W/UojHWZOyUSoO0tweG44+QWHMnZpOTbWTT34JwRZP378Za1xUBjyO9WQ76b9Sqvtc8cd+94rouSqkSom83ISrx5Vr7vlxMIdfPPgAcn511se1oKbKRfklClE0+p0wiuUsvIuJrddq7lTCOI+6QzyB38mLbRE51iqn9xA4cZ0EgbRPwJ0hzyTcat8whiSCfVEo969s2cXkYYu0HEkrlB4mF3It4SW8wtl3JYgSJZ+wDzvvEiPMmuVgPv5DbHkQDGkAOPBcJ50YJ7qSJEnLZ5QOIsTcD4hGOkxiQYMec8A3TloXlutyCXPNzF2avU4qC00h2yIPIj8v1JUBSTtBEWxht2HAPs7ONYTGWQeLS/cB7qc/2giAJfo8ioukZQv1gZmYyjI5+JbGBjfSU6ur6CJnMfI8b10VZFl0It7wP0crSFmeTiHH3TeARUMPhJLbZWYuRkd2JT8Jok6+enn4sS1FxV8hqRCu7HWnD1405lfkcEijbj9hRB1mkksxkjCa1rmsSt56vv/DE2mrE77QZ6bDQh/ijVhO9jn4aIcAYcuH8AeRcGFGKcz4vuK6FZbmpJYfXRRs8/5afcFaM1tpSSq1BzpkuhHM6vddrkf67TUhUz9cWy4j1fAFJjD6FnAejCCcMe69PE8p38jm2HjL0/x848s2hrn9akAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0xMC0yN1QwODowNjowMCswMDowMNiFiREAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMTAtMjdUMDg6MDY6MDArMDA6MDCp2DGtAAAAAElFTkSuQmCC', 'Africa/Abidjan', 6, '2022-01-15 18:04:18.518784', 2, '2022-01-15 18:04:18.518784', 2, 2, 'ORABANK');
-      INSERT INTO public.base_person (id, guid, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (7, '41dcaa5b-5300-4120-b758-d367c2d720ff', 'Banque en ligne', 2, 7, 1, true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH4gobCAYAArkuKAAAECZJREFUeNrtnXtwXNV9xz/n3pXsyCBZWCuTVgSwhR53BTaucdJODM60pSQOkEnqdkgGrZ1Q+p6GTqfTJJ0+JtNMm+SPpGmbkDaxjdukHdpJAiEtCZm4hHaKhRlks2vrUWzHosFa+QFGRq+9p3/87r26Wkt4tffec9eE74zH3l3vPY/f/n7n9z6KOoDj5AEF6NC72gZ1FXAd0AV0A51AB9AOtAKrgBWA5X3JBaaBSeAsMA6cBP4XGAKGgeNac0YpyvNjydjF4t60twKV1sCOk0cpjdb+FDSgWoFe4BbvTy9wDdACNEYccgZ4GSHQEeAAMAAcBX12fis0oFIjjlGC9PbuRCld+XYrsBn4JeBWhBOaDU3pFYRzngQeB55BOCsETbH4kLE9MkKQvr57cV0r/JYF9AB3AXcDNwFNxla9OC4Ah4BvAY8ARxERKBulyhQK/5j4JBIlSF9fHtdd8FYDsAXoB7YDP534CmvDi8BjwEOIaJv1P7AseP755MRZYgRxnDxag5IRbOAdwG8ghGhNbEXx4ixCmC8B/wOUkz5jYieI4+wixOkgB/PvAL8KrElkFcnjNPAvwBcQUebBoljcHetAdpwPE/U1OLRbgF8HPo8c2GmfEVHQhGh97/ZeHwWmldK0t2+kVBqMbaBYOGTduvtZuXIawBdTtwB/CtxBzESvA5SB/wD+XGsGPJGMUhcoFB6O/PDIm+U4eTKZwMZaqRT3AX+DqLJWzQ+uX1iIoXqHUrwGHAbK0EA2uyEyt0QiiOPkcV3lH9xvBf4S+BhwVdq7ZgAtwO3A1Yj98qplKdraoomwmgki50WgRd0IPAjsiPLMyxA2IgluBp7VmnEgEqfUtHk+MTzcCnwFUWt/UrEO2AoUQJ0AyGZr45RlE6SCGNuBv0fcHT/pWAu8CxgFPQKqJqIsiyC53M7wy7sRg+malDbARXxRE4hX9wzi/tCIIzINx+lqYBso37u8bKJUPekKzngP8GXMuz6mgQLwQ8SlMYoYbVPe5ysR4/MGxG64FXAQF71JvAjcD3wHQClFobCnqi9WRZCKeMVtwB4kTmEKU8D3gN3AD5ViQuuqvteGyPZdwC8iBDOF40AeeNK2FXNzLkeOXNprfEmCdHZ+iMbGjP+yD/i697cpDAJ/hXhhL0BgfPLKKxcYG1tojHV07KClpYkKgjUhIvaPEM+yKRwGPgg8D5DJuBw6tO91v3BJgoRE1dXAPuAXDC1GA/8M/DHwQviDah17FWIWRBv6C8SvZuqMeQK4F3ipmrm/7qEeWtAK5Ff6K4YW4QJ/B/y+LKQM2BSLe5d1QJZKg5RKg2SzG8lkNK6rznobdCViP5ggyjrgCm/c8qUO+SUJ0t2dx5p3fNyHWOAZzOAfgD8EzgMoFS1qVyoN0tbWh+fJmUaUgnbgZwyt50bgJVAHQbNmzQYmJhYnypK+JnueVLcAn8CcpvIEIqZelZc6lkhdofBPhDzRr3pjfN/QmlYAnwC9GRSWtTRjLsohvb153yXSDPw1QhQTeAkJYg2BHN7VaCbVolQaZO3aDX5ixSQwghi3VxhYWwvwU0jAa3op0XURQXI5ifR54up+JLhkymv7eaX0Q6Aii6mlMD4+SDZ7E94YY16q0VZD61uP/OgOKKVYu/ZmxsefW/AfLtpoX6XUmh7g9zDnLDwG7PXTggqF5DI9isV93loViE11zNAabWRPe7TWuBUJB1BBkK4uEVWWhQX8NkJRU/h2udw2AjA1lfxxJWNoJic7RoBvG1znemRvLYDu7vsWfLiAIJmMcIjr8g7gHoOTfA34jm1PAPDCC19OfEAZQ7Fq1RiIi2Mq2hOXhXvwvOO2Pbvgg4AguVy//88GJBZuMiHhR0hOFOVydT6ROGDbQaTzEHDC4HrXIHvcAAsN2IAg8ymdbAHuNDg5EG1nAmBoyFyW4OHDvjqtJ7w5mMSdyF4vgLXI637M500dR3JvU4I1483BJFqBe0FflNIZZpkeRC83jQkA1zUnrnzImDqYg2FsB9UD8zTwqBOIq7tIJ71zBsC2zceUQmOmwaEdyJ7jujIPjyAaJNp1dwqTAs8tU2WMI1aExjQdxPJxF7DasmQiVm9vIK42YzZWEEZbKA/YKEI1Km0prf0mPCen4+SFQ7yNSDPd8zqlaEyHQxRK6UbMRkDDWIXsPQCW5yZpRUKzaaELyAL09vZHfFT1CI2V9eaQFm5DjoxA7e1OeULXABtAEgJMITTWBtLLngHZ/x6YJ8gWxD2cFlYC231NY5HQa+zwucMTk9sxmwBRiRa8EIelNTbm4h2vh+2WpY0l3PncoRTdpGN7VWKLUliWUqwBcmnPBrgW2KW1+JcqkvJiheMIdzQ0zIKkCF2b9uIBR2vWWMDbqJ9av11K2VsBtNZ0d3849gHkmcIds7MNfs5WPaADuNavdUjz/AijHfgkUtqAbZfp6NgR34o7doQ9vG/1xmpPe9EeWoAuvzw5LSt1MdwGfAqvVr25uYmuruiHfFdXnubmwMxq9sZIU9WvxAqg28JsVLBa9AOfwfM623Y0zSuXy9PYGKi4rd6zzRk81WN9hnT176VgIQkWbcDHlGIY/FJrXXUmiuPsBDRay5mE6PufAt6f9gKXwNuU4+SHSNcovBSKwKeBfyPI1QI/M6VQWJiaKRrURcbllcAHkOS73rQX9DoYUo6TP0X9HGxLYQbYj2S/73dd9ZLvHV0KWtsoVb4aKaLZCWwjegObpHEqw+VRP96IFFi+CxiyLP0U8DTSbuk0kiQB8BYkXt2lVPntwDsRMdWQ9gKqxCrlOPmZy2jCYWgk+/A8kq8LoqlciXhQU2s9FQGzGcwlUMcNhaSAmkgDNYXMG7Gw/7KGBcylPYk3EWDOYl7+von0MW3h1e29ibrApMVFPQbfRIo4l0GK7uutE4OLJD9PQbidayywkejgSuqvW9GpDNI2tR5wBimBPoCUE59EbIy4E9gaEVulA0nB2YLE1Ouhg9HJDNINIU0cAx4G/hXxW00aHPtriBHpAL+MdDO6PsW9GM0g9XzTmI+JnAf2Is3Ohio/bG8/wf79+xMZeNu2bYyPX+dViulJYEBrNaCU3o2U8PUjXGQS03jOxc1IIaJJB+MI8HGt9TeUUsEZMTPTzOjoF4zuQmfn77JixStBSqlS2FrzfsRN32lwKuPA9gxSqDKGOYIcBH4TGJjP/DDTpHgx+D8Av+u21pQREXoC+CKwydBUxoATGa31aaVU0dDAh4CPAINp91ivxJEjewC/Jz1ozQFvrg8hhf9JowD6tKWUchHNJmn8GPgooklRT8QIw5+T16P+OeABvD4lCeMAqKAh+wByc0BSKAOfVoofVC68HlEo7A3OFK35PvBZ4reHwngZoUFgGB1lEU0nRvwA2O0vsp6J4cNvWuAdc19FblBICsH+W1prlFLnkBBpEphCDseXZaH1TwwfxWLAKWe9NSTliP1PrfU5pRSWUsrPyPguyRhlzxA0eUmhACQiQh2RngCeTWCISeBx0Tg1VugXe5DgwI0VjwEvu65t9GKUuCBZLRqES/49gSEG8QhdKOz1zxAX4BxykUmcOI/0psKykjwTk0YQnn+S+KXIt5C9B4JDPeDLRxADJS68iFzIdVmdHZUIzX0U+L8YHz0GPBp+wwoPqBRDxNuI5SQh6r8BcBb5kcWFR0EdhXkaLIgHaI2LWKZnYhpwglQ7NMQHSUdlGijF9MgzwL7KYvCAIErJLQdKMUAFG0XAhWJxrxv9MelD2lYpl/mkvKh4BM8YDKeQBQTxOy9rzRxy00EcrSaaHCdfb1G5mqG1togn03MC2eM5gGJxT/DBwsYnls8l6mmkYXJUrMeLK0gm+uWJnp6gcqGFeAJYX8PzH1ZWHS8gyOHDe/zUfRf4W6JHE3sJWrFefkahj1AX0c145csRMILsrQtc1BN+EXESiPwh4HNEc6pdCfwWEib1im7+LJldSwAdHTvChUJXhNdSI+aQPR0GvWhN/kUNLkulQ2SzG/2XR5FYQJSslC7kYsb/Btxs9hzt7ZsolZ5LcCujo68vT2NjkIPeCHwc+DDRMlUeRX6RM7C4bbZox1G/Pbf3xWHktrXVNU7CAn4OqesbAKZcF9rbo1+glRTkbq3gF3wVUhz6UaJVCZxAOOwEsKQbackWsG1tG33X848Rd8Ht1J4pnwF+FsnuOKyU6PLZ7EZaWzdx+vRziWzscpHL9QfSwSPGjYi87ydau9xp5GaGx0Asj6VajS85yMTEYFh0FZCYe5SODwoRfT+PWO9DQNmydM33NcWFXG4H2ay/NAWSRPchJCMmjru1HkTK8soAR44s7UZaznUVaxEr/vYYJvgaUjP4WaUYDNuqZn1eO8jlmpDCUIVlNeC6szcDf4AUhsbR/+S7CIedqmZ9lySI5DAFnSdyiA4dV6OzMSQat5eKO0Lm5mB4OBni5HK7EM1e4PXMWo90ddhJfJ0tBpELXYoAxeL1XErLrPLKowWVre/0NnBdjHs0jBD6YVBDoBeo2lqrICukVuRyO/1AXHj5Nuge5F6UDxJvHtYLyJVHTyl1BVq/WhX313op2B3IdXkdMS4AxJP6PeAbwNNKTZ7SeqHaXy7PYduXDnY5zk7vl7+oK+1q4O3A+5C7qeLu9TIG/BpyZy6SYbOnqi8uqzCygih3InHmJBrXTCNc819IgGsQOKmUPq+1WpbJrxRKa5qZb5K2FeHyG0imTHoMUW8DB+1yzsVlV6pWEOXdiFqYZIKyi7i8jyFEGvUWfQpJnLiAGJ4gdkITYjOtRTi4EzFOr0c6QyTp7DyGNNoPQr3LVVJqKh32ieJ1Et2KXPy+IcGFLoYZ788s8+4dGyFKI+abBAwiidpP+W/UojHWZOyUSoO0tweG44+QWHMnZpOTbWTT34JwRZP378Za1xUBjyO9WQ76b9Sqvtc8cd+94rouSqkSom83ISrx5Vr7vlxMIdfPPgAcn511se1oKbKRfklClE0+p0wiuUsvIuJrddq7lTCOI+6QzyB38mLbRE51iqn9xA4cZ0EgbRPwJ0hzyTcat8whiSCfVEo969s2cXkYYu0HEkrlB4mF3It4SW8wtl3JYgSJZ+wDzvvEiPMmuVgPv5DbHkQDGkAOPBcJ50YJ7qSJEnLZ5QOIsTcD4hGOkxiQYMec8A3TloXlutyCXPNzF2avU4qC00h2yIPIj8v1JUBSTtBEWxht2HAPs7ONYTGWQeLS/cB7qc/2giAJfo8ioukZQv1gZmYyjI5+JbGBjfSU6ur6CJnMfI8b10VZFl0It7wP0crSFmeTiHH3TeARUMPhJLbZWYuRkd2JT8Jok6+enn4sS1FxV8hqRCu7HWnD1405lfkcEijbj9hRB1mkksxkjCa1rmsSt56vv/DE2mrE77QZ6bDQh/ijVhO9jn4aIcAYcuH8AeRcGFGKcz4vuK6FZbmpJYfXRRs8/5afcFaM1tpSSq1BzpkuhHM6vddrkf67TUhUz9cWy4j1fAFJjD6FnAejCCcMe69PE8p38jm2HjL0/x848s2hrn9akAAAACV0RVh0ZGF0ZTpjcmVhdGUAMjAxOC0xMC0yN1QwODowNjowMCswMDowMNiFiREAAAAldEVYdGRhdGU6bW9kaWZ5ADIwMTgtMTAtMjdUMDg6MDY6MDArMDA6MDCp2DGtAAAAAElFTkSuQmCC', 'Europe/Paris', 7, '2022-01-15 18:04:18.521496', 2, '2022-01-15 18:04:18.521496', 2, 2, 'BANKONLINE');
-      INSERT INTO public.base_person (id, guid, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (8, 'f59938b7-6f4d-47e5-adbe-7f4198f8d23f', 'CONNEKT4', 2, 8, 1, true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAABcSAAAXEgFnn9JSAAAAB3RJTUUH4QoNBiUocN2mVAAAEs9JREFUeNrtnaFzG0n2gN+6UmUziclMYgqyjGJm6UjCYh24wFgL7uhq/4Io9w+clh5ZJcfyAz/FLEFymENOCrKZxGQ2YjLaA89T9uWyWXdP90xPz/dVuTapyu4qo+mv33v9uvuH3/4uvwkAVJIdHgEAAgAABAAACAAAEAAAIAAAQAAAgAAAAAEAAAIAAAQAAAgAABAAACAAAEAAAIAAAAABAEA4POIRVIjdmsj+4cP+7DYRuV7wzBAABE+jI7JXF2n2bn9/qL8XEWn13Pw/kqX+iIisZvrP67mKYnXOd1BSfuBMwBJRa+oM3jjUwV5v6U8IbBOR9VylsJ6LbJaIAQFAJppdHejNng78dFYvE8uZSmE1uxXDiu8VAcAfDnhXoXtoJEuRq6kKYTkTudnwvSOAirJbE2n3dbC3++Wc4V1ECFdT/SE6QACVGfTtvsjjPs/jPuu5yGKCDBBAhLRPRA4GDHpTGSwmpAkIoKTUmiJHQ5HOoJrhvStSEbCqgABKM9s/GcZbyCuKZClyPtIUgagAAQTHwalIdxTO2nysbBONCC7G1AoQQMHs1jTMPxoS5heVHpyPEAECYOB/c6Zcz+9+n7bwPpT7LcUhdR0iAgRQKMevwhn4aY/+aqb/3Nz+3tdASDcU7dVVEPWWSK0VTr0DESCAaHP8+7321/PwquKNjkoh3a9QpBTOR1ojoFiIADLT7Io8HT98K63LAb+albtttsj25m0i8mEo8uUN7zACsAx3n411HT8vLqd3vfKxhbG7tbu25zxbn9dzkY9D+ggQgAFPftJwP4+XNB30VVvfbnRUru1+PmnVxVhTA9ICBPC71Joizyf+w9Xl7K7vnRdSm6fyiAy2icjZQOTqPc8cAeQ8628TnYUWE6rU30sT2n1dZfFZc7mcqggqLl8EkMesn872FKPMaHY1RfBVg9kmIu/6la4NIID2iQ5+H7P+5VTk85jikwtB+9xUdTEW+fgzAqhcqOmrwk8zir/vzFf35XquKUHFTkKupgAaHZ31XeeYl1NdbmLgl1MEFewbqJ4AfIT8y5nIpxGhfixRXIVSgmoJ4PiVVvldkSx1xmdJqfgagesi7nKmBcLIVwmqIYDdmr4gro7jSpfzPr1m8IUW3T0du2sqSpYqgYjrAvELYLcm8nLmLt9fzrRYRJ4fdn3AVaQX+VJh3AJodEReTN3MCGwsKd9377LQ+34Q5XcfrwAaHZ35XRT76BorLy7rPh+GIp9/QQClyAVdVPq3ia7nR/alVzIacBUJLiYiZz9G82h2ovuyD071y846+Ndzkbc9Bn8MXC9E/nmogzcrnYHI818RQLCD/8TBl7yY6OCvWFdY1NxsdOZ+P9DIDglEJgAXg3+b6Aty9iP5fqx8eaNyv39YaoUlsMPgvyVZ6otBlb8aKcHbnhZ3Ky6B8gugfZJ98K/nmiMS8lcrJfi/P2tDV4UlUG4BpGu9LvJ9Qv5q8vFnTfuySuD4FQLIffBnXedPl3QY/NQF3vWzFQe7I01FEUAO7NayL/WlxT4AEd3Q9baXTQInE01JEYDnwf9ylq2pI9K2TshIWhzMIoHnE41OEYAnsvZ3M/jBpwT26jpB7dYQgHOOX2Xb0svgByRQUgG0T7Jt6mDwQ54S2D/U04oQgAOyLvcx+KEICXQGwa8MhC+A9DQf24o/gx+KlMDJJOiiYPgCeJbhVl4u4wBXEniXofb0YhpsPSBsARyc2p/4Gtm+bSiY1bl9x2C9lb1jtXICqDXtiyjruZ7eAuCSL2/0gBgbHveDrAeEKwDbvD/d1Ud7L/jg02v7g0WejXViQwB/wJOf7M54T09wZfCDTz4M7c4T2KsHlwqEJ4Asof+HIVt6wT83G/vNQ62eTnAI4Duhvw1U/CFPNis9KdqG7iiYVCAsAdiG/hT9oAiu3tsdKBJQKhCOAHZrdq2+24Qz+6E4Pv5sVw9o9YLYOvwomAf5bGxX9T8f5Zv3Z+lNIJ2Jk3d9kb/Nzd/fp2O9aq7AySsMATS7doPqcpr/uf31lttbaL/FasagKls94HxkXryut/QewwIvmQ0jBXhqkUeloT9ACHz+RWdzUwouCBYvgINTu17/D0PyfgiLs4Hd0uDTcUUFYFv4W87IkSHcVMCUx31NgysngKOh+dl+hP4QYypwPKqYAHZrKgBTLsZqWoBQ+WjxXrd6hUQBxQngaGi+bJIsC62YAjyI64Vdg1ABUUAxArCd/T/S7Qcl4XxkXhAsIAooRgA2s/9ypq2XAGXgZlOKKCD/RiDb2f/TiJcqFg5Os13s8qD3JYBU8dNrbXAz+bumUcDqPFIBtPvms//lNLcHAjnQGfjvpgylVnQ+Mr+9+ngk8q8/RZoC2Kz7k/tDWfnyRovXprWAnLoD8xVA+8Q89FtMWPaDcmPTHJTlEpxgBfBkmM/DAyh7FNAZ5HKUeH4CqDXN877LKbM/VDcK8L3tPFcB2FT+P495caC6UcDRMCIBmNpsOaPyD3Fhepx4veW9MSgfAbRPzJf+bM9eBwgVm8Ygz2lAPgI4MPxLbBO2+0J83GzMJ7Z232sx0L8Admu639m3KQFijAL26iqB0grA5sMT/kOsXC/MTxGulACWM5b+IG5MJ7jH/tIAvwKwCf+Z/QEB5BYF+BWAzYe+mvKCQNzcbLTJDQF8w4yc9AtVwHSi87R70q8ATD80sz8ggG+zV/dylZg/ATS75s0/nPgDpAHfGVO9MgnA8MNeMvsDUUDeAvB3IpBp/k/4f0dn4OXLzsT1XG/CheIEsH+oK2sO62R+BLBbM7/uiwsx76i3/J+ZB2GkAeu52Vhp9Zymyn5SANPBv57T/APVxHTicxwZ+hGA6Ydk9gfSAAQAUL0IwPDMC5ubtINPAZYIACqM6fvv8JAQ9wJodMzW/9dzuv+AOkBBaYB7AZhWr6/nvABQbUzHQOMwYAE0LFYAAKqM6RhwuETsXgCm4QkRAFSdzcrsJuH9kCMAUztx8i+AeRTQ6EQgAMJ/gNuJcFZIGuBWAKZWMr0oASBWTMeCo0KgWwGYbv8l/we4rQMYCiDICMC0AEgEAHCbAhjWwmohCsC39QDALtrOpwZgmJcQAQDcYdIS7Ggp0O15AKZWYgvw778IoW2QQtZRUpwATBofKpcPzkQ+veY5VI3rudlBus1u5j4atymASVhCD8D3BQDVo4BJcYenDlBdEABAWSM/B0uB7gRQaxLmAuRJPSQBcIotACkAACAAAEAAAPBgWAYEqDDXCwQAAAgAoHqYLqUjAICIKGApHQEAkAIAAALIAtt7ASosANMlDFqHAQqfdItLAWoIAOC/MD1Sz8Gp2tQAAELB0UGfxQnA5Nw4UgCAwnnkXAAPHdgIwD+7NacXSZZ5posyBXBwrN6jwl/Qmw1fvC/2D0VezngOsaYADsaO2xTAtCgR4uwEUKSwH4qjZXe3AjD9UISCAHbjwdGp2sVGAA0iAAAdC4Y3a0cRAVAIBLAbC9chRgCmYQnNQAB20bCjq9rcCuBmYxYFmFyDBIAA7tiEKACbKMA09wEgBQi0CGiTm1AHADBbAkyWzvpn3AvANDdpkgZAxWl2C8n/w4gAWAqEygvAcBJ0eK2eewGY3ldOIRCqTgHbgP0JQMS8QGEaAgHEhOkkuA5dAKYhCnUAqOzs3zFrAU6WIptVbBEAAgDy/7xn/3AiAOoAgAD8jK1CBLBZmS9VtE94GaB6PO4XKgB/B4KsZiL1gYEA+iJX73khXKdibwOMrp6OOQvCZtLbJs4vEPUngKupSMdAANQB3HOzMV+WzQPukLib9EzHlGP8nQq8NAxV6i32BQD5v8sxVagAbjbmH9gkYgAoM42O+T6YUkUANh/YNCQCKCtHQ7M/v557OUA3LAHUW3QFAvn/t1hMvHwMvwLYrMwbF0gDIPrBf2J+IK6H8N+/AGzM1e7rfQEAsXJgOMmt507bf/MVgKm59urUAiBeak3z5h9P4X8+ArBJA0wLJABlwSbF9RT+5yMAG4PtH9ITAAhARJfSPYX/4QqAKACizP1Pzdf+PYb/+QngZmP+F+kMNF8CqOrsv028hv/5CcDWZCwJQiw0u+bb3q+m3m/Pzk8Aq3PzLcJHQ5YEIQ6OR+b/zvnI+8fayfUhXIzN/vxenVoAVHP291z8K0YAi4n5VlCiACg7Tywmsc/jXD5avgKwKQYSBUDZZ3/Txp9kmdvhODu5P5ALC7MRBQC5vxce5f5ANiuNAkwq/Ht1kWdjkbMfi/9CP73WHwAfuf82EfnyJrePuFPIg7ExHH0BUDaeWkS7F+NcP2IxAkijAFOeT3ipoBwcnJoffLpNKiIA2yig1ePAEAif3ZqmrDazv+fGn3AEkCUKoCAIIdMdmR/4kSxzn/2LFYBtFFBvsSwI4dLs2r2f56PcZ//iBbBZ2UmgO2K7MISJTeEvWeZa+Q9HAGneY3NRBAVBCI3jV3Y3Hp0NCvvIxQvgZmMXBewf6gMHCIFGRyNTU5azQm9v2gni4X3+xe7aY1IBCIHdmn1EWuDsL1JEJ+Dv8XEo8nJmlwq87RVSQIEM37VplTxkuiO70P98lMuOv+/xw29/l9+CeZDPf7U7BGQxCaNNGKpH+0TkhcWpPclS5J+HhU9cO0E9zA9Du4JgZ6CdVwB5UmtmC/0DiFrDEsDNxj4nejamHgD58mJql8pcToO5tn0nuId69V4fkCl7dboEId901Sbv3yaFF/7CFkAaHtmkAvuH9AeAfw5O7Q+sDST0D1sAWVKBx32Rp//gJQU/NDoiJ5aTzMU4t5N+yi2ANBWw3RxxNKQoCH4Gv81StYhW/XM86af8AhDRB2bTICSilmbrMLgibfax7V941w+yVyVsAaSpgE09QESrtKwMgIvB/3JmV/QT0eXt60WQf7Wd4B/+9UIfoA17df3ikAAUNfgXE211D5SdUnwJX97Y1wOQAGTh2dh+8K/n9pMXAviKjz/b1wOQANhg25oucrfeH/gelZ1SfSFve+b3CyIByHvwi2jRL9C8v7wCuNnog7UtCiIBeEjOn3Xwvx8E0+oblwBE1Krv+vb/PhKA7w3+l7Nsg38xKex4r2oIQETt+n6ABMD94Lct+KWDv2Tb0ndK+4V9eZOtwrpXF/nbnI5BuOvwyzL4S1Dxj0sAIrq+anO3wH1OJpwtyODPPvjf9kp5KtVO6b/Asx+zS6A70sIPW4mrxcGpRoFZjicr8eCPQwCuJNAZ6EzABaTV4Pmv9rv6Ihn88QjAlQT2D3VGYBNRvNSaIn/9d7ZKfySDPy4BuJJAukJAXSA+2icq+Cz5fkSDPz4BuJJAWhf4679JCWJgt6aHxNie4Rfp4I9TAKkEXNy0mqYET35iEJWVtMrv4kLZyAZ/vAIQ0c1DWZqF7qcEz8Yif/l/ooGycfzKTcgvolFlZINfJLSLQXxwcKoD2MVNNNtETykKeH83iBZxn47dDPx08Ed68Uz8ArgfBrq6jmo50+utSrDbq3K5fnfkJtxPeT8oVW8/Avjey5G14+trLsYaEXAvYVyRXhrtveuXZlcfAnioBJ6Ns68BkxbEG+6LaLHvbFCJCK9aAkh58pOKwCXpsc8Rh4vBDfzjkUir5/a/ezktxUk+CMBFXeDFVKTeQgRlotbUGf9x3/1/+8OwcpFcdQWQpgTPJ35eJkRQjhk//a5KcoQXAvCVEnRH7gpIX79ci4kWDCkWmpPew+dj4ItUvpCLAO6Hls8n/l60bSJyNdUXjuXDP/4uOgP9cZ2i3f8+zgbB3dWHAGKOBlLW89uLIqdEBfdpn4gcDPykZPepWKEPAYQWDXz9Ml5NqyuDRkcbd9p9v9JN07GzQfRr+wjA5YyU5UJIZPD7z7XdF2n2/IX4X3M+og6DACzYrekM1R3l+/9dz1UEq1n5Z6xGRwd7s+c/vP+a5Uxn/c2KdxkBZEwLfK0/P/RFXs1Eruf665BnsmZXpHGoA77Vyy+CItxHALm83L7Wo01f8GSpUkiWIptl/i97o6MhfONQf+otty25NmwTbeih/wIBeBeB6x50l9GCiMoh5f6v70vkfmj8rbMQG4d3M3j663orv9zdZOBfjMnzEUDOtE9EngyLjwiqCgMfAZAaVBBarRFAkKTr2i63HMN/pzefx5Xv4EMAobNbUwkcDcPLl8sY5l9NdcZnOQ8BlDI96Azy6XaLbbZfTGiZRgARRQXtvv4U1U8QOuv53aBntkcAlZBBUc0yDHoEgAACoX1y1y4bYm+Bj5x+OSO8RwDwP9SadyKIQQjJUmf51ey2nZnzEBAAmKULqQxCabn93mBPW5Sv5zrwCesRAHjgfi9+vSVSa+XTprtNdGBvEx3k6V6E9ZxwHgFAMNzv7a9ZiuH+HgIGOAIAgHjY4REAIAAAQAAAgAAAAAEAAAIAAAQAAAgAABAAACAAAEAAAIAAAAABAAACAAAEAACh8h/f0FeRbf09+gAAAABJRU5ErkJggg==', 'Africa/Abidjan', 8, '2022-01-15 18:04:18.524062', 2, '2022-01-15 18:04:18.524062', 2, 2, 'CONNEKT4');
-      INSERT INTO public.base_person (id, guid, name, preferred_language_id, billing_address_id, preferred_currency_id, is_company, photo, time_zone_id, address_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (9, '8732a69a-904c-465c-9a42-a53122b7582a', 'CINETPAY', 2, 9, 1, true, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAABcSAAAXEgFnn9JSAAAAB3RJTUUH4QoNBiUocN2mVAAAEs9JREFUeNrtnaFzG0n2gN+6UmUziclMYgqyjGJm6UjCYh24wFgL7uhq/4Io9w+clh5ZJcfyAz/FLEFymENOCrKZxGQ2YjLaA89T9uWyWXdP90xPz/dVuTapyu4qo+mv33v9uvuH3/4uvwkAVJIdHgEAAgAABAAACAAAEAAAIAAAQAAAgAAAAAEAAAIAAAQAAAgAABAAACAAAEAAAIAAAAABAEA4POIRVIjdmsj+4cP+7DYRuV7wzBAABE+jI7JXF2n2bn9/qL8XEWn13Pw/kqX+iIisZvrP67mKYnXOd1BSfuBMwBJRa+oM3jjUwV5v6U8IbBOR9VylsJ6LbJaIAQFAJppdHejNng78dFYvE8uZSmE1uxXDiu8VAcAfDnhXoXtoJEuRq6kKYTkTudnwvSOAirJbE2n3dbC3++Wc4V1ECFdT/SE6QACVGfTtvsjjPs/jPuu5yGKCDBBAhLRPRA4GDHpTGSwmpAkIoKTUmiJHQ5HOoJrhvStSEbCqgABKM9s/GcZbyCuKZClyPtIUgagAAQTHwalIdxTO2nysbBONCC7G1AoQQMHs1jTMPxoS5heVHpyPEAECYOB/c6Zcz+9+n7bwPpT7LcUhdR0iAgRQKMevwhn4aY/+aqb/3Nz+3tdASDcU7dVVEPWWSK0VTr0DESCAaHP8+7321/PwquKNjkoh3a9QpBTOR1ojoFiIADLT7Io8HT98K63LAb+albtttsj25m0i8mEo8uUN7zACsAx3n411HT8vLqd3vfKxhbG7tbu25zxbn9dzkY9D+ggQgAFPftJwP4+XNB30VVvfbnRUru1+PmnVxVhTA9ICBPC71Joizyf+w9Xl7K7vnRdSm6fyiAy2icjZQOTqPc8cAeQ8628TnYUWE6rU30sT2n1dZfFZc7mcqggqLl8EkMesn872FKPMaHY1RfBVg9kmIu/6la4NIID2iQ5+H7P+5VTk85jikwtB+9xUdTEW+fgzAqhcqOmrwk8zir/vzFf35XquKUHFTkKupgAaHZ31XeeYl1NdbmLgl1MEFewbqJ4AfIT8y5nIpxGhfixRXIVSgmoJ4PiVVvldkSx1xmdJqfgagesi7nKmBcLIVwmqIYDdmr4gro7jSpfzPr1m8IUW3T0du2sqSpYqgYjrAvELYLcm8nLmLt9fzrRYRJ4fdn3AVaQX+VJh3AJodEReTN3MCGwsKd9377LQ+34Q5XcfrwAaHZ35XRT76BorLy7rPh+GIp9/QQClyAVdVPq3ia7nR/alVzIacBUJLiYiZz9G82h2ovuyD071y846+Ndzkbc9Bn8MXC9E/nmogzcrnYHI818RQLCD/8TBl7yY6OCvWFdY1NxsdOZ+P9DIDglEJgAXg3+b6Aty9iP5fqx8eaNyv39YaoUlsMPgvyVZ6otBlb8aKcHbnhZ3Ky6B8gugfZJ98K/nmiMS8lcrJfi/P2tDV4UlUG4BpGu9LvJ9Qv5q8vFnTfuySuD4FQLIffBnXedPl3QY/NQF3vWzFQe7I01FEUAO7NayL/WlxT4AEd3Q9baXTQInE01JEYDnwf9ylq2pI9K2TshIWhzMIoHnE41OEYAnsvZ3M/jBpwT26jpB7dYQgHOOX2Xb0svgByRQUgG0T7Jt6mDwQ54S2D/U04oQgAOyLvcx+KEICXQGwa8MhC+A9DQf24o/gx+KlMDJJOiiYPgCeJbhVl4u4wBXEniXofb0YhpsPSBsARyc2p/4Gtm+bSiY1bl9x2C9lb1jtXICqDXtiyjruZ7eAuCSL2/0gBgbHveDrAeEKwDbvD/d1Ud7L/jg02v7g0WejXViQwB/wJOf7M54T09wZfCDTz4M7c4T2KsHlwqEJ4Asof+HIVt6wT83G/vNQ62eTnAI4Duhvw1U/CFPNis9KdqG7iiYVCAsAdiG/hT9oAiu3tsdKBJQKhCOAHZrdq2+24Qz+6E4Pv5sVw9o9YLYOvwomAf5bGxX9T8f5Zv3Z+lNIJ2Jk3d9kb/Nzd/fp2O9aq7AySsMATS7doPqcpr/uf31lttbaL/FasagKls94HxkXryut/QewwIvmQ0jBXhqkUeloT9ACHz+RWdzUwouCBYvgINTu17/D0PyfgiLs4Hd0uDTcUUFYFv4W87IkSHcVMCUx31NgysngKOh+dl+hP4QYypwPKqYAHZrKgBTLsZqWoBQ+WjxXrd6hUQBxQngaGi+bJIsC62YAjyI64Vdg1ABUUAxArCd/T/S7Qcl4XxkXhAsIAooRgA2s/9ypq2XAGXgZlOKKCD/RiDb2f/TiJcqFg5Os13s8qD3JYBU8dNrbXAz+bumUcDqPFIBtPvms//lNLcHAjnQGfjvpgylVnQ+Mr+9+ngk8q8/RZoC2Kz7k/tDWfnyRovXprWAnLoD8xVA+8Q89FtMWPaDcmPTHJTlEpxgBfBkmM/DAyh7FNAZ5HKUeH4CqDXN877LKbM/VDcK8L3tPFcB2FT+P495caC6UcDRMCIBmNpsOaPyD3Fhepx4veW9MSgfAbRPzJf+bM9eBwgVm8Ygz2lAPgI4MPxLbBO2+0J83GzMJ7Z232sx0L8Admu639m3KQFijAL26iqB0grA5sMT/kOsXC/MTxGulACWM5b+IG5MJ7jH/tIAvwKwCf+Z/QEB5BYF+BWAzYe+mvKCQNzcbLTJDQF8w4yc9AtVwHSi87R70q8ATD80sz8ggG+zV/dylZg/ATS75s0/nPgDpAHfGVO9MgnA8MNeMvsDUUDeAvB3IpBp/k/4f0dn4OXLzsT1XG/CheIEsH+oK2sO62R+BLBbM7/uiwsx76i3/J+ZB2GkAeu52Vhp9Zymyn5SANPBv57T/APVxHTicxwZ+hGA6Ydk9gfSAAQAUL0IwPDMC5ubtINPAZYIACqM6fvv8JAQ9wJodMzW/9dzuv+AOkBBaYB7AZhWr6/nvABQbUzHQOMwYAE0LFYAAKqM6RhwuETsXgCm4QkRAFSdzcrsJuH9kCMAUztx8i+AeRTQ6EQgAMJ/gNuJcFZIGuBWAKZWMr0oASBWTMeCo0KgWwGYbv8l/we4rQMYCiDICMC0AEgEAHCbAhjWwmohCsC39QDALtrOpwZgmJcQAQDcYdIS7Ggp0O15AKZWYgvw778IoW2QQtZRUpwATBofKpcPzkQ+veY5VI3rudlBus1u5j4atymASVhCD8D3BQDVo4BJcYenDlBdEABAWSM/B0uB7gRQaxLmAuRJPSQBcIotACkAACAAAEAAAPBgWAYEqDDXCwQAAAgAoHqYLqUjAICIKGApHQEAkAIAAALIAtt7ASosANMlDFqHAQqfdItLAWoIAOC/MD1Sz8Gp2tQAAELB0UGfxQnA5Nw4UgCAwnnkXAAPHdgIwD+7NacXSZZ5posyBXBwrN6jwl/Qmw1fvC/2D0VezngOsaYADsaO2xTAtCgR4uwEUKSwH4qjZXe3AjD9UISCAHbjwdGp2sVGAA0iAAAdC4Y3a0cRAVAIBLAbC9chRgCmYQnNQAB20bCjq9rcCuBmYxYFmFyDBIAA7tiEKACbKMA09wEgBQi0CGiTm1AHADBbAkyWzvpn3AvANDdpkgZAxWl2C8n/w4gAWAqEygvAcBJ0eK2eewGY3ldOIRCqTgHbgP0JQMS8QGEaAgHEhOkkuA5dAKYhCnUAqOzs3zFrAU6WIptVbBEAAgDy/7xn/3AiAOoAgAD8jK1CBLBZmS9VtE94GaB6PO4XKgB/B4KsZiL1gYEA+iJX73khXKdibwOMrp6OOQvCZtLbJs4vEPUngKupSMdAANQB3HOzMV+WzQPukLib9EzHlGP8nQq8NAxV6i32BQD5v8sxVagAbjbmH9gkYgAoM42O+T6YUkUANh/YNCQCKCtHQ7M/v557OUA3LAHUW3QFAvn/t1hMvHwMvwLYrMwbF0gDIPrBf2J+IK6H8N+/AGzM1e7rfQEAsXJgOMmt507bf/MVgKm59urUAiBeak3z5h9P4X8+ArBJA0wLJABlwSbF9RT+5yMAG4PtH9ITAAhARJfSPYX/4QqAKACizP1Pzdf+PYb/+QngZmP+F+kMNF8CqOrsv028hv/5CcDWZCwJQiw0u+bb3q+m3m/Pzk8Aq3PzLcJHQ5YEIQ6OR+b/zvnI+8fayfUhXIzN/vxenVoAVHP291z8K0YAi4n5VlCiACg7Tywmsc/jXD5avgKwKQYSBUDZZ3/Txp9kmdvhODu5P5ALC7MRBQC5vxce5f5ANiuNAkwq/Ht1kWdjkbMfi/9CP73WHwAfuf82EfnyJrePuFPIg7ExHH0BUDaeWkS7F+NcP2IxAkijAFOeT3ipoBwcnJoffLpNKiIA2yig1ePAEAif3ZqmrDazv+fGn3AEkCUKoCAIIdMdmR/4kSxzn/2LFYBtFFBvsSwI4dLs2r2f56PcZ//iBbBZ2UmgO2K7MISJTeEvWeZa+Q9HAGneY3NRBAVBCI3jV3Y3Hp0NCvvIxQvgZmMXBewf6gMHCIFGRyNTU5azQm9v2gni4X3+xe7aY1IBCIHdmn1EWuDsL1JEJ+Dv8XEo8nJmlwq87RVSQIEM37VplTxkuiO70P98lMuOv+/xw29/l9+CeZDPf7U7BGQxCaNNGKpH+0TkhcWpPclS5J+HhU9cO0E9zA9Du4JgZ6CdVwB5UmtmC/0DiFrDEsDNxj4nejamHgD58mJql8pcToO5tn0nuId69V4fkCl7dboEId901Sbv3yaFF/7CFkAaHtmkAvuH9AeAfw5O7Q+sDST0D1sAWVKBx32Rp//gJQU/NDoiJ5aTzMU4t5N+yi2ANBWw3RxxNKQoCH4Gv81StYhW/XM86af8AhDRB2bTICSilmbrMLgibfax7V941w+yVyVsAaSpgE09QESrtKwMgIvB/3JmV/QT0eXt60WQf7Wd4B/+9UIfoA17df3ikAAUNfgXE211D5SdUnwJX97Y1wOQAGTh2dh+8K/n9pMXAviKjz/b1wOQANhg25oucrfeH/gelZ1SfSFve+b3CyIByHvwi2jRL9C8v7wCuNnog7UtCiIBeEjOn3Xwvx8E0+oblwBE1Krv+vb/PhKA7w3+l7Nsg38xKex4r2oIQETt+n6ABMD94Lct+KWDv2Tb0ndK+4V9eZOtwrpXF/nbnI5BuOvwyzL4S1Dxj0sAIrq+anO3wH1OJpwtyODPPvjf9kp5KtVO6b/Asx+zS6A70sIPW4mrxcGpRoFZjicr8eCPQwCuJNAZ6EzABaTV4Pmv9rv6Ihn88QjAlQT2D3VGYBNRvNSaIn/9d7ZKfySDPy4BuJJAukJAXSA+2icq+Cz5fkSDPz4BuJJAWhf4679JCWJgt6aHxNie4Rfp4I9TAKkEXNy0mqYET35iEJWVtMrv4kLZyAZ/vAIQ0c1DWZqF7qcEz8Yif/l/ooGycfzKTcgvolFlZINfJLSLQXxwcKoD2MVNNNtETykKeH83iBZxn47dDPx08Ed68Uz8ArgfBrq6jmo50+utSrDbq3K5fnfkJtxPeT8oVW8/Avjey5G14+trLsYaEXAvYVyRXhrtveuXZlcfAnioBJ6Ns68BkxbEG+6LaLHvbFCJCK9aAkh58pOKwCXpsc8Rh4vBDfzjkUir5/a/ezktxUk+CMBFXeDFVKTeQgRlotbUGf9x3/1/+8OwcpFcdQWQpgTPJ35eJkRQjhk//a5KcoQXAvCVEnRH7gpIX79ci4kWDCkWmpPew+dj4ItUvpCLAO6Hls8n/l60bSJyNdUXjuXDP/4uOgP9cZ2i3f8+zgbB3dWHAGKOBlLW89uLIqdEBfdpn4gcDPykZPepWKEPAYQWDXz9Ml5NqyuDRkcbd9p9v9JN07GzQfRr+wjA5YyU5UJIZPD7z7XdF2n2/IX4X3M+og6DACzYrekM1R3l+/9dz1UEq1n5Z6xGRwd7s+c/vP+a5Uxn/c2KdxkBZEwLfK0/P/RFXs1Eruf665BnsmZXpHGoA77Vyy+CItxHALm83L7Wo01f8GSpUkiWIptl/i97o6MhfONQf+otty25NmwTbeih/wIBeBeB6x50l9GCiMoh5f6v70vkfmj8rbMQG4d3M3j663orv9zdZOBfjMnzEUDOtE9EngyLjwiqCgMfAZAaVBBarRFAkKTr2i63HMN/pzefx5Xv4EMAobNbUwkcDcPLl8sY5l9NdcZnOQ8BlDI96Azy6XaLbbZfTGiZRgARRQXtvv4U1U8QOuv53aBntkcAlZBBUc0yDHoEgAACoX1y1y4bYm+Bj5x+OSO8RwDwP9SadyKIQQjJUmf51ey2nZnzEBAAmKULqQxCabn93mBPW5Sv5zrwCesRAHjgfi9+vSVSa+XTprtNdGBvEx3k6V6E9ZxwHgFAMNzv7a9ZiuH+HgIGOAIAgHjY4REAIAAAQAAAgAAAAAEAAAIAAAQAAAgAABAAACAAAEAAAIAAAAABAAACAAAEAACh8h/f0FeRbf09+gAAAABJRU5ErkJggg==', 'Africa/Abidjan', 9, '2022-01-15 18:04:18.527109', 2, '2022-01-15 18:04:18.527109', 2, 2, 'CINETPAY');
+      INSERT INTO public.base_sequence (id, step, next_number, size, name, prefix, suffix, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('835b95cc-2b77-4735-8523-129943154690', 1, 1, 5, 'Purchase Order', 'PO/{year}/{month}/', NULL, 'PO', '2022-01-15 18:04:17.712926', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.712926', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'PO');
+      INSERT INTO public.base_sequence (id, step, next_number, size, name, prefix, suffix, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('ddb2feaa-644d-4936-8319-3b7562fe96ec', 1, 1, 5, 'Invoice', 'INV/{year}/{month}/', NULL, 'INV', '2022-01-15 18:04:17.715443', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.715443', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'INV');
+      INSERT INTO public.base_sequence (id, step, next_number, size, name, prefix, suffix, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('06c545c5-6f45-4d33-b1f1-67bef1937df7', 1, 1, 5, 'Payment', 'PAY/{year}/{month}/', NULL, 'PAY', '2022-01-15 18:04:17.718212', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.718212', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'PAY');
+      INSERT INTO public.base_sequence (id, step, next_number, size, name, prefix, suffix, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('de1f482a-068a-4f29-bb4b-4002ef35ed05', 1, 1, 5, 'Payment request', 'PAYR/{year}/{month}/', NULL, 'PAYR', '2022-01-15 18:04:17.721234', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.721234', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'PAYR');
+      INSERT INTO public.base_sequence (id, step, next_number, size, name, prefix, suffix, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('203da52b-6002-426c-9ffb-6969bd9e7dda', 1, 1, 5, 'Transaction MOMO Test', 'MOMO/TEST/{year}/{month}/', NULL, 'MOMO_TEST', '2022-01-15 18:04:17.726081', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.726081', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'MOMO_TEST');
     </sql>
     <sql>
-      INSERT INTO public.base_sequence (id, guid, step, next_number, size, name, prefix, suffix, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, '835b95cc-2b77-4735-8523-129943154690', 1, 1, 5, 'Purchase Order', 'PO/{year}/{month}/', NULL, 'PO', '2022-01-15 18:04:17.712926', 2, '2022-01-15 18:04:17.712926', 2, 2, 'PO');
-      INSERT INTO public.base_sequence (id, guid, step, next_number, size, name, prefix, suffix, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, 'ddb2feaa-644d-4936-8319-3b7562fe96ec', 1, 1, 5, 'Invoice', 'INV/{year}/{month}/', NULL, 'INV', '2022-01-15 18:04:17.715443', 2, '2022-01-15 18:04:17.715443', 2, 2, 'INV');
-      INSERT INTO public.base_sequence (id, guid, step, next_number, size, name, prefix, suffix, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (3, '06c545c5-6f45-4d33-b1f1-67bef1937df7', 1, 1, 5, 'Payment', 'PAY/{year}/{month}/', NULL, 'PAY', '2022-01-15 18:04:17.718212', 2, '2022-01-15 18:04:17.718212', 2, 2, 'PAY');
-      INSERT INTO public.base_sequence (id, guid, step, next_number, size, name, prefix, suffix, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (4, 'de1f482a-068a-4f29-bb4b-4002ef35ed05', 1, 1, 5, 'Payment request', 'PAYR/{year}/{month}/', NULL, 'PAYR', '2022-01-15 18:04:17.721234', 2, '2022-01-15 18:04:17.721234', 2, 2, 'PAYR');
-      INSERT INTO public.base_sequence (id, guid, step, next_number, size, name, prefix, suffix, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (5, '203da52b-6002-426c-9ffb-6969bd9e7dda', 1, 1, 5, 'Transaction MOMO Test', 'MOMO/TEST/{year}/{month}/', NULL, 'MOMO_TEST', '2022-01-15 18:04:17.726081', 2, '2022-01-15 18:04:17.726081', 2, 2, 'MOMO_TEST');
+      INSERT INTO public.billing_address (id, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('f9c113e6-4013-48fb-8050-407582bd6917', true, '2022-01-15 18:04:18.393758', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.393758', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ADMIN');
+      INSERT INTO public.billing_address (id, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('437884de-bfa1-416b-b142-ca8503160db3', true, '2022-01-15 18:04:18.397069', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.397069', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ANONYMOUS');
+      INSERT INTO public.billing_address (id, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('727f74c2-0c81-4dc2-aab8-b290c3000210', true, '2022-01-15 18:04:18.400139', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.400139', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'MTN');
+      INSERT INTO public.billing_address (id, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('cc034a79-45c7-431f-96f7-da13a7a2533e', true, '2022-01-15 18:04:18.403455', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.403455', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ORANGE');
+      INSERT INTO public.billing_address (id, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('b38ec4eb-adbe-48fb-8432-f4779a625048', true, '2022-01-15 18:04:18.406176', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.406176', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'MOOV');
+      INSERT INTO public.billing_address (id, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('c35142bd-4a15-4176-b8f9-ef9ef13b6e21', true, '2022-01-15 18:04:18.408857', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.408857', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ORABANK');
+      INSERT INTO public.billing_address (id, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('e198fdbe-2626-4519-8513-b37390ca98bf', true, '2022-01-15 18:04:18.411189', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.411189', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'BANKONLINE');
+      INSERT INTO public.billing_address (id, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('f3fee586-8346-47c8-bd72-2cd39accf98e', true, '2022-01-15 18:04:18.413054', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.413054', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CONNEKT4');
+      INSERT INTO public.billing_address (id, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('147ad348-9721-4e29-8a84-dd6c602c5d56', true, '2022-01-15 18:04:18.414958', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.414958', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CINETPAY');
     </sql>
     <sql>
-      INSERT INTO public.billing_address (id, guid, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, 'f9c113e6-4013-48fb-8050-407582bd6917', true, '2022-01-15 18:04:18.393758', 2, '2022-01-15 18:04:18.393758', 2, 2, 'ADMIN');
-      INSERT INTO public.billing_address (id, guid, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, '437884de-bfa1-416b-b142-ca8503160db3', true, '2022-01-15 18:04:18.397069', 2, '2022-01-15 18:04:18.397069', 2, 2, 'ANONYMOUS');
-      INSERT INTO public.billing_address (id, guid, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (3, '727f74c2-0c81-4dc2-aab8-b290c3000210', true, '2022-01-15 18:04:18.400139', 2, '2022-01-15 18:04:18.400139', 2, 2, 'MTN');
-      INSERT INTO public.billing_address (id, guid, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (4, 'cc034a79-45c7-431f-96f7-da13a7a2533e', true, '2022-01-15 18:04:18.403455', 2, '2022-01-15 18:04:18.403455', 2, 2, 'ORANGE');
-      INSERT INTO public.billing_address (id, guid, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (5, 'b38ec4eb-adbe-48fb-8432-f4779a625048', true, '2022-01-15 18:04:18.406176', 2, '2022-01-15 18:04:18.406176', 2, 2, 'MOOV');
-      INSERT INTO public.billing_address (id, guid, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (6, 'c35142bd-4a15-4176-b8f9-ef9ef13b6e21', true, '2022-01-15 18:04:18.408857', 2, '2022-01-15 18:04:18.408857', 2, 2, 'ORABANK');
-      INSERT INTO public.billing_address (id, guid, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (7, 'e198fdbe-2626-4519-8513-b37390ca98bf', true, '2022-01-15 18:04:18.411189', 2, '2022-01-15 18:04:18.411189', 2, 2, 'BANKONLINE');
-      INSERT INTO public.billing_address (id, guid, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (8, 'f3fee586-8346-47c8-bd72-2cd39accf98e', true, '2022-01-15 18:04:18.413054', 2, '2022-01-15 18:04:18.413054', 2, 2, 'CONNEKT4');
-      INSERT INTO public.billing_address (id, guid, submitted_to_vat, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (9, '147ad348-9721-4e29-8a84-dd6c602c5d56', true, '2022-01-15 18:04:18.414958', 2, '2022-01-15 18:04:18.414958', 2, 2, 'CINETPAY');
+      INSERT INTO public.billing_payment_method (id, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('439804fe-55ac-40be-9601-329a016b2872', NULL, false, NULL, '4788fb05-d7ac-4739-9b64-70a80f5e7af4', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAjVBMVEX///8BAQEAAAD5+fn29vb6+vrz8/MZGRkREREjIyPw8PDr6+sbGxtAQEAUFBQmJiYJCQnPz8/i4uJCQkI0NDQ8PDzJycnc3NzW1tapqak2NjZlZWUqKirn5+efn5+Ghoa6urpwcHCBgYFZWVmTk5Ozs7OXl5dLS0t4eHi/v79eXl6hoaFsbGxJSUmLi4tgD4zdAAAgAElEQVR4nO1daXvquq4GZ4AwhrnQtIXSAp34/z/v2pLlOQMp3efDXTrnWbtAEue1ZU2W7E7nH/2jf/SP/ncUx//T5qM/bz4ZDv+6iUoaPv1xA0k8SP64iUqKB9HfNpBEUfS/RBjzF/jbFtIkbjcRYk7Rr6dw1EnjVj0cx/zGuL5zkjRNklZDmCYR/3+U/A5izJ+RtBnDmA8Mb7y2eX5JkvL/tWmBvxfv/HoGWA+qnsIbj9s0L1ibv0Jd8wkf5oh3Y9quBfmSlW2kB/Zd+iMfBM7pLZrXrFPDRHEsBjG6XZZi1+FtcdUbbhmnWcmPwD5JcrssNXu1qnmOLo07bbiEvxe/m8NM3PZselgw1u2yZdlTRPNR2gJgIkZHNV8GUQCEUby1AZyDcFusPwcuexX4OLHn0M9RlHa4nAs2P3uvaj5q1Dx0An98fPsIggJL5J+yzcBl70wC7DIWMJr4AAph6N8a7w/8zvK3SsQMkfIfbw4rVCFo+TC30WfA1vKhcQce47/P/EcB5BA/vd/TmPOnP0E2J3Efp3V5+wKhfG0hz6MSfSq0ZdJKUGMTCCoRXZT4XJK8Ej74D2MfbvN8hkTODI4+LgAObruUNx/rMUxE7waZVLwY/3/aFmFCE0F0n88ke41vmQPEifuS3FYUVpH6Zr49M3PUs4rmRXsx/iXmS5ANU/FucVuTC+9L+f1pCOD8qPCxq9AX4q836wHA3WoORrNrxkx84oZ5efMRNR+XAgQ5yq2lm0cQZZzqmTgAMHkjRmPsKF5zxzxhI5uHxzxtH2108u6g/O2YzcP7h1k0FTyatGDROWPbDvI4PCjQwsdUDWBvD9/McCoe9RsKBk2EGkwe3hYOOk5TuP5c+haya6DpMMBBFMWt1MRTztv/6oD8glf1Whh+6gF8oZ8utrARzM2ZtDPYf488eN3P9+EA+brcnI2Qb0pZdMBb6EAbN9JwAl18UhAjNwDxLN+Y/7vQ8yjF73rYYJoKe33zvLB4Ez5kLzN4HvL1vvxNqPkwQCFf+Djfbu2mIzk6V2ojtufgLNMDaNkk7/jtFV6O23uzS8+VK4ydv1SfXAFhucFOzZe4ffxHPgduFzJRRq/EXvExkQVw8K1NmIszOxZMicf59rPIRqvcHr3Lh3nHA6vRF8CopfamULVtABYGSwl1nNgT+VmrwPGDe/NGCpvZS8b4XJ6Oc6bh/Zw27vU4Eb3HWO9ToeviNmGDZCUnGL7Xwfl5ttQqcBu4/ZWp4epnDEcQPh32IYFygN/fAr80o+h2nz45y1csJNBH89f0Ww/gITjBo1z1D4fIPwh042vZKMHEZatb3/I39CkBfnV+JESt3sDL7eXAWLuyd97L0aex635uK4K0Ul/8dRzVoEcJS9gZRwn2LGWD8HL5VyOhK8vtkI5gAtbtA7zly7rG6x1De1VO4n3pIAGe4JO0OtlCvGWKTgRnuz77rgqdP4nrOH/m5y9PsPh0ggYf6y+8D12QZ1CfdWhEu2wXd95zNQGnRjQmJGxeuEbvoknk0Pri+lZcX0CTfxwqJpKxCNCCSAeJanXWKvCkb9iMjWsVJQIgv9CW8YOtsPOO3tWIsCyEdV96kSxqKoiLsl3kf46aQSPxowmY6AMfZDxn9laA1AlAQVv26n79F/QmWdS2oa6WwdwzuAyjM7xDfI10xK5CcTuEaAzxeOFeDd3B+vdGE6AvKUfcSX9SEC3ndv6j+La/JTduu8L3f8JBXPJpdrKdJv/5MfZTuRt8L9qS9vNG5Jm6/6y1VvTC8q5Gzo5vX19vXPRSH5yQqY+204QXfzo22A80HBJZd6V3CfAcMIK2chL2lJLfC203yg2IinAsksKcvg7E0d56/FeNG3wf+pBzcBG0cd/JF0QxgdEZ1u3lzH15NpHCch3Api8rTg+DwWCDk3qObf8HAIVSKPG2SaiI2KaKznSZD5GrCSmLHssRqjHvIsOAs+ZFIe9KawlgWRpO+CCH/mM9UhIGDDjrxYWiz1F5DysGUaFEmwfUcFXY9Nf0IAFmFbbYWilEy2E3R5E/ADSeVG3P1QjhDrRuIYDlxlnvSRupJiaVBv6MINrv2OuqEcXImY4mFrUQ2Q4u/Gt98SRHMC9pgQToJiQXu2ykIKrg4oL6pBah7IxPMOcDxtG9AEIUOic/4HI0reD0rFZO5iUQpcs7VfOTfKFDPcQ9XMgFWX8SMFnvQhA3FBDJXuRWWr5XPwshqoJ98zyo3no5w2eor3LUOWmNsFEGzpMAyNjtQcEGNMhQxqiBegNhMX3Zz4fz/UsPrWXyT59GoXcGiJn1jXQ4tnUQSQueoZ195/6ULrWeA3omxadUFrwHmVTDaYhRudLIupaIpeDZshbhjJq1fZF7UbyTePbyi61WBtCr6m+CmBb+sPArC1v1M/aDlz/UDiKqlhkTXNq/e8JWskA1objwveyFdFwmXrnX8AdkrnWjHnmpQ4ipDUk/n/DnVIZN29DZ4cGPKluSHKdk4UGcdg2lQRBRbNQJG9IX3yBr7q0vjpJFaXhmIU9Av8qL7hjbVJsCQ9sQGRlhpWxB173TZRzi+N4AUaRQ/GBmCvzQu1z0nVoxkKJnDqMq9fNThVBFFFIGEO+a/foNc7BrAGTVEI0lIr0yQ6Za1zTg8CNaZEFTSF806ctkkx8wa+4ZNr1IY5RCZQ+M1UFkOpPkoiOLBliHUWU08bWC9ft9UlQn4Kg7hk3RYckV523IvaiGeLTu54Ayi2EtZ4qWduN+qYDuCwH6Il9AfNO7W9j0CqaK5rt5n8akhlHPxhMY+IPmr7bXT0/flzySTSaiV6d41X3Dpm9yBIgphj1tNddAXJBWvnoAu47Xr973HHyiYNGu9powbBqIL7chGTfMiecGJq/VMeqK7ONTAKDt9dPa7lPQmhUsCn+gOv4AhMVdAMrEnom0rDqxZU/XQiwG5nO8n3vmqrZUtdeApUcAVXLK/dzgdzA42UilgjrWdC2jjqogWkpDufvuYIOaUBeheAFeDi3n3EoybtiTE7yT7DwrrA5iTuGOgAyxlQbpF9celHNQfviQ/dXtdu/gBq9lqDOjwOhP4C3rGFXxUsCStZSGcsuO9kRQLAof0WvCcBFrmYCnaIZqojcieXEMQWkOcR2wZc25SAsxVmzRBqgEUg8Q/jJsinG77mhCBuBjGElAEVg/j5SjMyvz+ulP6S+8mUEO2wagsOn1DvoC11vzUZ+G4FDqEHbdcDZ9D5aMoZsDTq5tgcuFDFOeuRMfPTOcQPlvAMpsnj5TYbVyXiwbW/ESGfgka/3UAKPqP/2FDE+wYvgxwon4CzdYmmb6Ga+1sTD3VXJMNcHH0IwJRRlNsLULGaRU4IqqLI/OsDIcN+w5AF9uBsh6fdP62dOTJ5UQ+wFh41yCXhPqi0U5hHRYJWljyjekCfR2O8Dl0hb6FP4YBKOM6jIZHShfyJA2+hOyaenyUFXBSJSkI+kfGXHDFgAL2z8ijjJCcGYYkr7ZoNWyK2uR5TjMEHws1RcimbrMu4qT5Ke/XPbtuOGtANmuWNoBUB07iigEx8bn83lcmDCFDyNy0ZOgZsHnIGOhvigLm8ZJaVVQ3Il3edGbrPr1ccNygMtVf+WGEnWUJ5K2Edlp8ez9BYsO2GTFtiJdP+mULmRIfSGzh8Ig4jTqlAFMIqxO6U9p4pQ5pVUAl9mKrZYeRArBJUcZkTIW5NOPS87yVY6VP3FCwsZPX0CvKQFhGNQXVdnAnEWPcg5+yRKbqsBoCcDRopstitxbE/RDcNpJhjfbHwQesFRi9Ez5FY9ebjQa86gvAtmmkag3iNNgKi0H+MjySQ6ZIFhMWJVFUAJwmmXj1WRJyxwWqXlDWXArQx7w9uYHWs+OO3IZYZhsTksTo5w+e0Doh01jUeEbhachcH+xWCwK4CdR3lYZ+Q0DXC7HvWyVE6ZJsTgej+cdlr/oCNm3ZFSdD4DldE+vU+TdhJKkxYfNq7FKgpZPSXUCHyVRdBBUFpxxL5zDxuPx8lX2acjKqgFYFGw1nk6FhBy/7DdGT85np08jCeciIU6H1HyEtW8PP1IEvDDDg4ifu2pmqrBp18s2FbV3olA6OAkjYZotOcLlFasuksoIbRjgqM92Wb4SefZBlfvwdiTQMl7B+ggxxmIJQSeYadFA9gHd+8XkF6inwSpwwqZi+okq6RJ1/8bFNUe4fOlAAVk8b8GiuzHXpPlxH24BSPGVzIKTLgUWvMkXjVI+myj5SuUipujfSK9JusHmaAkWjctr5a9ZLuTg8tLB2qBkkN0KMCtExv13g3RfICkupWzRJZKRLDqX8Rgj5LTOwS3HD5g9ZBRdYvFpVFaq/sxWorH+gQBGNZ5AYAQnrJctHpoHoykFUKg13CYixmplubWJFDY/+o74U0A0w6ZqnasTpaIEnf9b1piYPSIVXdYPiutOtyEsxqz46NxStkGJftwUk1WB/AWN+sFX7AFTnJzUIh+GTXfqF5h/pSa3SKRYjTAdT9cPxs0HEZXB6/AmgMokFNIjkiKIWBReAGPdE/Ot97Qm4mUPRaJ+sQTgHuyGVb6TAo1aqE9zUQCzbCRcpFv3KaCSC64U5Pyxqvv2pmyRtCbxgunFqFu4ok/52AxKAK7JTgTBnegW9g0RQsRt8oDjfxupLLh3CdEurzsG4hUzP2wqVCBWMQeJ8tB6Q3i2MdJNZQ0HWByHNw+g1TqHCA3bM2nOAt78x6P+DcwaLjyitHzfJ2pimgpOTszNCBoiFEP4KZyWFgBVCA6qLtKOa49cEYad+fyO1xTkBqf8naOwsQ2XG7aCKJU1pH3jMZwsk7RFjTTShiDm14FfAYpuUjDP6wV+ukBVZ1yy1QQQpf0Kr97ebqA+Z1COYTHoRHVzMBqWhVUoC46xgDv0gT+F3Pk1IOxB4V31hi3GbLepoULkPg63syo1/f4gvIv8+BzMTH1S62ds4Q2WrMgIrfkiB2+EEVum6CWp2e4k+tclm9FrrdWODWF6H2kf8Qhy8cHuzMFIQZy464Lo7gdXRNENhirrumUaNdutIOua9RpMxMr6O0HJI810pO+BmOD28l+qQgLgxCd747cThR08EkWXXI/XgEOaE0QznWrH+qMGCOsW8hb07J/r8wVia2JMHXaJxwriNJ7tLKaclgmbIWYPVew5ZdATReC1KSsc63qItVWdn3IAj+hzrMH+9QtfIpWlIKpurW6TFsnRz4PKIMlt3whhZ0iRbmUiLSDAV8OotTy6lbEtbXm9MbcmDEiUFasAm90Bj8p6degNcjGbZptSnoW+AfLZJpWjyCbTqmeKNLTRhFlVYAkMYihcfVTixhmtoaHPLKoKmwYolqLTjBeJMEMFRC6K3EYdeoPQhlH5KbIBHsntdYhWYT0e/iJ96Y4iImycPQR5suKOTzNeJCCWYGS9vGTLLkViTvFRVIIw+RFx02du6IX0p1yHZX1XquwI4sC9odu9qeiSMmWtrLTSuSiW0GpyBNE6HmlpdMRp88Os2h6lTKkQderwKS1kuBl7GDat62aTVNm5mbJVwqiwRljzPHwDvU/ApxQyG2a7RFsaUblUySYORCozdjhyKOPGN0CkbQRU8d2pDCIAfKl8mNrBhFYoHlVQ+DG3FMJmSRDfyDqwbRtKkoaojcGqwbBpNcmcV7ajqQD7y/iMCgBrU68kQgnmoPl/5gxisTO6tKtDcIq2NIjb69LgnFDYtI4OqJZYRhC/QhAFwJrNVDyEF6bjZgNHq3/pAP+X1KAOxJ1SlqZIvVFfIL3KR6mp8C4lqguwgRCTCAEYn9IrbZ9PbQhcJBXUnooy4pxLDCzw/ePWYNOpGzZtQrLsnOXU5F7OReYArFdE0rvLEphgU0NDcOVr7brHeaRntqfVXyS140WKCHtmYMSxTh64ZAfcO2gZGoyKAJswx1w+aCCmc2GupcFuLYZJe2FdKwsOIYLpI1McE2vdoqMuhS68EaEMuHc1H81gLkpGlQCb6CEZcmUbwXmmGhfZFFaU8J2Z7VE1LkjJ8YEuATR2tlfboktnKsgMfZyLBLBRZpk0Rriizy2lJcSJVc87t+OGM3qBrdAx8i2gNqnvoDHDprcQVd0rnnggA04BbPTYbyUB7fcqXJdAuvJuFpyAeCGLYY7+4I91Ixbpt8g23ZNjTl7ARs7Fns7ZbWDxPhNCW/S/+w5U5rhIG3qB7Yty8F+wwNJS8DJ7qEW2qYpP7eUXc6Hi+4WRlNyA+dfyIXZnJH1/99IV9YXKgsOi2i4UriKLR9MebCdlwcG96tpkm86oE6nLhhziaDTSCBuYg5HsJ/sFLgGu+lTeoWpvImeKtlr2TBgatgBAfdGqSP9B8Yn8YjDK+1pphCInT16Gi3RXrEDoPpR0d9E9pwpRjd5USdKwrZTJ87N2+gJITQVy76KdqTT8DY1Sv6jsalg1RB/e1jMdGcGWD6b2BroabITfzLFAyOohFTZtQRTWVyG4ZKUNOH/n4jjzYiZzDPbSC1aQRmiE/OIdc766Qva+JcZ12LQFzSdyFMkCTX6U1++NYbT0CnSHfZJXtXP21bB77fbkV9IYnYgKDDlDsDXcq67tpi7DTEI0U7ZwLrrzMBp76wKihh+zMOs1i7UcawgTLERlSvpyGS8gArNgcy3cYJMGSzkICuKjtG7cSCl/FYcXRfhue7ClVSk51Q52FhzowQ/1WXwSXSazvlbMFME3U4wpaj2rMBStG2tyGzsjSeJcy7+BIEGv3sKzs2ZZ1+pSEC+y9AMi3X3IUZCc8Qad2L5IX+S8gkdvFoYCo5pWvthizWZFwbUvaET3csfUCpAbKLGy4EAcsB1ORdFnnFGfuTmDXhPqi18U6Uc/6NFbITgB0Qh375nHtmfk7CHuh1GnrwLp67pLX6W8kk5yxqAeKv0grXFj2DRAXs7ri+CU3OQLQGhGM89kW0NdTK0vGcii82ptOaNCH4K72meHK4mXw2/0hQmxy8bECWLxITfX9L6cMTwqLps2EnVbP5rHbxobUU34BqvhhAbknNsnAYZBy98VXVIIbmmF4EwLWPCxnpiPetrKDYNrbI5gGQljS2rCclJQP0yUbEhbusEWUTTaLAy17Ol306c14oZoUtfW8JSsHGiIKkXsgfCC0sAebxE29Ymi0SMjBGcZ9CLhXjKVGTdshrBkbxPOiBl1qUoRExIFCy64uMFOPrV1gy2iqdA3CkPN34UHjpOdd8ZYW3RFEy59KwHIR6lH7Zl5MTLKMVFF+qxRZKyGvBDchy2gv+Ta0JsxfTqS/+okTS84DaHAUicvmHEHGVukxS8surwxbOrTsxuCW9vh9EfQJ7wjCsNi3TdxLjwmhTHpyphe1wvB7TGVXb9LiyL9YA6VNduhScv4TgrOp1tnw7pdKAbo0rcLMMd9pAluIARH7/JF2G9k0yR8PJ81230awqpC3wRICy2VknzgDCFYTNZnM6rZRSd5bPrWGJi9YS/sJC1JNFQJoWGWf+oze8ZRT1dt+e8VOHI2z9xvvBDcs9zcVRpSNxbpizy8ymTUbkmOh5go7KzEZnygqyuDfQMXznTFuu6oku59okeeUP7KF7mxSD+uOJ3NC8FZAKeZcKuOaz6Ow9krc+dtmC4OwMmCTd2MM6MQlV7gFdP1UQnDMkHOxFE59bn0SSwOfCm9zgvBGeB37CG69HZdyvByZlHpAy0svXy38vZvMBh1OJIvIDMzUYhxZzRf5ftOg8MJk7rj+VRCqJMsFPGOX3eSzkcxzRU+/p9djb24s4VKsVr1d25xnxWIUXEHeQfMiisHOOFWVkXJhQYIR2FUZPzOaRRtfyV5kltcJ+9HpqhXF794cwDuoHrKre6zBFhqFXCil7hmHCCq3RqIcC5YzemATwTRDFvEePgZPmTzdp72+9niWncegL3XAn9utsrGq9XE25bXWgSNrU06QCSkKzjy5qEOouDPtP54vuFE8qBuF9KQ00ieUiJub5QWPehbAKfj6WgxYpm/tbKt6iJzLzgR14whnFNkqC+iqIwFE5H0ng46tSs5FI1W7oV/OmCzsMnY4tFi11+MskXfn4Xe1rpmbI4LmyR65zJ4sfpGLioVN+J4PlFkWi9wcTPMLq2S4emA5vF8DYR2R6/HSBYt2HK5Kkb+VhsBk+HTHMRNxLXIbjEeF2nl6YB4Sm6zo9fisYT4qRDq0wGTpNm5Nd8Wr0359CtY4cvRbjDtw1CjsEH8z0rUh64TOL4vjFCwaNTw3TpOFlyspAxUU4eP53Pp0RrBYsdVPZc0IWc4hPCsdQbYH9eCj+HqBdRdyQmaUGQ6aF7aY2bBQX041vXEZWefBe5nGmCesWzJHb7gfjeB9UECiF7FcsAthwWnHZwJFD4dUGjCuLZuwiTKcF7QWWSxrElpcpDpk12jPVpMuEbLfGMGf/YCaZSB9wyxxVHGuyCfLHcF6Itw/4pzauMbK1+o7Hyp7djyAxZtskv9hWkwnixXq5Idi7zM0m8J8A23wOajPxPxLz6Zv8rOlktFfeLg1mNqD3IUi6HcqKH0eD6b4out6Hv9Phf2k8DWvHSJbSJSLbjQx8L+YLtsBVGO5fgzPIJcVaetTgd8lU1lT3IWNgL44e5tN+mNemxSwqJ4jflUygDD2XkS0egddw75ZF6Ml0E3WBxv2ep0QArBQbELVNfV1690Nu7mtFmeTSDlvRSgrRGpW2lZAdb6dv30LBAGF/LwvOC0WWmGSyrndSMYtf605NnRQcL6vdFC6IkKfOIyZQRTXFOt3ICwYcVly/JxP+gGRygDWy5PqSy4B3Ees9D85f7gYJt5I8W6o3y8LMqEjBppc6/0ru3Qw0IGm27ZShh8gVmSiMK/cp+3jowsOLTV1uxtFnjafHtkAU6E7VuLoKI3AVIYgzrUXLiX22Scx5AVGoohRYOb9KBLXhaciBf9vG0f5uiExU+b/fN3n4XwiRu5sq8QMl0ZIjXb6rIf632/ZCC1PHLZ4rR4k7wQ3Fw5wFkxHdFeJ6UA8sqd+zBA6rTkrBLIJEj4p132UA2pQlRrbzbt6VcLkW7JBTokbOyVjg251UiGI902e6iGvEJUsSFvg/rFSgXRdSNCan9JX2CansYd9jYNkFeIOiisHaBLQOQVm9QxNgI1oPSEHijfEjeCrn91JJRZdg6U8rkROATCBjiq/BmP3HnRLSiEvjTR26790REfgUJUcTzCtJoNR3VKMGPOVuLyBy8/1dxJ+s+OhFIBdyMrrQoiH8EGIkhtJW6Zsn4W/UzHXf/uSKghbZppZqWVQhQAq/GJi9RW4o4t69jXqR0Q+SuEFIIzVvg/S+3NZgBJZjrbZjInrKHOTJFs9Cf6AiilgLvyBB5LJKoQMnUIdUbHwNtp2/SmZiu1hjCBfPE/OxKqA1lwcFaEFgUH2Gy3DcCuqoNMly7AR82l6UWvkRxSzDa98xEfFsmjng2dfAmMYo2akBfRnnzRjzMJp4Zx/a6XaIqZyjb97V7YlRBVFhzx0dWD2GwEKaMjWVjHYHELQBvRyptmZPkgm+7/EKFRiKoLQ7uWRG2gJoRBQx65yEXKNBDzDFC9CMs+h6qxbt2y+q/JOP8Y6dlSGs1YdEIA8ZwbSsc2R2evJWhP8S0e8fHHJ112DrJjzSw4XVnQSE2oSjDiCOvMREFzddyStcwn9zb965ORVQjOyIKTo1hrquE7Eyt+q2HiEM96OTm5Mg3QyhO4uUi/Hcn2reMRMNO0wRzs6vwbHVe1j5b9mBhcb5eQYtFlxV7Yd6ITZWgZhaGw0VATFlU2yYseJ/aqdfyTeYSCGw+XQZvm2UNt6VlHGZHWAmIjIeNvJc4Fs2GInayYgFesjtlDf34yst64xcxKm/aazEGSiyetIoz3XTuxf8+lx6LLgH91d3LOPxYubL/W6w/EDbkhr/lw6J5D4afr3OmIjya0d6OMc0NplALcy4tVJuTSEJXP3gGggYwrb2/Tv6MPV03Pa7z+rnfGorUH1qzwT0UJIHyFVm8t0m9HfghuUgnRD4xONbMNvkHp2xBZIGZxzyOhakkl+qnjO7MKiHrAqGtGGuCWHpVZqiJ03iNOxD87GdmmDTGqCsEtS+eiFzdkPSViHsZac2RKBHFH8T2QQd62SL8dYfQ775nHI4QlKnPjhnr3kfjVUIHy6GUugq6BBaDB/lsmL9ZWk92LRJm78Af1CaVndcKQGfL34ob6fOx3O3ou6jbZeesPXjJ//jHSItstiLagpxEbARjjhFI8QFk4fhmjjBFa0lWBV2nGbH6YM/Oml7Wv7eL165RZQ/1XYVOfhpQiZhSGCmDT04Z38+DhCotTZHw99eXVqAWiF5arQ8sFLU6BSNrT9tNeARIf/ixs6tOA9oIzjkcYGZIgOenQlUoBRlNlnzO9AwB/6ZBgWV939vqW+DQ+3f3U4CqKaVMIXRiaWbPkgQCm1gYZT2dcnoF3Lt4Cbm36fvAHjx1CHfHHtHBDcGGzMaKYMswhcX57DwGeQ+/8cFr5g1dc/9q/LyEKwVW6pkkhrxIAP3KG/jJjE19oDD4OE3/wPgMS9j8jgriqWFBfyGu4kfcksuZy3L726t6y+QKtoPUqqMfL+u5Hkt9GKgRXurxnHAAu6nC7ORwzc7TNr/jjRWoYCRE+HL/+IyOtkqgQdVmiimmUnztr0Gx5T8Sz7Q13LK0grZvRZf+fKfcaepUQi+BkeSSA6SOAABZ91RIpmV3HltyED6vTg8eb/0NmVbW2gTjRQQK8yvCHYNGx0mnp+2PuC5ag3d1JSvcOvx8lZcfzUcpW7s0amUzBdj9awZNN8HBa+EqvXCtUH513H0qfytrwQnCSXvXcov9eMJ9zf7HRAbzHbXm0sOSwoLtSXJFjqhxZy6iifMOucjogOrN5Pvvoeq+VIRg8CqKMGmWg15JIGC9vI1SIqlI4SQ0IBl2/jvyZd/6qWcFO4qSigyEL8xdZiuoxVYMYKESVrJuvVsteseSmymUjq+gvj/gAAAKHSURBVMMseJPDR22mTCoO0ym9KhYHConj+X4FMY4GpcfzIX0Qo0pbbEsAe2y0nPZWvR9bsMCH8dumwfQSFQflqbIRzdBfQRRMEkfVfLAmiKDN3wngBJkU/rAH7/u9mfyHip+So/NkUYh6y+aQ3DbSyhNDkMwQ3N4CSIOpB28ZTMcNNy7OckrLSnxh+kVpoj+0oRhPtSmtjiN6INGyXWtUTHjzoOzHPSl0jtsbzM1UHlYS5tGUj6AoHJXFoy2zvul4vvr+UWXnxgj2VosxuE+sKxK22ev6phQ8Uf3aiQclVXNQL6iOXOo0ra5zKI3geL5GvaMKUeEfATAXhxMupgxV+vOtvkIsCkPLq36AdW+vH3TaiKFwqmHK+FAvsnARynFNAaEIuTTQCh6JE7vE4YBl720gFEUhrZRiJIrck+ZSSp9/jMe+FYvxalk8CnMzuVnUpWBlVDSeqCpXPPanxTSMoW7tFjGcqmJKthTmSzF+FYOXNKsNsxvnQ8gxlp1L1pGqIoFTz/TZcjcRnEnUqMLWeC8qAxYHk2CMPpKHE95I8ui8ivvoYDc4cLgNQNFG1EiKWs2eUa6wb/AVImkq3Nq8kJJwTG5VU6TBWgJs0kbwviPE6Aekw5I2LDoYDER9bwWLCiJDoN0cTGUbLbrmGXyFJHQ6YNPG+ahwLVxbNIf936YFPFpTtPELczZSpwPe+hAxsZpVoAPEpGJXk8o2Ko7na0YIMa7f7cBrXRwN2Kz6lV+atIoApKKKv+botSbNV+qzivuSeNBw5G8oxrfb4NS0jQoC77TFbUJNNW28qcHl3jYo34jipue0MoY7txdo305RWnM839/SfaJL1dSu8//RP/pH/y/o/wCA063XByrVYwAAAABJRU5ErkJggg==', true, 'CASH', 'Espèces Test', '2022-01-15 18:04:18.684927', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.684927', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CASH_TEST');
+      INSERT INTO public.billing_payment_method (id, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('bbd4d845-cf02-4b27-84b4-e187d6facb7f', NULL, false, NULL, '4788fb05-d7ac-4739-9b64-70a80f5e7af4', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAjVBMVEX///8BAQEAAAD5+fn29vb6+vrz8/MZGRkREREjIyPw8PDr6+sbGxtAQEAUFBQmJiYJCQnPz8/i4uJCQkI0NDQ8PDzJycnc3NzW1tapqak2NjZlZWUqKirn5+efn5+Ghoa6urpwcHCBgYFZWVmTk5Ozs7OXl5dLS0t4eHi/v79eXl6hoaFsbGxJSUmLi4tgD4zdAAAgAElEQVR4nO1daXvquq4GZ4AwhrnQtIXSAp34/z/v2pLlOQMp3efDXTrnWbtAEue1ZU2W7E7nH/2jf/SP/ncUx//T5qM/bz4ZDv+6iUoaPv1xA0k8SP64iUqKB9HfNpBEUfS/RBjzF/jbFtIkbjcRYk7Rr6dw1EnjVj0cx/zGuL5zkjRNklZDmCYR/3+U/A5izJ+RtBnDmA8Mb7y2eX5JkvL/tWmBvxfv/HoGWA+qnsIbj9s0L1ibv0Jd8wkf5oh3Y9quBfmSlW2kB/Zd+iMfBM7pLZrXrFPDRHEsBjG6XZZi1+FtcdUbbhmnWcmPwD5JcrssNXu1qnmOLo07bbiEvxe/m8NM3PZselgw1u2yZdlTRPNR2gJgIkZHNV8GUQCEUby1AZyDcFusPwcuexX4OLHn0M9RlHa4nAs2P3uvaj5q1Dx0An98fPsIggJL5J+yzcBl70wC7DIWMJr4AAph6N8a7w/8zvK3SsQMkfIfbw4rVCFo+TC30WfA1vKhcQce47/P/EcB5BA/vd/TmPOnP0E2J3Efp3V5+wKhfG0hz6MSfSq0ZdJKUGMTCCoRXZT4XJK8Ej74D2MfbvN8hkTODI4+LgAObruUNx/rMUxE7waZVLwY/3/aFmFCE0F0n88ke41vmQPEifuS3FYUVpH6Zr49M3PUs4rmRXsx/iXmS5ANU/FucVuTC+9L+f1pCOD8qPCxq9AX4q836wHA3WoORrNrxkx84oZ5efMRNR+XAgQ5yq2lm0cQZZzqmTgAMHkjRmPsKF5zxzxhI5uHxzxtH2108u6g/O2YzcP7h1k0FTyatGDROWPbDvI4PCjQwsdUDWBvD9/McCoe9RsKBk2EGkwe3hYOOk5TuP5c+haya6DpMMBBFMWt1MRTztv/6oD8glf1Whh+6gF8oZ8utrARzM2ZtDPYf488eN3P9+EA+brcnI2Qb0pZdMBb6EAbN9JwAl18UhAjNwDxLN+Y/7vQ8yjF73rYYJoKe33zvLB4Ez5kLzN4HvL1vvxNqPkwQCFf+Djfbu2mIzk6V2ojtufgLNMDaNkk7/jtFV6O23uzS8+VK4ydv1SfXAFhucFOzZe4ffxHPgduFzJRRq/EXvExkQVw8K1NmIszOxZMicf59rPIRqvcHr3Lh3nHA6vRF8CopfamULVtABYGSwl1nNgT+VmrwPGDe/NGCpvZS8b4XJ6Oc6bh/Zw27vU4Eb3HWO9ToeviNmGDZCUnGL7Xwfl5ttQqcBu4/ZWp4epnDEcQPh32IYFygN/fAr80o+h2nz45y1csJNBH89f0Ww/gITjBo1z1D4fIPwh042vZKMHEZatb3/I39CkBfnV+JESt3sDL7eXAWLuyd97L0aex635uK4K0Ul/8dRzVoEcJS9gZRwn2LGWD8HL5VyOhK8vtkI5gAtbtA7zly7rG6x1De1VO4n3pIAGe4JO0OtlCvGWKTgRnuz77rgqdP4nrOH/m5y9PsPh0ggYf6y+8D12QZ1CfdWhEu2wXd95zNQGnRjQmJGxeuEbvoknk0Pri+lZcX0CTfxwqJpKxCNCCSAeJanXWKvCkb9iMjWsVJQIgv9CW8YOtsPOO3tWIsCyEdV96kSxqKoiLsl3kf46aQSPxowmY6AMfZDxn9laA1AlAQVv26n79F/QmWdS2oa6WwdwzuAyjM7xDfI10xK5CcTuEaAzxeOFeDd3B+vdGE6AvKUfcSX9SEC3ndv6j+La/JTduu8L3f8JBXPJpdrKdJv/5MfZTuRt8L9qS9vNG5Jm6/6y1VvTC8q5Gzo5vX19vXPRSH5yQqY+204QXfzo22A80HBJZd6V3CfAcMIK2chL2lJLfC203yg2IinAsksKcvg7E0d56/FeNG3wf+pBzcBG0cd/JF0QxgdEZ1u3lzH15NpHCch3Api8rTg+DwWCDk3qObf8HAIVSKPG2SaiI2KaKznSZD5GrCSmLHssRqjHvIsOAs+ZFIe9KawlgWRpO+CCH/mM9UhIGDDjrxYWiz1F5DysGUaFEmwfUcFXY9Nf0IAFmFbbYWilEy2E3R5E/ADSeVG3P1QjhDrRuIYDlxlnvSRupJiaVBv6MINrv2OuqEcXImY4mFrUQ2Q4u/Gt98SRHMC9pgQToJiQXu2ykIKrg4oL6pBah7IxPMOcDxtG9AEIUOic/4HI0reD0rFZO5iUQpcs7VfOTfKFDPcQ9XMgFWX8SMFnvQhA3FBDJXuRWWr5XPwshqoJ98zyo3no5w2eor3LUOWmNsFEGzpMAyNjtQcEGNMhQxqiBegNhMX3Zz4fz/UsPrWXyT59GoXcGiJn1jXQ4tnUQSQueoZ195/6ULrWeA3omxadUFrwHmVTDaYhRudLIupaIpeDZshbhjJq1fZF7UbyTePbyi61WBtCr6m+CmBb+sPArC1v1M/aDlz/UDiKqlhkTXNq/e8JWskA1objwveyFdFwmXrnX8AdkrnWjHnmpQ4ipDUk/n/DnVIZN29DZ4cGPKluSHKdk4UGcdg2lQRBRbNQJG9IX3yBr7q0vjpJFaXhmIU9Av8qL7hjbVJsCQ9sQGRlhpWxB173TZRzi+N4AUaRQ/GBmCvzQu1z0nVoxkKJnDqMq9fNThVBFFFIGEO+a/foNc7BrAGTVEI0lIr0yQ6Za1zTg8CNaZEFTSF806ctkkx8wa+4ZNr1IY5RCZQ+M1UFkOpPkoiOLBliHUWU08bWC9ft9UlQn4Kg7hk3RYckV523IvaiGeLTu54Ayi2EtZ4qWduN+qYDuCwH6Il9AfNO7W9j0CqaK5rt5n8akhlHPxhMY+IPmr7bXT0/flzySTSaiV6d41X3Dpm9yBIgphj1tNddAXJBWvnoAu47Xr973HHyiYNGu9powbBqIL7chGTfMiecGJq/VMeqK7ONTAKDt9dPa7lPQmhUsCn+gOv4AhMVdAMrEnom0rDqxZU/XQiwG5nO8n3vmqrZUtdeApUcAVXLK/dzgdzA42UilgjrWdC2jjqogWkpDufvuYIOaUBeheAFeDi3n3EoybtiTE7yT7DwrrA5iTuGOgAyxlQbpF9celHNQfviQ/dXtdu/gBq9lqDOjwOhP4C3rGFXxUsCStZSGcsuO9kRQLAof0WvCcBFrmYCnaIZqojcieXEMQWkOcR2wZc25SAsxVmzRBqgEUg8Q/jJsinG77mhCBuBjGElAEVg/j5SjMyvz+ulP6S+8mUEO2wagsOn1DvoC11vzUZ+G4FDqEHbdcDZ9D5aMoZsDTq5tgcuFDFOeuRMfPTOcQPlvAMpsnj5TYbVyXiwbW/ESGfgka/3UAKPqP/2FDE+wYvgxwon4CzdYmmb6Ga+1sTD3VXJMNcHH0IwJRRlNsLULGaRU4IqqLI/OsDIcN+w5AF9uBsh6fdP62dOTJ5UQ+wFh41yCXhPqi0U5hHRYJWljyjekCfR2O8Dl0hb6FP4YBKOM6jIZHShfyJA2+hOyaenyUFXBSJSkI+kfGXHDFgAL2z8ijjJCcGYYkr7ZoNWyK2uR5TjMEHws1RcimbrMu4qT5Ke/XPbtuOGtANmuWNoBUB07iigEx8bn83lcmDCFDyNy0ZOgZsHnIGOhvigLm8ZJaVVQ3Il3edGbrPr1ccNygMtVf+WGEnWUJ5K2Edlp8ez9BYsO2GTFtiJdP+mULmRIfSGzh8Ig4jTqlAFMIqxO6U9p4pQ5pVUAl9mKrZYeRArBJUcZkTIW5NOPS87yVY6VP3FCwsZPX0CvKQFhGNQXVdnAnEWPcg5+yRKbqsBoCcDRopstitxbE/RDcNpJhjfbHwQesFRi9Ez5FY9ebjQa86gvAtmmkag3iNNgKi0H+MjySQ6ZIFhMWJVFUAJwmmXj1WRJyxwWqXlDWXArQx7w9uYHWs+OO3IZYZhsTksTo5w+e0Doh01jUeEbhachcH+xWCwK4CdR3lYZ+Q0DXC7HvWyVE6ZJsTgej+cdlr/oCNm3ZFSdD4DldE+vU+TdhJKkxYfNq7FKgpZPSXUCHyVRdBBUFpxxL5zDxuPx8lX2acjKqgFYFGw1nk6FhBy/7DdGT85np08jCeciIU6H1HyEtW8PP1IEvDDDg4ifu2pmqrBp18s2FbV3olA6OAkjYZotOcLlFasuksoIbRjgqM92Wb4SefZBlfvwdiTQMl7B+ggxxmIJQSeYadFA9gHd+8XkF6inwSpwwqZi+okq6RJ1/8bFNUe4fOlAAVk8b8GiuzHXpPlxH24BSPGVzIKTLgUWvMkXjVI+myj5SuUipujfSK9JusHmaAkWjctr5a9ZLuTg8tLB2qBkkN0KMCtExv13g3RfICkupWzRJZKRLDqX8Rgj5LTOwS3HD5g9ZBRdYvFpVFaq/sxWorH+gQBGNZ5AYAQnrJctHpoHoykFUKg13CYixmplubWJFDY/+o74U0A0w6ZqnasTpaIEnf9b1piYPSIVXdYPiutOtyEsxqz46NxStkGJftwUk1WB/AWN+sFX7AFTnJzUIh+GTXfqF5h/pSa3SKRYjTAdT9cPxs0HEZXB6/AmgMokFNIjkiKIWBReAGPdE/Ot97Qm4mUPRaJ+sQTgHuyGVb6TAo1aqE9zUQCzbCRcpFv3KaCSC64U5Pyxqvv2pmyRtCbxgunFqFu4ok/52AxKAK7JTgTBnegW9g0RQsRt8oDjfxupLLh3CdEurzsG4hUzP2wqVCBWMQeJ8tB6Q3i2MdJNZQ0HWByHNw+g1TqHCA3bM2nOAt78x6P+DcwaLjyitHzfJ2pimgpOTszNCBoiFEP4KZyWFgBVCA6qLtKOa49cEYad+fyO1xTkBqf8naOwsQ2XG7aCKJU1pH3jMZwsk7RFjTTShiDm14FfAYpuUjDP6wV+ukBVZ1yy1QQQpf0Kr97ebqA+Z1COYTHoRHVzMBqWhVUoC46xgDv0gT+F3Pk1IOxB4V31hi3GbLepoULkPg63syo1/f4gvIv8+BzMTH1S62ds4Q2WrMgIrfkiB2+EEVum6CWp2e4k+tclm9FrrdWODWF6H2kf8Qhy8cHuzMFIQZy464Lo7gdXRNENhirrumUaNdutIOua9RpMxMr6O0HJI810pO+BmOD28l+qQgLgxCd747cThR08EkWXXI/XgEOaE0QznWrH+qMGCOsW8hb07J/r8wVia2JMHXaJxwriNJ7tLKaclgmbIWYPVew5ZdATReC1KSsc63qItVWdn3IAj+hzrMH+9QtfIpWlIKpurW6TFsnRz4PKIMlt3whhZ0iRbmUiLSDAV8OotTy6lbEtbXm9MbcmDEiUFasAm90Bj8p6degNcjGbZptSnoW+AfLZJpWjyCbTqmeKNLTRhFlVYAkMYihcfVTixhmtoaHPLKoKmwYolqLTjBeJMEMFRC6K3EYdeoPQhlH5KbIBHsntdYhWYT0e/iJ96Y4iImycPQR5suKOTzNeJCCWYGS9vGTLLkViTvFRVIIw+RFx02du6IX0p1yHZX1XquwI4sC9odu9qeiSMmWtrLTSuSiW0GpyBNE6HmlpdMRp88Os2h6lTKkQderwKS1kuBl7GDat62aTVNm5mbJVwqiwRljzPHwDvU/ApxQyG2a7RFsaUblUySYORCozdjhyKOPGN0CkbQRU8d2pDCIAfKl8mNrBhFYoHlVQ+DG3FMJmSRDfyDqwbRtKkoaojcGqwbBpNcmcV7ajqQD7y/iMCgBrU68kQgnmoPl/5gxisTO6tKtDcIq2NIjb69LgnFDYtI4OqJZYRhC/QhAFwJrNVDyEF6bjZgNHq3/pAP+X1KAOxJ1SlqZIvVFfIL3KR6mp8C4lqguwgRCTCAEYn9IrbZ9PbQhcJBXUnooy4pxLDCzw/ePWYNOpGzZtQrLsnOXU5F7OReYArFdE0rvLEphgU0NDcOVr7brHeaRntqfVXyS140WKCHtmYMSxTh64ZAfcO2gZGoyKAJswx1w+aCCmc2GupcFuLYZJe2FdKwsOIYLpI1McE2vdoqMuhS68EaEMuHc1H81gLkpGlQCb6CEZcmUbwXmmGhfZFFaU8J2Z7VE1LkjJ8YEuATR2tlfboktnKsgMfZyLBLBRZpk0Rriizy2lJcSJVc87t+OGM3qBrdAx8i2gNqnvoDHDprcQVd0rnnggA04BbPTYbyUB7fcqXJdAuvJuFpyAeCGLYY7+4I91Ixbpt8g23ZNjTl7ARs7Fns7ZbWDxPhNCW/S/+w5U5rhIG3qB7Yty8F+wwNJS8DJ7qEW2qYpP7eUXc6Hi+4WRlNyA+dfyIXZnJH1/99IV9YXKgsOi2i4UriKLR9MebCdlwcG96tpkm86oE6nLhhziaDTSCBuYg5HsJ/sFLgGu+lTeoWpvImeKtlr2TBgatgBAfdGqSP9B8Yn8YjDK+1pphCInT16Gi3RXrEDoPpR0d9E9pwpRjd5USdKwrZTJ87N2+gJITQVy76KdqTT8DY1Sv6jsalg1RB/e1jMdGcGWD6b2BroabITfzLFAyOohFTZtQRTWVyG4ZKUNOH/n4jjzYiZzDPbSC1aQRmiE/OIdc766Qva+JcZ12LQFzSdyFMkCTX6U1++NYbT0CnSHfZJXtXP21bB77fbkV9IYnYgKDDlDsDXcq67tpi7DTEI0U7ZwLrrzMBp76wKihh+zMOs1i7UcawgTLERlSvpyGS8gArNgcy3cYJMGSzkICuKjtG7cSCl/FYcXRfhue7ClVSk51Q52FhzowQ/1WXwSXSazvlbMFME3U4wpaj2rMBStG2tyGzsjSeJcy7+BIEGv3sKzs2ZZ1+pSEC+y9AMi3X3IUZCc8Qad2L5IX+S8gkdvFoYCo5pWvthizWZFwbUvaET3csfUCpAbKLGy4EAcsB1ORdFnnFGfuTmDXhPqi18U6Uc/6NFbITgB0Qh375nHtmfk7CHuh1GnrwLp67pLX6W8kk5yxqAeKv0grXFj2DRAXs7ri+CU3OQLQGhGM89kW0NdTK0vGcii82ptOaNCH4K72meHK4mXw2/0hQmxy8bECWLxITfX9L6cMTwqLps2EnVbP5rHbxobUU34BqvhhAbknNsnAYZBy98VXVIIbmmF4EwLWPCxnpiPetrKDYNrbI5gGQljS2rCclJQP0yUbEhbusEWUTTaLAy17Ol306c14oZoUtfW8JSsHGiIKkXsgfCC0sAebxE29Ymi0SMjBGcZ9CLhXjKVGTdshrBkbxPOiBl1qUoRExIFCy64uMFOPrV1gy2iqdA3CkPN34UHjpOdd8ZYW3RFEy59KwHIR6lH7Zl5MTLKMVFF+qxRZKyGvBDchy2gv+Ta0JsxfTqS/+okTS84DaHAUicvmHEHGVukxS8surwxbOrTsxuCW9vh9EfQJ7wjCsNi3TdxLjwmhTHpyphe1wvB7TGVXb9LiyL9YA6VNduhScv4TgrOp1tnw7pdKAbo0rcLMMd9pAluIARH7/JF2G9k0yR8PJ81230awqpC3wRICy2VknzgDCFYTNZnM6rZRSd5bPrWGJi9YS/sJC1JNFQJoWGWf+oze8ZRT1dt+e8VOHI2z9xvvBDcs9zcVRpSNxbpizy8ymTUbkmOh5go7KzEZnygqyuDfQMXznTFuu6oku59okeeUP7KF7mxSD+uOJ3NC8FZAKeZcKuOaz6Ow9krc+dtmC4OwMmCTd2MM6MQlV7gFdP1UQnDMkHOxFE59bn0SSwOfCm9zgvBGeB37CG69HZdyvByZlHpAy0svXy38vZvMBh1OJIvIDMzUYhxZzRf5ftOg8MJk7rj+VRCqJMsFPGOX3eSzkcxzRU+/p9djb24s4VKsVr1d25xnxWIUXEHeQfMiisHOOFWVkXJhQYIR2FUZPzOaRRtfyV5kltcJ+9HpqhXF794cwDuoHrKre6zBFhqFXCil7hmHCCq3RqIcC5YzemATwTRDFvEePgZPmTzdp72+9niWncegL3XAn9utsrGq9XE25bXWgSNrU06QCSkKzjy5qEOouDPtP54vuFE8qBuF9KQ00ieUiJub5QWPehbAKfj6WgxYpm/tbKt6iJzLzgR14whnFNkqC+iqIwFE5H0ng46tSs5FI1W7oV/OmCzsMnY4tFi11+MskXfn4Xe1rpmbI4LmyR65zJ4sfpGLioVN+J4PlFkWi9wcTPMLq2S4emA5vF8DYR2R6/HSBYt2HK5Kkb+VhsBk+HTHMRNxLXIbjEeF2nl6YB4Sm6zo9fisYT4qRDq0wGTpNm5Nd8Wr0359CtY4cvRbjDtw1CjsEH8z0rUh64TOL4vjFCwaNTw3TpOFlyspAxUU4eP53Pp0RrBYsdVPZc0IWc4hPCsdQbYH9eCj+HqBdRdyQmaUGQ6aF7aY2bBQX041vXEZWefBe5nGmCesWzJHb7gfjeB9UECiF7FcsAthwWnHZwJFD4dUGjCuLZuwiTKcF7QWWSxrElpcpDpk12jPVpMuEbLfGMGf/YCaZSB9wyxxVHGuyCfLHcF6Itw/4pzauMbK1+o7Hyp7djyAxZtskv9hWkwnixXq5Idi7zM0m8J8A23wOajPxPxLz6Zv8rOlktFfeLg1mNqD3IUi6HcqKH0eD6b4out6Hv9Phf2k8DWvHSJbSJSLbjQx8L+YLtsBVGO5fgzPIJcVaetTgd8lU1lT3IWNgL44e5tN+mNemxSwqJ4jflUygDD2XkS0egddw75ZF6Ml0E3WBxv2ep0QArBQbELVNfV1690Nu7mtFmeTSDlvRSgrRGpW2lZAdb6dv30LBAGF/LwvOC0WWmGSyrndSMYtf605NnRQcL6vdFC6IkKfOIyZQRTXFOt3ICwYcVly/JxP+gGRygDWy5PqSy4B3Ees9D85f7gYJt5I8W6o3y8LMqEjBppc6/0ru3Qw0IGm27ZShh8gVmSiMK/cp+3jowsOLTV1uxtFnjafHtkAU6E7VuLoKI3AVIYgzrUXLiX22Scx5AVGoohRYOb9KBLXhaciBf9vG0f5uiExU+b/fN3n4XwiRu5sq8QMl0ZIjXb6rIf632/ZCC1PHLZ4rR4k7wQ3Fw5wFkxHdFeJ6UA8sqd+zBA6rTkrBLIJEj4p132UA2pQlRrbzbt6VcLkW7JBTokbOyVjg251UiGI902e6iGvEJUsSFvg/rFSgXRdSNCan9JX2CansYd9jYNkFeIOiisHaBLQOQVm9QxNgI1oPSEHijfEjeCrn91JJRZdg6U8rkROATCBjiq/BmP3HnRLSiEvjTR26790REfgUJUcTzCtJoNR3VKMGPOVuLyBy8/1dxJ+s+OhFIBdyMrrQoiH8EGIkhtJW6Zsn4W/UzHXf/uSKghbZppZqWVQhQAq/GJi9RW4o4t69jXqR0Q+SuEFIIzVvg/S+3NZgBJZjrbZjInrKHOTJFs9Cf6AiilgLvyBB5LJKoQMnUIdUbHwNtp2/SmZiu1hjCBfPE/OxKqA1lwcFaEFgUH2Gy3DcCuqoNMly7AR82l6UWvkRxSzDa98xEfFsmjng2dfAmMYo2akBfRnnzRjzMJp4Zx/a6XaIqZyjb97V7YlRBVFhzx0dWD2GwEKaMjWVjHYHELQBvRyptmZPkgm+7/EKFRiKoLQ7uWRG2gJoRBQx65yEXKNBDzDFC9CMs+h6qxbt2y+q/JOP8Y6dlSGs1YdEIA8ZwbSsc2R2evJWhP8S0e8fHHJ112DrJjzSw4XVnQSE2oSjDiCOvMREFzddyStcwn9zb965ORVQjOyIKTo1hrquE7Eyt+q2HiEM96OTm5Mg3QyhO4uUi/Hcn2reMRMNO0wRzs6vwbHVe1j5b9mBhcb5eQYtFlxV7Yd6ITZWgZhaGw0VATFlU2yYseJ/aqdfyTeYSCGw+XQZvm2UNt6VlHGZHWAmIjIeNvJc4Fs2GInayYgFesjtlDf34yst64xcxKm/aazEGSiyetIoz3XTuxf8+lx6LLgH91d3LOPxYubL/W6w/EDbkhr/lw6J5D4afr3OmIjya0d6OMc0NplALcy4tVJuTSEJXP3gGggYwrb2/Tv6MPV03Pa7z+rnfGorUH1qzwT0UJIHyFVm8t0m9HfghuUgnRD4xONbMNvkHp2xBZIGZxzyOhakkl+qnjO7MKiHrAqGtGGuCWHpVZqiJ03iNOxD87GdmmDTGqCsEtS+eiFzdkPSViHsZac2RKBHFH8T2QQd62SL8dYfQ775nHI4QlKnPjhnr3kfjVUIHy6GUugq6BBaDB/lsmL9ZWk92LRJm78Af1CaVndcKQGfL34ob6fOx3O3ou6jbZeesPXjJ//jHSItstiLagpxEbARjjhFI8QFk4fhmjjBFa0lWBV2nGbH6YM/Oml7Wv7eL165RZQ/1XYVOfhpQiZhSGCmDT04Z38+DhCotTZHw99eXVqAWiF5arQ8sFLU6BSNrT9tNeARIf/ixs6tOA9oIzjkcYGZIgOenQlUoBRlNlnzO9AwB/6ZBgWV939vqW+DQ+3f3U4CqKaVMIXRiaWbPkgQCm1gYZT2dcnoF3Lt4Cbm36fvAHjx1CHfHHtHBDcGGzMaKYMswhcX57DwGeQ+/8cFr5g1dc/9q/LyEKwVW6pkkhrxIAP3KG/jJjE19oDD4OE3/wPgMS9j8jgriqWFBfyGu4kfcksuZy3L726t6y+QKtoPUqqMfL+u5Hkt9GKgRXurxnHAAu6nC7ORwzc7TNr/jjRWoYCRE+HL/+IyOtkqgQdVmiimmUnztr0Gx5T8Sz7Q13LK0grZvRZf+fKfcaepUQi+BkeSSA6SOAABZ91RIpmV3HltyED6vTg8eb/0NmVbW2gTjRQQK8yvCHYNGx0mnp+2PuC5ag3d1JSvcOvx8lZcfzUcpW7s0amUzBdj9awZNN8HBa+EqvXCtUH513H0qfytrwQnCSXvXcov9eMJ9zf7HRAbzHbXm0sOSwoLtSXJFjqhxZy6iifMOucjogOrN5Pvvoeq+VIRg8CqKMGmWg15JIGC9vI1SIqlI4SQ0IBl2/jvyZd/6qWcFO4qSigyEL8xdZiuoxVYMYKESVrJuvVsteseSmymUjq+gvj/gAAAKHSURBVMMseJPDR22mTCoO0ym9KhYHConj+X4FMY4GpcfzIX0Qo0pbbEsAe2y0nPZWvR9bsMCH8dumwfQSFQflqbIRzdBfQRRMEkfVfLAmiKDN3wngBJkU/rAH7/u9mfyHip+So/NkUYh6y+aQ3DbSyhNDkMwQ3N4CSIOpB28ZTMcNNy7OckrLSnxh+kVpoj+0oRhPtSmtjiN6INGyXWtUTHjzoOzHPSl0jtsbzM1UHlYS5tGUj6AoHJXFoy2zvul4vvr+UWXnxgj2VosxuE+sKxK22ev6phQ8Uf3aiQclVXNQL6iOXOo0ra5zKI3geL5GvaMKUeEfATAXhxMupgxV+vOtvkIsCkPLq36AdW+vH3TaiKFwqmHK+FAvsnARynFNAaEIuTTQCh6JE7vE4YBl720gFEUhrZRiJIrck+ZSSp9/jMe+FYvxalk8CnMzuVnUpWBlVDSeqCpXPPanxTSMoW7tFjGcqmJKthTmSzF+FYOXNKsNsxvnQ8gxlp1L1pGqIoFTz/TZcjcRnEnUqMLWeC8qAxYHk2CMPpKHE95I8ui8ivvoYDc4cLgNQNFG1EiKWs2eUa6wb/AVImkq3Nq8kJJwTG5VU6TBWgJs0kbwviPE6Aekw5I2LDoYDER9bwWLCiJDoN0cTGUbLbrmGXyFJHQ6YNPG+ahwLVxbNIf936YFPFpTtPELczZSpwPe+hAxsZpVoAPEpGJXk8o2Ko7na0YIMa7f7cBrXRwN2Kz6lV+atIoApKKKv+botSbNV+qzivuSeNBw5G8oxrfb4NS0jQoC77TFbUJNNW28qcHl3jYo34jipue0MoY7txdo305RWnM839/SfaJL1dSu8//RP/pH/y/o/wCA063XByrVYwAAAABJRU5ErkJggg==', true, 'CASH', 'Espèces', '2022-01-15 18:04:18.689318', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.689318', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CASH');
+      INSERT INTO public.billing_payment_method (id, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('491cfa96-1bdc-4c24-8f59-c5aded990aa8', NULL, true, NULL, '4788fb05-d7ac-4739-9b64-70a80f5e7af4', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQMAAADCCAMAAAB6zFdcAAAA51BMVEX39/lSWmXvQCNNVWH//f6EiJNRWmdDSlfo6e75+vpJU2Cjpqr7+/3MzdNCTVnh4eRRW2NHTl6+wsWxtbtpb3iTl5x1eYDT1tnl5emZnqZ9g4uLkZqGipP4///1///3+PfuNxHvKwD1rqLvQCbvOxzuMwu4ucA7Q1H59vvDyMtLVmVGS15aYGtaX2314dz17ejwX0zsnZLuZFT17ef0jHvz08/tfWvwU0LxeW7ym5LvdmPvkIJscnrsRin30cv53Nz1wLb43NDvUDYxO0jyuq/zqaPxiHP0hH3zqpz1w770pqH0oY/uAAAk0yz8AAAHvUlEQVR4nO2dbVfiOBSAA42UlFCGlxFEYlppFV0WlFHH0UFdV2dGd///79kEUNtQWIp6nKT38Vst55CHm9yb9CUIAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL83vZTnk3f5Fh8LYaiYihb/6K/8xlBc3si5Kfi70TQsEnCrYVu51Sk4dUzF53qcM0b4cDAYDhmjnKftUb8PuFk9TGEgZ/VbdPJBtjO8P78NfEFwe7Y7oNrGBqnYaQwUnO9IKuCUPRz5YZCfEYT+6IYQxLUcKNIYyOWcTYpkM9nDrf8sYKbBv70SfeOj25MeWqqm6ggNEQQcMX6hGphauBhSDSXkCmkc9Iuy0++c5hMMSLzglOk2NJLyojAoWDGmpuym/JnZjZ9sQOLfUM3GBFxyFilodyK0J6e5JYzkULBEgZDwQHtaScDbyZXBYa6IYzSlhL78CL0OlynI58OBZg46yQ6sbRw7j+NGruCWqSiM0HjBWPA8Mo5Tzz8+lEUOcg1MY4gUan2XXnZOvHiLQ1EjhTEt4SX76HalAW8scGBt1qLsNaxc9UDkBHIaHwz80e7V9dXdeTRVdv1TqlEkLHSQs6pV54WqOK0/SYuj6E8e5K8YxkwwuA26zw680c5HNywFix3EEanRKZEe6g3iYSAmS1j+Ecojw0TXv9Zo7rCqA4HbpOpo4P8lIuDmaDx6ECqidrxLjQIhhQNLns+7ka4QnIuOcClGAs/fxRSfvegJuhplx9UdWG2RGGlsRPRv8NOv7w8xvouEiBgVP7ppK5PCQUl2hcdIfeT51xj/44dhGHS9E4y/RRyE97o5cFbArYnqgJ29dAXvZJdj/LAruPDy4Y+TaPkYnOlTIkwcOPVVaInT2dGLg/G0iBZDAv4imh/EyqTgiGkzIkgHBbuoFIXJiNNZpKXe3YCI5g8Ex/MziO6Obg5WzeYs2tjwX9EXjuRyojenIB/o1RfSOIi2NgxFN7jIj8fdhImkwQ7GkVbKGnEyHrCr+QWFsbEOdiJjYp5PxkOpQRYJYSwYgiN9CsW0cfDjxUEwHonC6HgkEAe9+/uoA++nsXFAdyO/diBrpF9+IHJFEP7C+D7yv3BXn0lT2ji4jvb88A7j4fSAx6WD59lz3r9+16/9pqRzwBG5jc6ZRoywez8MPP9BTKBHLysI+Vt9wiBtHCD2LTZ3lk2/vjy/HGCCo8nB+6bPkJjaARr63UgghKfTJRTBwItEiD98x+/81qR2wCKrBPmuGAunRQJ7iB0+1ygM0jsgX+IXGsPg5/3d7uU4ViX5X97xK785qR0g9qgUhZ4Xhl7Mi//IdLofI70DxEYJU6QImq0qr+WADxdddJ4NlN0vml1rS+8A7QyWOQjCgT5l8oQ1HPQQGwQLLXhd3RSsFQciOQyP/G6Chm7ePxrqpmBNB5yz4+R7cXSqD59Yz4GADS7UJbTAv9CuH0jWdiCHxsu8mC9NwiEQ06bxiTCgVUKYsb4DeV8SP308+xr6vvf1/PiUixjQqTR65hVxIKFsyg5j+lxXUnmlA4Sm0c/1uvsmzqsc6Nj5E3iNg14PYapvF3jmNQ5o2e3UD1oarZol8xoHpGxbzv6W9pHwOgfVXMEpZcJB0gVoCSm78k6tLDiglXKc5uwfmXHQI/V99ZGu/jQpZsYBYn8eqk84TG5YzZID3HEP448yOHZlEgiZccA5Km1/jjN7uDEzDgQEK8xanSUHGJMoGXTAi9tthQM8mSVmxwFpO5bCfiVbeaGH+3N389rlbOUFRGt2NVYh2fvfUcYcIFqsKBCT68Tk5mRrzqTctixKASTFtBRMzo18o6GwRTk/sO34eGBvcmPHA/q5mlOyoF2jCXlBPuuJzHSAN+beh1GtU7zpFubqA2Md0ErOjT+64jZkWtjeVKhRY/uCyPrqK4Bk+widnzOZ60A0S0Ee45maN9JiU2FSMdS3FJrTZpvogJbVlUPbKRLcsZUh0bFbxs6ZcDsxL/TnHnV0zV1PpCX1F7f2y5TOrSvbfWSsA0Tq2wryuc656wtlZPB6Iifq7GgyQ6S9WK4we87EEyqBhNxIZpnUSAekpK4c7skGqkc7JufGhDHxgCQcdcytE3F77p1ZIjfS+Tfn7LcmnzXRAW3acVy7UCS06SpH9zvTdyeZ6ABR3lRWDmUWpEg9avJ8YX7pcHJQzZhPnzXUQSrAATiQgANwIAEH4EACDsCBBByAAwk4AAcScAAOJODAOAdrfZaWbZMcUPWi+ypgk+LAVRcMV6NVc8xxkGpvpsi112rBGAevAhxkw8HTTizZdeDm2pvWgh1bsuHAsmoEY1R3M+zArchbDQg+WCLBcAdOabYvDe4s3tTOcAfu00aV9GDxkPAsSl8W7ssjm/f0sg9SWdwZDHfgFp/ioLnMgf59YWtJHOw9jQdbS/rCnvYOaG1Z4pvuVklaS7Y3tCvaO0DFJQ6shtyYAVcKS/LnJ/0VILy9ZDNX649Ovd5eWiLVtX8tjrxff9l2roVDx1laTBeMeE8U2Vv2O/8PdtOAroDkNpZrS7Br2hcHUzjes2Xu+5QGacCxyoYoEODiVs51qmlwXLtfWvBssI5wjjBq1tJxUCHYiPEwwiobNCXfqgkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADoxH9KvfN1MDMhigAAAABJRU5ErkJggg==', true, 'MOBILE_MONEY', 'Mobile Money Test', '2022-01-15 18:04:18.694047', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.694047', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'MOMO_TEST');
+      INSERT INTO public.billing_payment_method (id, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('609a6ba9-5574-427e-8797-7df7b8c5a016', NULL, true, NULL, '4788fb05-d7ac-4739-9b64-70a80f5e7af4', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQMAAADCCAMAAAB6zFdcAAAA51BMVEX39/lSWmXvQCNNVWH//f6EiJNRWmdDSlfo6e75+vpJU2Cjpqr7+/3MzdNCTVnh4eRRW2NHTl6+wsWxtbtpb3iTl5x1eYDT1tnl5emZnqZ9g4uLkZqGipP4///1///3+PfuNxHvKwD1rqLvQCbvOxzuMwu4ucA7Q1H59vvDyMtLVmVGS15aYGtaX2314dz17ejwX0zsnZLuZFT17ef0jHvz08/tfWvwU0LxeW7ym5LvdmPvkIJscnrsRin30cv53Nz1wLb43NDvUDYxO0jyuq/zqaPxiHP0hH3zqpz1w770pqH0oY/uAAAk0yz8AAAHvUlEQVR4nO2dbVfiOBSAA42UlFCGlxFEYlppFV0WlFHH0UFdV2dGd///79kEUNtQWIp6nKT38Vst55CHm9yb9CUIAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL83vZTnk3f5Fh8LYaiYihb/6K/8xlBc3si5Kfi70TQsEnCrYVu51Sk4dUzF53qcM0b4cDAYDhmjnKftUb8PuFk9TGEgZ/VbdPJBtjO8P78NfEFwe7Y7oNrGBqnYaQwUnO9IKuCUPRz5YZCfEYT+6IYQxLUcKNIYyOWcTYpkM9nDrf8sYKbBv70SfeOj25MeWqqm6ggNEQQcMX6hGphauBhSDSXkCmkc9Iuy0++c5hMMSLzglOk2NJLyojAoWDGmpuym/JnZjZ9sQOLfUM3GBFxyFilodyK0J6e5JYzkULBEgZDwQHtaScDbyZXBYa6IYzSlhL78CL0OlynI58OBZg46yQ6sbRw7j+NGruCWqSiM0HjBWPA8Mo5Tzz8+lEUOcg1MY4gUan2XXnZOvHiLQ1EjhTEt4SX76HalAW8scGBt1qLsNaxc9UDkBHIaHwz80e7V9dXdeTRVdv1TqlEkLHSQs6pV54WqOK0/SYuj6E8e5K8YxkwwuA26zw680c5HNywFix3EEanRKZEe6g3iYSAmS1j+Ecojw0TXv9Zo7rCqA4HbpOpo4P8lIuDmaDx6ECqidrxLjQIhhQNLns+7ka4QnIuOcClGAs/fxRSfvegJuhplx9UdWG2RGGlsRPRv8NOv7w8xvouEiBgVP7ppK5PCQUl2hcdIfeT51xj/44dhGHS9E4y/RRyE97o5cFbArYnqgJ29dAXvZJdj/LAruPDy4Y+TaPkYnOlTIkwcOPVVaInT2dGLg/G0iBZDAv4imh/EyqTgiGkzIkgHBbuoFIXJiNNZpKXe3YCI5g8Ex/MziO6Obg5WzeYs2tjwX9EXjuRyojenIB/o1RfSOIi2NgxFN7jIj8fdhImkwQ7GkVbKGnEyHrCr+QWFsbEOdiJjYp5PxkOpQRYJYSwYgiN9CsW0cfDjxUEwHonC6HgkEAe9+/uoA++nsXFAdyO/diBrpF9+IHJFEP7C+D7yv3BXn0lT2ji4jvb88A7j4fSAx6WD59lz3r9+16/9pqRzwBG5jc6ZRoywez8MPP9BTKBHLysI+Vt9wiBtHCD2LTZ3lk2/vjy/HGCCo8nB+6bPkJjaARr63UgghKfTJRTBwItEiD98x+/81qR2wCKrBPmuGAunRQJ7iB0+1ygM0jsgX+IXGsPg5/3d7uU4ViX5X97xK785qR0g9qgUhZ4Xhl7Mi//IdLofI70DxEYJU6QImq0qr+WADxdddJ4NlN0vml1rS+8A7QyWOQjCgT5l8oQ1HPQQGwQLLXhd3RSsFQciOQyP/G6Chm7ePxrqpmBNB5yz4+R7cXSqD59Yz4GADS7UJbTAv9CuH0jWdiCHxsu8mC9NwiEQ06bxiTCgVUKYsb4DeV8SP308+xr6vvf1/PiUixjQqTR65hVxIKFsyg5j+lxXUnmlA4Sm0c/1uvsmzqsc6Nj5E3iNg14PYapvF3jmNQ5o2e3UD1oarZol8xoHpGxbzv6W9pHwOgfVXMEpZcJB0gVoCSm78k6tLDiglXKc5uwfmXHQI/V99ZGu/jQpZsYBYn8eqk84TG5YzZID3HEP448yOHZlEgiZccA5Km1/jjN7uDEzDgQEK8xanSUHGJMoGXTAi9tthQM8mSVmxwFpO5bCfiVbeaGH+3N389rlbOUFRGt2NVYh2fvfUcYcIFqsKBCT68Tk5mRrzqTctixKASTFtBRMzo18o6GwRTk/sO34eGBvcmPHA/q5mlOyoF2jCXlBPuuJzHSAN+beh1GtU7zpFubqA2Md0ErOjT+64jZkWtjeVKhRY/uCyPrqK4Bk+widnzOZ60A0S0Ee45maN9JiU2FSMdS3FJrTZpvogJbVlUPbKRLcsZUh0bFbxs6ZcDsxL/TnHnV0zV1PpCX1F7f2y5TOrSvbfWSsA0Tq2wryuc656wtlZPB6Iifq7GgyQ6S9WK4we87EEyqBhNxIZpnUSAekpK4c7skGqkc7JufGhDHxgCQcdcytE3F77p1ZIjfS+Tfn7LcmnzXRAW3acVy7UCS06SpH9zvTdyeZ6ABR3lRWDmUWpEg9avJ8YX7pcHJQzZhPnzXUQSrAATiQgANwIAEH4EACDsCBBByAAwk4AAcScAAOJODAOAdrfZaWbZMcUPWi+ypgk+LAVRcMV6NVc8xxkGpvpsi112rBGAevAhxkw8HTTizZdeDm2pvWgh1bsuHAsmoEY1R3M+zArchbDQg+WCLBcAdOabYvDe4s3tTOcAfu00aV9GDxkPAsSl8W7ssjm/f0sg9SWdwZDHfgFp/ioLnMgf59YWtJHOw9jQdbS/rCnvYOaG1Z4pvuVklaS7Y3tCvaO0DFJQ6shtyYAVcKS/LnJ/0VILy9ZDNX649Ovd5eWiLVtX8tjrxff9l2roVDx1laTBeMeE8U2Vv2O/8PdtOAroDkNpZrS7Br2hcHUzjes2Xu+5QGacCxyoYoEODiVs51qmlwXLtfWvBssI5wjjBq1tJxUCHYiPEwwiobNCXfqgkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADoxH9KvfN1MDMhigAAAABJRU5ErkJggg==', false, 'CASH', 'Pay Test', '2022-01-15 18:04:18.697627', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.697627', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'PAY_TEST');
+      INSERT INTO public.billing_payment_method (id, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('a3b6c142-8f5f-4dfe-943d-2385a40d7d21', NULL, true, NULL, '83cb0342-a471-407e-9e84-969ccb80623d', 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxASEhUREhEWFhUVGBUXFxUVGRMVFRYYGBkXFxgdFRgYHSggGB0lGxUXITEhJSkrLi4uFx8zODMtNygtLisBCgoKDg0OGxAQGy0lICYwLy0vLS0uNS0tLy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLf/AABEIAMwA9wMBEQACEQEDEQH/xAAcAAEAAgIDAQAAAAAAAAAAAAAABQYEBwECAwj/xABJEAABAwICBgYHBAYJAwUAAAABAAIDBBEFIQYSEzFRkQcUQVJhcSIyM4GhscFCcpLRCBUjYqKyFyQ0Q1SCk8LSU+HiFjVjc/D/xAAbAQEAAgMBAQAAAAAAAAAAAAAABAUBAwYCB//EADcRAAICAQEHAgUDBAEDBQAAAAABAgMEEQUSExQhMVFBUiIzNGFxBjKBI0KRscEWYqEVJNHw8f/aAAwDAQACEQMRAD8Av6+Yl+EAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBZMC6AyKel1gXFwa0b3OyHNWWDsy3L6x6LyR7smNS6nWqpXRnPcdzhuK1ZeBbiy0n28nuq6Ni+E8VC/BuCALACAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIGdzJHHFJUTZRxgk+J7AFd7G2Zzdms18K/wBkLNylTDp3IWj02wyWweJYD4gubzFyuiv/AExVLrDoVVW2Nf3FioKSOazopmSR9rmG58iOxU7/AE7bC1KT+EsVtCEo6x7muekDSk1DzSxgsgiNi0gtL3DtcDnbgF3GFiQprSic1mZMrJ6HbQ3Td1PanqSZKc5XObovqW+HYsZmFC+DTRnFzJVPRs2DV04bZ7DrRvALXDMZ5r5xtLZ0sSeqXws6zHyFbH7mPdVfYkhYAQBAEAQBAEAQBAEAQC6AXQC6AXQC6AXQC6AXQC6AXQC6AXQHaNhcQ0byttNUrZqEe7PMpKK1ZTOk7GQ57KGI3ZEQX2z1pDuHja+7iV9R2XhQxqUkcftDJdtmiIaLRpsYDqyfYl2bYGNMtQ4fcHq+9TXc3+1EZY6X73p9vUncLwkQkSU9DiNxukEkUZPm1aZy16SaJFdaj1UWS2J1WHVgENYyWnn3NllYGG/Z6bfRd5LxBWQ6xeqNk3VZ0mtGULSTRyeifqyWcx3qSt9R4+h8FMqtU+3cgXUup/byWbo10jseoTG8b77In7Du7fgc7Kv2nhQyKmtCbgZTrlusvZwqUH1b+N18/lsbJUmorodQsqvTqzj9Vzd34rz/AOj5ftM81X5H6rm7vxT/ANHyvaOar8nnLQytFyw2Wm3ZuTVHelE9RyK5PRMx7qFobgsAIAgCALIF00MExhuFi2tIPJv5rp9m7HWisvX4RX5GT13YEj1SPuDkrrksb2Ii8WzyOqR9xvIJyWN7UOLZ5HVI+43kFjksb2ocWzyOqR9xvIJyWN7UOLZ5HVI+43kE5LG9qHFs8jqkfcbyCclje1Di2eR1SPuN5BOSxvahxbPI6pH3G8gnJY3tQ4tnkdUj7jeQTksb2ocWzyOqR9xvIJyWN7UOLZ5HVI+43kE5LG9qHFs8jqkfcbyCcnje1GOLZ5ITS/FoqGmdK1rRIfRjGWbj9Bv9ylY2DTxNYxSNGVkShB6s1to7RSMEczRr1lW5wg18xG2/7Sd4433FWtsk216Iq6otaP1f/wB1Nn6PaMw0oLvaTOzknfm9zu3M7h4KDZbKX4LKumMOvqRmnektRRugEMbXCRxDi/JuVrN1vsk33+C2UVRmnqasm+Vem6Rz9OqOQGnxGldESPSbI3XZnu8R52XrgSj1gzXzUJfDYtDyloo6YspZSZcOq7CJzjcwPdm0BxzDT2HsXpScviXSSEoqHwy6xfb7FC0owGagn1CTb1opBcXAOWfeGVwpdVisiQbqpVS/0Xavw52K01PWNxCSkc1pjl1XFrC4G2YuADft4FVtsdybRb49nEgmR7ejyci40glt9/8A8lqNx3i6Nqpxs3HpieAcSfg5AROPzYto/JDIa11VTyuLSyXO5AuRnmDa9jdZ79Ai/YZiNPXwCrpXXafaM+0x3aHDsIXLbW2VprdV/KJ+Nkf2yOQuaLALACAIBdZ0ZjUmcKw61nvGfYOHmup2Tsrd0tuXX0RX5OTr8MTJxGvEYsM3HcOHmp20tpRxY7q6y/0aaKHY9X2IF07yblx5rjpZN0pNuTLNVxS7HG1d3jzK88e33MzuR8Dav7x5lZ5i33MbkfA2r+8eZTmLfcxuR8Dav7x5lOYt9zG5HwNq/vHmU5i33MbkfA2r+8eZTmLfcxuR8Dav7x5lOYt9zG5HwNq/vHmU5i33MbkfA2r+8eZTmLfcxuR8HG1d3jzKK+1/3P8AyNyPgyKJjnutrGwzcbnIKbs+u7JuUd56eppyJQrhroaw07x01tVqsP7KMiOMdhNwHO95y8gvp+PUqq9Dj8q3i2aehsHRKlaa6peB6NOyKmj/AHQ0Aut5myiWv4F9+pOoWtjfjoW6rqGxsdI82awFxPgBdR4rV6EuT0TZrqmxmOpopZK4l8dTPqQxNDS+K/qkdtxv93ipcq3Ga3PRFerFOt7/AKvocaH4SI6yejrYts9zGlkrxrNdEzIDP1d/zHYlstYKUegor0m4TWpb9M8ObLQzRgD0WFzP3XMzbbyIWimTU0Sr4a1tFUq524hFHSS22ktOyenkNvaNu17b+Orf3ngtyTrlvLyRpNWxUX6roQOhUBmhr8LlFjIx5De0SNGqbcNzea95UU0po84MmpODNNFpGTrgjIi5yIyI5hQtCzJHRkydcptm4h+2iAIJG94v7rXQwbP/AEh6676Sn4CSU+eTB8yiBU+iLGJKfEomNJ1Jzs5G9jsjqm3EHtWJLVGTdtbGGyOaOOS+eZ1ahfKK8lzTJygmzxUQ2hZBxdOpgmsKw21nvGfYOC6nZWyt3+tcuvoivycnX4YmViNeIxYZuO4fmp20dpRxY7sesjRRQ7Hq+xXXvJNybk/FcXZOVknOb6stoxUVojha+5kIZCaGAgCGQgCAJoYCaGQgCJGH0IzTvF+p0uwYbTVAztvbH2nw4L6JsDZypr3pd31Zzm1Mv+1GqIn6pa7ulpt5G66VlCn8SN1aIzgVtbHfKQx1DP3mvbvHFVty+CLLeiXxyR7aXYvM2amo4A0uncS/XGs3ZDJwI8V4qgtHJnu6x70YL1IHSHQZ0EjaygAuxwf1d/qX/cv2+HJbq795bsyPbjOL34f4LtgFY6eGOeSHZSOGbT6wzPbvt22UWa3ZbqZNrk5RUmjz0sqxFR1Eh7I3WHEkWA95K9UrWaMXy3a2zT+kc76eSiaw2fTwRHyc4l9j7iFYVxU1LX1ZU2twlH7ItLHt/WFFiMItHWDZybvRkIs4Hz1eYWh/scH6ElacSNsfU09p5QiDEauIZASuI/zAP+bioZZkl0TUO2xWnFriMukPk1pHzITUwZXTRW7XFZGg3ETI2DwNruHOyIHn0N0W0xWE2uI2yPP4bD4lH2Mm66p93uPiV85zJ7985fcuqlpBI8lGNgK9aGCZwrDbWe8Z9g4Lp9lbL00uuXX0RX5GTr8MTKxGuEYsM3HcPqp+0doxxo7q6y9DTRQ7Hr6FdkcSSSbk7yuLsslZJyk+rLWMUloiv6aaQmhpxMIw8mRrNUnVGYcd9j3VM2dhLLt4eunTU1X28NakHoj0gGsqBTvhbHrNcWuDi67h2bgp+fsbl6eJGWuhqpyt96NF7VCTDX2k3SO6mqXwRwNkEdgXl5Gdsxax3bl0OFsNXUqyUtGyFZluEmtCS/8AWLv1Z+sNiNbW1dnrG3ravrW+iivZi5zlt7p5PfMf09/QrH9LMv8AhGf6h/4qz/6dr95p5x+Dn+lmX/CM/wBQ/wDFZ/6ch7zHOvwT+henL66WSN0DY9SMvuHF17HduCr8/ZMMaEZKWur0N1eRvvRohoulZ20AfStDNaznB5JAvYkDVUx/p6LhvKfU1878WmhsyKRrmhzTdrgCCO0HMLmZxcW0+6J0Xr1RS9M9OX0M4hbA14LGu1i4tOZI3WPBXWz9kxyqXY5aEW7I3JaaF4wmdrjFI4WBDXEb7XF/qoOI668pcTsmbbN6Vfw9yH0p0FkrJ31DKxhLrarHNsGtG4XB+i+iY+0aHFKLRzN+DZKW9qU/EdA8Riv+x2gHbGQ4e4GzvgrGOTXL1IE8S2PoS+A109opGscKujaWuicC11RTHeG3+03h5LVOK6+H/s31ylon6r/yixaQsNeyDEMOeHTU5PoHJ1jmWkHcQew71pr+DWE+zN9utiU6+69DAqsQxHE9SkdRup2azXTSHWAs039G4FsxftXvdrr+LXU8OdtrUdNPJsq4aMzYAZk8BxUPuyw6JGvNJcbjq3HO1DTODpZOyeRubIo+PpWuVKrhuL/uZButU3/2o1nile+omfO/1pHF1uA7B7hYKfGO7FIrJS3pOTLloDKZ6eWk3vifHURe5w1gORPvUa9bslL+CZivei4eOqKf020+piryNz4on+86wP8AKFXFuTP6PtDrVdROf7uJrQfvuJP8g5oYNe6T123rKmbvzSHkdX6L0ZNh9ANL+2q6jsjiaz3vOt/sWjJnuVSl4RmK1kkbGXzdvVtl6ugWAS2DUQP7R3uC6TYuz4zXHn/BX5VzT3EZuI14jFhm47hw8SrTaO0Y40d2P7vT7Giih2PV9iuvcSSSbk71xdlkrJOUnq2WsYpLRHC8Ho190yyf1aFvGa/hkx35roP08v60n9iFmP4UjXkD3Uc1LUjIEMlHkDqv+q6OemTXZU/ToQ1/TcZG+K7EGRwPqPsNjMnmLXH0XBVUOVyq++haynpDU0C6B0sM9Y65O2jF+LpNcu5ZLv4zULIULx/oqWtU5m1eixjJMNax7Q4CSW4cLj17hcrtuUoZjlF6dET8Va19TN01w2BtDO5sMYIZkQ1oI8lo2dfbLJgnJ6a+T1fCKg3oU7oepY5H1IkY19mRW1gHWuX3tfyVz+oLJQjDdbXcjYkU29TZzaGKMOMcTGktcCWgAkWK5lXWTklKWvUnOKinoj5/oMNdO6YMzdGx8mrxDXZjldd9ZfGqMN7s9EVChvNmxOiXSLXZ1KR3pMBdETvLO1o42+S53b2Duy48Oz7k3Ft1+BkF0vf25n/1M/mcp+wfpX+X/o05fzEbbw72Mf3Gfyhclev6kvyyxh+1GQFqT07HrRM94quRu558t4UqrOyK/wBs2a5UQl3RkNxG5Bkja4jMOsA4HwVtR+obo9LFqv8ABGngQfWJH1uBU0shnp5n0s53ujNmvP77dx896v8AF27j2rdb/hlbds+cXrHo/sJabGo2367TuaBcvMVjbyG8q2jKmS1SIso3x9UU/GcdiddtVWy1RG+CBpp4T4SOOa3wrf8AakiJbav75N/Yq+MYzJUarSGsiZ7OGPKNg8u0+JzUmutQ/JFnY5/ZEathrLF0fV+xr4T2PJjPk7/uAtORHWBIxZ7tiZx+kBBatgf34SPwuH/JVKLwl+iRvVsHras5FxlLT4MYGt/jLkBpdpJzO85nzOZ+K9Ho3h0K0uzw2omtnLMW+YYAB8yqva1m5iyNuPHWxFsC4MuAhgseC+yHmV3GxfpEVOV8xkLiftX+a5faj/8AdzLDH+WjGVebwgNadNUno0reLpDyAH1XT/pyPWb/AAQM30IjSvDL4TQVFvUY1rvuyZt+Kl4N6WfbW/X/AINVsdaos9MX0hLsDgj1iXufsn8bRHWJ8sgF5x8Ld2lKWnRLX/J6lb/RR64lhOwwFlx6UkjJnf5vV/hsvNOTxdqPwloYlDdpJ/off/U3i/qyu9181XbfjpkJ/YkYb+AnNO/7BUfcULZn1UDbkfLZSehb2lV9yH5vV3+o/wBtf8/8ETD7s2jL6rvun5FcvX+9E+fY030WOAxBwt6zJB8e1djtn6SL8aFbjacRmNpbhkmGVzZYcmF21hPZv9Jh+I8ituBdDOxXCffTR/8AyebYumzVHPSPXtqJoKhnqywRkeBBOsDwsSsbKqlTVOqXo2L5b0kzc2G+xj+4z+ULjb/mS/LLOH7UZK0nsIAgBWH2DMbSjHpKR+GQsfq7eoDXjL0oyCCD/me0+5fQtmwcMaCfgpbus2yKx3GMNnqZaWug2TmPLWVDN9srFxGYPMKZDLdctCfZ+nnfjxur66rt6lex3QSeJu2pnCphIvrMsXgeIG/zCs6sqM+5yuTgWUvquxUlKRBPSCbUc1/cc134SD9FhrVaGYy0aZZf0gXazqGYDJ0Uvx2bh9VTaaM6KL1RIY1/VNFo4u2drB/qvMnyXkyaXK9GT6K0IpdjhFIwiznjXd43uflZc9+oLNKox8sl4a1m2SK5AswhgseC+yHmV3GxvpUVOV80hcS9q/z/ACXLbT+rn+Sxx/loxlANwQGqummT9pTNzybIfDMgfRdX+nFpCciuzX1SLW3ChPg7Ke2+mbq33hwbcfJVfMOraLs/7jeoa06Gn8DpX1M0FNnZz/V7tzd5t5BdflWRqqlb9v8A8K+tOUlE290lwj9WyAZBmpYeAIC5DY83LNTfqWGStKtCI6GH/wBXqBwlb8WBS/1FH+rB/Y14T1TLLp1/YKj7n1VZsz6qBIyPlspPQr7Sq+5D83q8/Uf7a/5ImF3ZtKX1XeR+RXL1/vRPl2NMdF//ALj/AJZF2W2Pol/BW43zTZWmuACtpnRj2jfTidwcOzyIyXN7NzHjXKXo+5Nvq34mhpC4eg641CRqn7JuLjmF3i3WnKPqiqeuujPo/DfYx/cZ/KF84v8AmS/LLqH7UZK0noIAgOWi5A4kL3XHemo+TEnomyuaWN2+kGG029sDHSnwyJHxjHNfSK47kFFFE2VfpGaBiM9uLTzaFEt/ed/sZ64cDC0f0kqaN2tC/wBHtjdmx3u7PMLEbJRN+Zs+nJjpNdfPqXKWgosYaZKe0FYBd0Zya/8AP7wz4q0xs16aM+fbW2DPHlr6ejNe11HJE98UrS17TZzT2fmDx7VaxkpLVHLyi4tqXcnulC89FhLhcuf6HOw+iqrVpNl7jy1rTJHp3lEVPQ0bdwuSPBjWtb8ytZuNOtj1iGdriG+9xDfqsg+o6iHZxQQ/9OJg5AD6LkP1DZrbGHgsMKPRsxlz77k4LBgseC+yHmV3GxvpUVOV80hcS9q/z/JcttP6uf5LHH+WjGUA3BAQWP6J0la9r6hry5o1RqvcwAeQU7F2lfjRca9OposojZ1ZMU0LY2NY31WAAXzNh4qJOUpycn3ZuSSWhF4foxRQTGeKENkOsda/e325qVbn5FtfDlLoa40wi9TNxfDYqmJ0ErSWPtcAkHI3yIWmi+dE1ZDuj1OCmtGYmj+jlNRB7adrgHkF2s4vuQLdq25ebbktOz08HmqmNa6GbiNDHPE+GQEseLOAJBI8CNy002ypmpx7o9SipLRkfo/oxS0ReadrgZA0O1nufk25Fr7t5UjK2hdlJKzToeK6Yw7EyW3uOIPLcoSlo9TY/BAYPobRUsu3hY8PzF3Pc4Z78ip+RtO++vhy0a/BqhRGD3kT6gM3lZxPQPD6iV08kT9d5u7Ue5gJ8grSnbGTVBQTWiI0sauT1LJDGGtDRuaAB25AWCrJScm2/UkJaLQ7ryZCAIDIw5l5Gjxup2za+JlQX31NOQ9K2VbRS9RpFXz72wMETTwPog/7l9AKcqvSJJrYjOeBaOTQoNv7j6BseOmHAri1loz0pal8b2yRuLXNNw4bwfqsptPVGuyqNkNyfVM2JMY8ZpC8ANrqduYH940bvMH4FWmHlPXRnzjb2xuBLej29H/wY9HSdYp8FbbNlY4EWzAYyWQg/gWzJ+YysxPlIq3TtXbTEhGD7GJjbdl3EvPwcOS0oklT0Oo9tX0kR3OmZyb6X+1DJ9HYu+8rvCwXCbXs38qX26Frix0rMRVZJCGCx4L7IeZXcbG+lRU5XzSFxL2r/P8AJcttP6uf5LHH+WjGUA3BAVnS3SGWlcxsbWnWBJ1r9itMDBhkRbl6Fjg4UchNy9DO0bxfrFPtX2DmlwcBuFs/ktOZi8G7cXZ9jRl43Bt3F6ldotNJpJ2x6kYY6QNvY31SbX38FZWbKrhU5NvXQn27LhGpy1eqReguf/BTHAcPNenF9w0VLTDGZ4JomRP1WuAuLDPMDtVvs/GqtqlKa7FrgYtdtUnJdi2A81UOOjKtpkLpRVVkbWGmZrEn0srnwy4eKnYFdM2+KyZh10Sb4rIzTHGKmBkBY7Uc9ri8WBzAbx8ypWzsWq2c0+qXYkYGNVdKal2XYtdM4ljSd5APwVROKUmkVc0lJo9AV5aa9DAWAEAQBZBnYQQHuf3Gk/8A7krvYNe9kOXhETMlpDQqXQezaMrqz/EVLyPIEn/euyKskNIejWOolfOyocx8hLiHAObc8LWIC0zoTepf4e3pUVxrlHVIqGI9G2IR5sDJR+4bHk6y0ypkuxd07fxZ/u1T+5Wa7DZ4cpYXs+80ge4rU4yXdFpXk029YSTMnRnF3UlTHO05AgP8WE+lf5+5ZjNxlqas/FjkUSg/4/JvKkwWIGN8dtVssk7Rw2rHNNvxk+9WLlvdT5oq+G3E+a9Pa7b4jVyb/wBq5oPgyzB8AsnsnOhWj2mKxuIuImSPPnazfmV5k9FqDctQ67nHiSvnOTPfunL7su61pBI81HPYQwWPBfZDzK7jY30qKnK+aQuJe1f5/kuW2n9XP8ljj/LRjKAbgsgommw162nj7CGC33nWV/sxuOPOSLzZr3ceckRlJWmmjrICbE+i371y0/CylzpV8q7ESLKlfKqxHg+kMElJlYuDHm/EuH/Ze+KrYWfY2K1Wws+3QmtMK2WWpbRseWt9EGxtcuzz8AFCwKa66XdJEPAphXS75LUwsboJMOljfFK4g559pG8EdoK241sM2Eozjpobca2GZCUZR0PTTqQvlp3DIujBHgSR+axsxKMLF6JmNmLdhNeGeeP4FLSNZOJ3OcTZxuQQ453B4L1i5VeRKVTijOJkwyJOtxPXSzEXyU1LLctLw7WsSM7WO5eMGmMLrIadjxgUxjdODRzpx7CjP/xn+VibM+Zal5MbN+Zb+TI0yxV7RDTtcWtLGl5G+2Qt9Vr2fjRbnZJatPoedn48ZOdklq0+hBvrYqeWN9JPI7vh4tfdzBzU1VSthJXRS8aEzhSuhKN0UvGhtSJ1wCO0A81yklo2jmWtG0dl5MBAFkHTGKzq+HVs43tifq+J1Tb4ldT+nYfDOf30K7Nl1SK1o7jbcHwCnqDFrvkIsy+rdz3HefutuulIJ64T03UT8qiCWE8WgSN/hzAWBobA0fx+lrY9rTTCRoNjbe12+zh2FASUkbXCzgCPEAoeoyceqZX8S0Jw6e+tTNaT2s9A+8t3rW64v0J9O1curopv+SRqCympXG51YYnZnM2a07z7l7SIM5ucnJ+p8jSSFxLiblxJJ4km/wBV7PJtfoCpbOrKi2TWMjB4HNx+BCi5c1CmUn4PUFrJI2EvnTerLxBYAQwWPBfZDzK7jY30qKnK+aQuJe1f5/kuW2n9XP8AJY4/y0YygG4LIKhj+FTyV0MrYyY2bO7uwWddXOHkVwxZQb6vUtcXIrhiyhr1epjaQ6MTS1hexn7N5aXOuMu9ce5bMTPhDG3W+qNuLnQrx92T6o9tL8HmkmhdFGXNY0DK2ViPovGBlVxqmpvqzXg5NcapKb6s50twGd0zaqnF3AN1m9oLdxHFMHNqUHTb2GDl1qDqs7GBV0NfXyM20WyY3Ik5eZt2lSIXY2HCXDerZuhbjYkHuPVsy9LsEnllhEMd2sYGh18hY9vC1gtWBl111y4j6s14OVXXCXEfVmFiNPidXqwSRaoac3Ws09msT2rdVZiUf1IvVs3VWYlGtkH1Zm6U4DKYaeKFheIwQSLcFpwcyCsnOx6amnBy4Kyc7HpqNLMJqJYaVscZcWMs4cDZv5FYwMquFljb7sxg5Fddljk+57aU4BLKIpogC+NrQ5nabZ5cV5wc2uuUoTfR+p5w8yFcpQn2b7mNSSVxcxrqCMZjWcWAZdvktlix0m42s2WLHSbVj/yXcBULKY5WAEAKAr3SzPqYRswbOnlYweILs/gu42JXu4qfnqVOU9bCR0w0HdW4fS0jJmxPgbGQHeo4hmqbgZ9pVuRjUuLdGGL0+fV9q3vQkOP4d6GTanQfgU1LRyOmjdG+aUnVeCDqtAa02O66wYNZ6S6fYk2vqHQ1UjGNkcxrPRLNVhtuI8Cfesgk8K6a6+MjrEMUzcrlt43W7bbwTyWAbM6T8V1MHnlAttWMYAcjaUhvOzkB8zBej0bz6G6XZ4VLL2zzO/hOp9FU7Zs3MWX36G7GWtiLSuFLcIAhgseC+yHmV3GxvpUVOV80hcS9q/z/ACXLbT+rn+Sxx/loxlANwQEXjGOw0xaJNb0rkaovuUvHw7MhPc9CRRiWX67noZOGYhHPGJY76puM8iLb7rVdRKme5I13UyqnuS7kZDpZSulEQL9Yu1B6OV723qXLZt0Yb77aEmWzrlDffYnrKvb1ISeoWAEAQxoEMgIwE6dgFkBYAQBAcFZSBWek5gmq8JoOx0okPuyzX0TDhw6Ix+xSWPWTZR+mbE5H4s8BzmmFjGNsXN3jWJbb71rjgpRrIrC+kPFaUehVve0Z6s37UG3Zd13fFAfSFPi7W0bauotGBE2WTeQ0aocfFYBqiqw7RbEpHPjqjTSvJc7Mxhzj2kSDVzPCyA8o+hV5kjfDXRyQ6zXOdq56oINhqkhxO5ATP6QNYGUlPTty15bkfuMY76lqyDRRKyej6P0QpdjhNHHaxcwPcPFw1j81zf6hs0rjDyyXhL4mzNXJlkEAQwWPBfZDzK7jY30qKnK+aQuJe1f5/kuW2n9XP8ljj/LRjKAbggKFp83XqYI+IA/E630XQ7Je7TKRe7L+Gqcjz0bxMwU1XGfWjuWg8TdtuYuveXj8W+uS7MzmUcW6uS7MhKKExy0zj9stf7tbJTbJ71U0vToTrZqdc0vQumlWkr4HtggbeR1iSc7XyAA7SVS4OBG2Lts7FLh4UbIuyx9COk0hr6WRratrXNcL5WBtfOxHaOCkLBxsiDdLeqN8cPHyIN0vqjM0o0kmp5Y9lqlj2B1iMzfx7OxacLAruhLf7o1YWFXbCW/3TI6q0mxCB7XTMaGP9IMsPV4A8bKRHAxbYtVvqiTDBxrYtVvqic0n0jMDYxEA58ou2+4A2zPE3KhYWArZS3+yIGHhcWUt99ERUmkNdSvZ1oMcx+Z1bXAyvmNxF9yl8jj3xfB1TRLWJj3QfC1TXkyMQ0iqIaxsT9XYuLSDq5lr8hn4Gy01YNNmO5r9yNdWHXZjua/cjvi+P1ArG0sBbY6oJIubnf5ZLzj4VfLu2w804lbx3bZqWxVJWBYAQHeFt3NHEj5rdRDftjH7o8TekWytVLttpM2+bKSmv5OIuvo0VotCkIfEOk/CKuRzK3DtaMOIbLZkhsMgbb89+S9mBh+hmjmIyN6nVvjdfWMF/SIGZGq8XaPJAbC6Q8MmlwuenpmFzyxrQwWu5oIuBxOqCsA+ZcQw2eA6s8L4yN4e0gc9yyC99BUsv6yDWyO2eykLm6xLD6oble2+6wDL/SArtethh/6UJP8AqO/8FlA1lHCZCI273kNHm42HzWQfUlfHqNiiGWpG0W8gB9Fx36gnrdGPhFnhL4WzEVATAgCGCx4L7IeZXcbG+lRU5XzSFxL2r/P8ly20/q5/kscf5aMZQDcEBRNKTfEqccNl/PddBgrTCnr9y7wumHN/kitKKJza2SJpylc0gcdY/Q3UvDtTx1KXoSsO1PGUn/aZ2mcQinpmjIMa0A/dIWjZ89+mxv1bNGz5b9Vkn66jS6J8NaypLSWHUN+y7RYjwyzTBlG3HdWvXqMCUbMd1Lv1PLSnFmVskUVO1x8xnc+HAL3g47xIylYz3hY7xIylbodtNYtSWmZfNsbR7wQF42bJSrsfls87PlvV2PzqZnSXuh8nfILXsbo5mvY/eZi6Y0jtWnmsSzZtaSOw5W8rhbdnWx3pw166mzZ9qUpw9dTEjiwx+q3Xnu4gWyyJy32W1vMim9FobZPLim9I6IsGnmG3gZK3fDYX7dU9vuKr9l5GlrhL+4gbMv0tcJf3GDoLA6aokqn56osD+8QB8gpG1JxrqVUTftOarqVUS+Bc72KMIAgMvCo7yt8M1ZbJr38qP26mjJlpWyodHsHWsQxipuQHu2DT3cjuXeFOUHGOiXFKe+pG2dg+1ERrWG70DnfwCA7dFOBVH62g2kMkex15Ha7HNtZpaA64yvrfBZBsTpk0zqqA08dK8MfJrPcSA67W2Fs9wJKwCpYf0yyuaGV1HFO3tLRb+B1weazoDZPR3UYVUMfVUFO2Jznako1dV7SM7G2XbfLLNYBo3pQrttilU7eGuEYPg0D6krJkw9BKLbYjSR8Zmu/B6ef4UYPojFX3ld4ZclwW1p7+VL/BbYq0rRiqtJAQBAWPBfZDzK7nY30qKjK+YQuJe1f5/kuV2n9XP8ljj/LRjKAbgmoPN9OwnWLAXDttnzXpWSS0T6HpTklomdjG0m5AJ4opyS0TMJtLRHWWnY71mg23XAKzGyUezEZSj2ZzLE1w1XNBHA5hYjOUXrFhNxeqPOmooo/Uja2/dAC9TunNaSZ6nZOf7mzvJTscbuYCRuJANliNkorRMxGcorRMS07H+s1rrcRdI2Sj2YjOUezOxYCNUgW3W7F53mnqjGr119THZh0DTdsLAeIaLra77Gusme3dY1o5Mrml8FbM8U8TbxOAJIyG/wC2eHgrPZ86KoOyb6osMCePUnZPuidwLDG00LYhmRm48XHeq/LyHda5MhZN7uscmSCjGgIAgMnDp9SQE7tx96sNmXqjJjJ9uxpyIb8Giiw4nJo/X1O3hkfQ1T9qyWMa2o479b5WXfJ6rVFMX/A9OcNq/Y1TCe646jh5hyAsItvHPisAqGnugEGKaj3yPjkjBa1zbEEE3s5p35hZBqrG+hvEobmF0dQ3gCWP9zXZHms6g2Z0WYHLh+HHrDNSUukle24JAHqgkZX1WhAfOdZU7WSSXftHvf8AicSPgUMl66D6PaYmHEZRRPffxNmj5lYlLRNjQ27K67nHiSvm+RPftlL7l3BaRSOq0nsIAgLFgvsh5ldxsX6RFRlfMZE4jE4yuIaTnwXObRx7ZZM2ovuTqJxVa1Zj7B/dPIqDyt3tZu4kfI2D+6eRTlbvaxxI+RsH908inK3e1jiR8jYP7p5FOVu9rHEj5Gwf3TyKcrd7WOJHyNg/unkU5W72scSPkbB/dPIpyt3tY4kfI2D+6eRTlbvaxxI+RsH908inK3e1jiR8jYP7p5FOVu9rHEj5Gwf3TyWeVu9rHEj5ONg/uu5Jyt3sf+Bvw8gQP7p5LHK3e1/4HEj5Odg/unkU5W72scSPkbB/dPIpyt3tY4kfI2D+6eRTlbvaxxI+TjYP7p5LPK3e1jiR8mVHNJq6j4tozuvbcfFWuJnZlEd1xbRGspql1T0IDFdAMIqjrPpHQvvfXiu3PibZFXlO1FP98Gv4Ik6NOzTIoaA4xR+lhuKOe3fsp87+FzcW5KzjJTWqNDWhz/SBjFDliWGOc0b5qe+r+XxXowWTA+k/Can0RUiJ/cm/Zm/AE5H3IDI6RMbigw2okEjdZ0bmx+kPSc4WAbbfvQHy6LAAe4L0ZN2dDGj8tLBPWztLDOGsia4EO1W6x1rHdcu+CgbQvjTRJs2VR35pFwXz8ukFgBAEBKYRXtYNR2QubFdFsjaUKY8KzovRkHKocnvRJYVcffbzC6Hncf3ohcKfhjrcffbzCc7je9GOFPwx1uPvt5hOexvehwp+GOtx99vMJz2N70OFPwx1uPvt5hOexvehwp+GOtx99vMJz2N70OFPwx1uPvt5hOexvehwp+GOtx99vMJz2N70OFPwx1uPvt5hOexvehwp+GOtx99vMJz2N70OFPwx1uPvt5hOexvehwp+GOtx99vMJz2N70OFPwx1uPvt5hOexvehwp+GOtx99vMJz2N70OFPwx1uPvt5hOexvehwp+GOtx99vMJz2N70OFPwx1uPvt5hOexvehwp+B1uPvt5hOex/ejPCn4HW4++3mE53H96HCn4HWo++3mE53G96HCn4HW4++3mE53H96HCn4HWo++3mE57H96HCn4K7jeiOEVdzNTxFx+02zHX822v71nnqPehwp+Cj1nQvQFwMVa9jB9l2q8j7pyssc/jr+9GeFPwWDA9EcKobGKDbSj+9l9I+6+Q9wVbk7dqh0rWr/8ABuhiSl+7oS1VVPkN3HyA3Bc1l5tuS9Zv+CfXTGvseKhm0IAgCAWToDiyA5sgFkAsgFkAsgFkAsgFkAsgFkAsgFkAsgFkAsgFkAsgFkAsgFkAsgFkAsg0CGAhkIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAID//Z', false, 'MOBILE_MONEY', 'Momo', '2022-01-15 18:04:18.701871', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.701871', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'MOMO');
+      INSERT INTO public.billing_payment_method (id, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('bd31cccf-9613-4965-8cd3-d75e1efabfe6', NULL, true, NULL, '3217cea9-4670-4869-b0ae-3dfa28000e6e', 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxITEhUTERITFhUXGBcXGRgWFxseGRggFRcWIBkdGRoaHiggGBslHRgXIjEjKCkrLi8uGh8zODMtNygtLisBCgoKDg0OGhAQGzUlICY1LS0tLS41LS8vLS8tLS0vLS0uLS0tLS0uLy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLf/AABEIAOEA4QMBEQACEQEDEQH/xAAcAAEAAgMBAQEAAAAAAAAAAAAABQYEBwgCAwH/xABOEAABAwICBAcOAwQIBAcAAAABAAIDBBEFEgYHITETNUFRYXHSCBciMlJydIGRkpOxsrMUVKFCc8HRFSMzNENTYsIkY4PhJUSCosPw8f/EABsBAQACAwEBAAAAAAAAAAAAAAABAwIEBQYH/8QAPBEAAgECAwQHBgYABQUAAAAAAAECAxEEBTESIVFxBhMyQWHB0SI0gZGhsRQkM0Jy8CNDguHxFlJTYqL/2gAMAwEAAhEDEQA/ANk6eaaQYZAJZQXvccscbd7zy7f2WjlKjUGlqjXpiRcSyKla3kGR5IHSS/afUEsgfPv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIDv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIDv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIDv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIDv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIDv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIDv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIDv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIHqPXniYNyykI5uDft9j0sgbb1b6w4cUa5uXgp2AF8d7gg/tMPKL7OcIC73S4OcO6JnccRiYScradhA5AXPkufXYewItAasUgIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIC76mKhzcYpcpIzGRrukGJ+w+sA+oIDqa6qJOce6G4zZ6NH9cqsWhBrBSAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgLlqf44o/Pf8AakQHVaqJOce6G4zZ6NH9cqsWhBrBSAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgLlqf44o/Pf9qRAdWKok5w7objNno0f1yqxaEGsFICAIAgCAIAgCAIAgCAIAgCAIAgP0BAWvR7QOpqY3Sn+qjDSQXNN32F/BbsuDzrl4vN6GHmoL2n4d3N+RkotlVIXVMT8soB+IAgCAIAgCAuWp/jij89/wBqRAdWKok5w7objNno0f1yqxaEGsFICAIAgCAIAgCAIAgCAIAgCAIDJoKKSZ4jiYXvdsAH/wB2BYVKsKcXObskDbOh+rqOHLLV2kk3hm9jea/lH9F5PMM8lVvChujx736FkYmwGhedbZYiDk0Iw5xJNKy5273cvUVvrN8Yv8x/T0GxExZdXOGH/wAuR1SSdpWxzzGr9/0XoOriYU+qugPimZvU+/zCuh0gxS1s/gR1cSIrNUDf8GqI89l/1aVu0+kr/fT+TIdIruIasK+O5a2OUf8ALft9jgF0aWfYSe53jz/2uYOm0VSvw+WF2WaN7HczgR7L711aVWnVjtU5JrwMLGIrAEBctT/HFH57/tSIDqxVEnOHdDcZs9Gj+uVWLQg1gpAQBAEAQBAEAQBAEAQBAEB+oCwaLaKz1jvAGWMHwpDuHQPKK0cbmFLCx9rfLuRKVzc+jmjsFGzLC3abZnnxndZ5uheLxmOq4qV5vd3LuRYlYmAtFkntqxZkj2FiZn6oCP0IAgCA+FZSxytLJWNe08jhcfqradWdN7UHZ+BDVzW+lurNhDpKK4dtJiJ2HzCdx6DsXpsvz6V1DEb1x7/j/blUqfA1VNE5ri1wIINiDvBC9SmpK60Ki3an+OKPz3/akUg6sVRJzh3Q3GbPRo/rlVi0INYKQEAQBAEAQBAEAQBAEAQBAT2idJSPk/4ybI0bm2Nndbv2QtTGTrxp/wCDG7/vcQ7m8cKdDwbRAY+DA8HgyMoHRbYvD4mNTbfWXv46/UziZ60yw9BQwegsWZI+gWJkfqglH6EAQBAfikHykVkSGae1uYU1kzJ2i3CAh1uUttY9dvkvZ5FiHOk6b7tPiUTW8wNT/HFH57/tSLumB1YqiTnDuhuM2ejR/XKrFoQawUgIAgCAID3HGXEAC5PIFDdldmcISnJRirtkvDo7IRclregk3/Ra8sVBaHdpdHMTNXk1Hw3v7GBW0LojZ46iNxV0Kimro5eMwNXCT2aq5PuZiLM0wgCAIAgP26XBk0GIzQuzQyPYf9JI9o5VXVpQqq01deILrgus+oZYVLGzN8oWa/8ATYfYuNicgoT30nsv5olSL7gem9FU2DZODef2JLNPqN7H2rgYnKMTQ3tXXFFikmWZq5TM0e7rGxkY8+JwM8eaJvW9v81dHDVZ9mDfwYukR02l9A3fVRep1/ktiOV4uWlNkbceJgy6xMNb/j36mOP8FfHI8a/2fVEbcT4O1m4d/mSHqjP8VYuj+M4L5kdZE8jWbh3lyj/plT/0/jOC+Y6yJkQae4c/dUBvnNc35hYSybGQ3uF+TTJ20Q+s6Fs9EXxkO4NzX7DyG4P1X9S38mcqOJ2ZK11YrlvKZqf44o/Pf9qRetKzqxVEnOHdDcZs9Gj+uVWLQg1gpAQBAEB9qaBz3BrRclYykoq7LqFCdeap01dst+G4e2JvO7ld/LoXNqVXUfge/wAuy2ng4bt8u9+XgjJina64a4G2+xWDi1qjdp16VRtQknbgzCx6DNC7nb4Q9W9W4eVprxObnlBVcHJ98d68/oU5dI+fnpguhKTe5Fiw3AhYOlvfyf5rSq4l6RPW5d0fjsqpidf+31MXSGgbHlcwWB2EdKsw9VzupGlnuXU8M4zpKye5rxIVbJ549xRFxAaLk7gFDaSuzOnTlUkowV2yUdgMoZm2X8m+3+SoWJg3Y7Muj+KjSc3a67v7uIpwWwcMuejeq7E6xgkjhbHG4Xa+Z2UO6htd67WQFqh0L0hw5maExzRt2mNj84A6Guyn1NWlicuw+J/Ujv4rcyU2jHfrDhqaaanq4zDI+N7LgEtzWIFx4zfCtv3LiLJKuHrwq0XtJNPg/Qs201ZlB0b0Yq655ZSQukI8Y7A1vnOcQB816gqLm7UfioF70xPkiU3/AFbb9UBRsfwCpo5OCqoXRv37bWI52uBIcOpAS+h2gVZiTHvpeCtGQ12d9jci4sLH2oCIxvBZqWofTSt/rWHKQ3aDcAix5b3RuyuDYerrVpLK7hpmjM3K5sbjsF9xdznZu9q5dbETxF6eH7tX5IxvfQnNYcbKaCVlQWhxblblO0lw2AfxWhh8PVhiFHvW98DFJpmv9T/HFH57/tSL0ZYdWKok5w7objNno0f1yqxaEGsFICAID3FGXEAC5OwBQ2krszp05VJKEVdvQt2G0LYGZnEXt4TuboXOq1HVlZHvcvwNPL6LnN+13vh4EHiuLukNm3DP1PX/ACW3SoKCu9TzOZ5xUxT2Iboffn6GNhlQWStI5wD0glZ1YqUHc0suryo4mEo8Un4plrxd1oX+bb2rn0f1Ee7zWSWDqN8H9SkhdQ+blh0ewz/FePNH8Vp4mr+1HrchyzTE1V/FefoSkeItdKYm7SASTybLbOnetd0mobTO1TzKlVxLw8N9k233bu4jtKj4DB/qPyV+E1Zyekz/AMKmvF/YrbRdbp49K+hbMEw4RNzP8Yj3RzLnV6u27LQ91k+WxwtPrKnaf0XD1JUe1a52001daEZq+wRlVi0MDxeMSuc4c7Y7useg2A9ZXXh2UfMcVFRrziu5tfU3Zri00mw2GFlKGCSUkAkXDGsA3DdfaOpZGuQep3WRVVtS6lrC15LHPY8NAPg2uDbfsN/UgKhr/wAFjgr2SxgNE7M7gBYZmmzj1nZdAbZ0Io48NwVkmUEiE1EnO9zml209GxvUEBqGl114mJw95jdHm2xBgAtzA7wbct0BtTXJhcVVhL57DNE1s0brbQDbML8xB/QIDX/c71MsdXKwtdwMsfjHY3OxwLbX3mxesHUipbN95F0XfT/CaaGr/GvDGuewAvfbZkuNl9xsR0rk5n1rkoR0fcuJjO5Y9X8sb6UzsN2vc7wuQhlxcdF7rZy7Dyo03tKzZMVZHM+neOurK6eYuJaZHBgvcBrdjcvMLAFb6ilvSMiR1P8AHFH57/tSKQdWKok5w7objNno0f1yqxaEGsFICA/WhCUruxa8Ew0RtzvHhEe6Fz69XbeytD3GTZYsNDrqvaf0X91MPFJZZzliY9zBygGxPXusrqUI01eT3nCznNfxE+qg/YX1fHlwMZmjtRa7mBo53OAVn4in3O5wtpH7S4VlkbmmivmGxpJJsegKJ1fZdkzby+PWYqnH/wBl9yY0h/sHdbfmFqYb9RHtc+f5Gfw+6IbBML4Q5nDwB+p5ltV62wrLU87k+V/ip9ZPsL6vhy4knjmI8G3g2eMRyfsj+aooUtp7T0OznWZLDw6il2mvkvUwNF23lceZp/UhW4p+wkcvo3C+JlLgvu0ZOlTdjDyXKwwmrN3pMvZpvmecBwrdI8eaP4lTiK37YleSZS7rEVl/FebPOkOI3PBsOweMefoU4elb2mYZ9mW0/wAPTe5dp8fAlsHP9Sy/Mtat+ozvZS28HTb4GdqalH9Nx3PjcMB03a4rpQ7KPA4qW1XnJd7f3Ld3SrD/AMG62z+tF/dWRrlW1AsJxZpHJDKT0CzR8yEBN90m4fiaQcoif+rx/JAbKrBnwA5Nt6IWty/1QQHM9HgEzxmcBG3ypDlHqG8qmVeC038jBzR0/pg9kODymVuZrKdgLeewaLbelZTTlCy3Mye9GiMO1jPiqIXxxtZGx7S7lOW4zAcg2XWtSwUYS2pO7MYwtvNq6/cM4bDWzM2mKRjhblEpyfNzVumZJY2/+jMALQbPjpWxAj/Mkblv7ziUBy2UBcdT/HFH57/tSIDqxVEnOHdDcZs9Gj+uVWLQg1jZSCbwnRepnsWsysP7T9g9Q3la1XF0qeru/AhtEy3R2OB4u8veN+yzQereStWWKlUW5WX1PVZDlm1bE1V/FcfH0PE+kEULiMhe4epo6zyqYYaU1duwz7NNq+GpP+T8vX5EXWaV1D9gLWD/AEj+JWzDC04+J5RRRDz1D3m73OcekkrYUUtyMj7YO600ZPlD9VhWV6bOhlUlHGUm+JdZGAixFweQrlptO6Pok4QqRcZK64MwMTxBsLLC2a3gt/iraVJ1Hd6HNzHMKeBpbMbbXcvPkVGaQuJcTcnaV0kklZHgKlSVSTnJ3b3sltFpLSOHO35ELXxS9lM7/Ruoo4mUeK+zLM+MHxgDbbtWgm1oeyqUoVF7avz4kXjeKCMZGnwz/wC3/utihR2ntPQ4mcZqsPF0qb9t/QqjiugeHbuWA40xsAay+fLbdu5z0rT6huo29D1DzqlSwUaVLt2ty4v0sR2CYq+lqIqiI+HE9rxflsdoPQRcHrW4eXOjItJ8FxqnbFUvjB2OMUrsj2OttLHbL794PKhB7oJsBwVj3xSxMc4bbPMkjuYAAk2v6kBobWDpU7Eax85GVniRt5mN3X/1HeUBs3VDrOpo6ZlFXvEfB3bHI4HI5pJIa4geCRci52WsgLQNGNHmyirL4CQc4Lqi7ARuOUutsUJJaApGuTWXDVRfgqJ2eMm8stiAcp2NZfeL7Sd2wWUg02UB01q+0woq3D44KmaMSsa1kjJHBpPB2yuF948EHZzICn6+9M4Jo4qKllbJZ5fKWG7RlFmNuNhNySbbrBAaVQFy1P8AHFH57/tSIDqxVEnOHdC8aM9Gj+uVWLQgj9AdHonR/ipgHbSGNPity73G+w7fkuTj8VNT6qHx+PcYyZK1ekud5ZTgFjdhkO49DBy9aojhdlbVTXh6nYyfKXi6m3PsL6+HqVjHcT4MZWm7z+nT1rdw9Had3oejznM1hafU0u0//lf3QqbjddE8M3fez8QBAemutuQlNp3RPQY3M8BkcWZ58kEk9TQFqSw9OPtSdkeifSSv1eyora4+dj1LoliL7vdSzm+3a3b7N6rWY4NeyqiODUnUqScpu78SNp8DqXvMbKeYvG9vBuuOvZs9a2J4qhCO3KatxuV2Znu0YxCC0hpZxblDSflfYqI4/CVfZVRfMtpVKlGanDc0fCbH5SLWa084G3/srlhoJ3OxU6Q4qUNlWT4oi2hzzYXLieskn5lX7kt+hw5Scnd72TEeiFe5uYUk9ulhB9h2rTlmOEi7OovmRssiqqlfG7LIxzHDkcCD7CtuE4zW1F3XgQfEBZAlcP0brJhmippXN5w0gHqJ2FatXG4ek7Tmk+ZKi2eq7RmshGaWmma3yspIHWRsCUsdhqrtCab5hxaIhy2iD609O95DWNc5x3BoJPsCxlKMFtSdkCXfohXhuY0k9vMN/ZvWosywjez1i+ZOyyGmic0lrgQRvBFiOsHctxNNXTuiDIoMMmnJEEUkhG0hjS63XbcsKtanSSdSSV+O4JXPFbRyROySxvjdYHK9pabHlseRTTqQqR2oNNeAPeH4ZPOSIIZJMu05Gl1r7r23bljVr0qSvUklzdhY+dbRSROySsexw25XtIO3dsKyp1IVI7UHdcUC1an+OKPz3/akWYOrFUSc4d0Lxoz0aP65VbHQgydAsPbUYY6F5cA57xdpsRe36dC8zmdeVDGdZHgtSLq+8yKnQuSNlqZzHWGwPu0+s2IKrhmsJSvVTXLeeroZ/QpUNiFNppbuHqUqu0GxG5c6HOTvLXNP8V16ebYO1lK3NM81UnOpJzm7tmC7RCuG+ll9Qv8AJXxzLCP/ADEV7LLDpBq+eI2zUrSfBBdEfGBtty337eTetDDZvBycKr5Pu+JBQ3NtsO9dsHlAbp1RYRGykFRlBklc4ZuUBrrADm2gleMz/FTlX6m+6Nt3PeXU1uuYsmtJoqDF+HPBh+TNm2+Na9rK6PR5ujt7e+17fDQjrC741iTaeCWoLbhjc1hvdzBcPDUJV6saSer+Rm3ZXKtofrB/GVHAOhyEtJaQ6/i8h2DkuurmGS/haXWqV/hb1MYzu7FW1wYOyKaOaNoHChweBuLmkbesg/oup0fxM6lKVOW/Z05f8mNRbywap9HI44BVPaDJJfKT+w0G2zmJ33XPz7GynV6iL3LXxf8AsTCO65+YjrUhjmdGyF72NJaXhwBNt5aFNLo7UnTUpSSb7rB1Ca0qwiHEaPOwAuLOEifbbuvY9B2grSwOJq4HE7EtL2kv78zKSUkap1e4M2prWMkF2Nu9w58lrA9F7L1ea4l4fDOUNXuT595VFXZtTTTS9uHiNrYs7n3sL2DQ3/8AV5XLcseOcpOVku/xLJSsfPQnTQV7pI3RZHNANr3DgdiyzPKnglGaldP7iM7mttZuDMpqw8GLMkbwgaNzSScwHRf5r0mTYqVfDLb1W70K5qzNlaDYHFRUYleAJHM4SR/KBa4aOYAW9a81mmLqYvE9XHROyXn8SyKSVyIp9a8BlDXQPbGTbOSLjpLeb1rcn0cqRhtKacuBHWGTrR0djmpnVLABLEMxcP2m7Lg89t4PWqskxs6VdUZP2ZbuTJmt1yE1I+PVebH83rd6Sv2aXN+RjT7yH1v8Yf8ASj/3LbyD3T4sipqTOpHxqvqi+ci0+kulP/V5GVMhNbZ/8Qd+7j+RW7kHua5sxqanjU/xxR+e/wC1Iu0YHViqJOcO6F40Z6NH9cqtjoQetVWIt4F8V/Ca/N6nf9wvP5xQbmp+FjCRsFkl156dOwTPsHKhxM1I9hyrcTNMbFG9E7it6U6F09YC7+zm5Ht5fPH7XXvXUwOa1sN7OseHoGkzUWkOjNTSOtKzwb+DI3ax3r5Oor12Fx1HEq9N7+HejBqxuDVZxbB1yfdevHZ577P4fZF0NDSdR/eHfvT9a9tD9BcvIo7zeen3FtR+7HzavC5V77DmXy7Jq7VTxjH5sn0r1Ge+5y5r7ldPtFn12eLTdb/k1c3o3rU+HmZVC26H8WQW/wAj+BXJzBfnp/yMo9k58K+gFBv/AFf8WwX8g/Ny8Bmvvs+ZfDsmv9VXGUnmSfUF6DPfco819jCnqZWuz+1p/Mf9QVXRr9OpzQqHw1L/AN6l/df7gs+kf6EefkKep61y/wB7g/dj6io6O+7z5+Qqamz6wQ/hSKiwi4MZ73tlyi+7avM0nV/ELqu1fdzLHpvKUKXR3y4vekXa6zOeD+SMPYJLSDSrDzRTxRVMZJgfGxozXPgENG7qWthMuxixUKk4PtJt7uJLkrWK5qR8eq82P5vXR6S9mnzfkY0+8iNb/GH/AEo/9y28g90+LIqakzqQ8ar6ov8A5Fp9JdKX+ryJpkJrc4xd+7j+RW7kHua5sipqeNT/ABxR+e/7Ui7RgdWKok5w7objNno0f1yqxaEGvcJxKSnkEkZ2jeORw5QehYVaUasXGRDVza2j2lMU4GV2V/KwnaOrnC89icDKm9N3EqaaLLDWArmToEpmUyYLXlSaMrn0D1U4GSZ+5ljsE7R8qvgyxwlDCyxzZ7Zbct77LLOmpKScNe62ouedFvw/4dv4W3A5n5bXt45zWvyZsyxx/W9c+u7W6/y3fQvhoc+1A/4h370/WvoMP0Vy8ijvN6afD/w2o/dj5tXhcqX52HP1L5dk1dqq4xj82T6V6jPV+TlzX3KqfaLNrs8Wm65Pk1czo1rU+BnUJPVTjzJaYUziBJFcAE7XNN7Ec9txWtnuDlTr9clul9GTB7rEbiWqjPM50VQGRudfKWXLb7wLGx6Ny2aXSPZpqM4XkvHX6epDplpx/EIcOocrSBlZwcTb7XG1h/MlcvC0KmPxW0+93k+Bk3so11qgN65x/wCU/wCbV6LpAvyqtxXmV09TP12D+up/Mf8AUFr9G/06nNE1DH1L/wB6l/df7gs+kf6EefkKep+66P7zD+6/3FT0c3UJc/IVNS8aHYvFX0QjeQXhnBysvt3Wv1EbfWuJmGGqYPFbcdL3izOLuioz6o5MxyVTC3kzMN/XY2uutHpJC3tU9/Mw6sjdINW76WmfO6pa7JbwQwi9zbfm2b+ZbOEzyOJrRpKFr99yHCyuYuq/G2U1XaR2VkrchJ2AG4LSejYR61bnWElXw94K7i7+pEHZl/070H/HPZLFI1kgblOYEhwBJG7cRcrgZXm34SLpzV09+4slC571f6ISUHDGSRj+EDAMoOzJm5/OVebZnDGbGymrX18bExjYoGtzjF37uP5FegyD3Nc2V1NTxqf44o/Pf9qRdowOrFUSc4d0Nxmz0aP65VYtCDWCkHpkhBBBII3EI1fUFlwvTSoi2SWkb07He0b/AFrSq4GnPetxg4IteHad07tji6M/6hs9oXPqZZNabzHZaLLRYwyQZmPDhzg3XPqYRxdmiL2MfGdLYaZvhuu7kY3xj/IKaOXTrPdpxMldmsdJdLairNnOyRckbd3/AKj+0V38LgKWHV0rviZpGPh2lVbBGIoah7GC9mi1hc3O8c5U1svw1abnUgm+JkpNESZDfNfbe9+lbndYgmK3SytljMUtQ9zCAC02sQPUtOnl+GpzU4QSZLk2R2HYhLA8SQvLHi9nDft371sVaUKsdiauiDIxfHqmpy/iJXSZb5b22X37gq6GEo0L9VG1yW2zCp6h7HB7HFrhtBabEesK6cYzi4yV0QWGPT3EgLCqdbpawn2lt1z3lGCbu6f39TLaZCYjiU07s80jpHc7jf2cy3qVGnRjs01ZGL3n7heKTU7+EgkLH2IuLbjybVFehTrx2aiuiU7HvFsZqKktdUSukLRYE22A9QWNDDUqCtSjZBu5+YVi89M4vp5HRuIsSLbR61NfD068dmoroJ2GK4vPUuD6iR0jgLAm2wc2xKGHpUI7NONkG7nxoq2SFwfE9zHDlabFZ1KcKkdmauvEgsDdYGJAW/FH1sjJ9pbdaDyfBf8Aj+r9TLbZH4npRWVDSyaoe9p3t2AG3QAFfRwGHovapwSZDbZj4LhUlTK2GK2d17XNhsFztVuIxEKFN1J6IJXdi90eEY/TtyRSHKNwzscB1ZwbLg1MTlNd7U1v5NfYzSmi56EwYiBI7EZMxOUMb4Pg2zZj4IAF7j2LjZnPBPZjhVxu9/hbUzjfvNXaz6tsmIy5doYGMvzlrRf9Tb1L1GSUnTwcb99382VTe8+up/jij89/2pF1TE6sVRJzh3Q3GbPRo/rlVi0INYKQEAQBASdDjksURjjIbc3J5fUqp0ITltSMXFN7yPkeSSSSSd5O8q21tDI8IAgCAIAgCAIAgCAIAgCAIAgCAIDMwrEpKeRssLsr27ja+/oKrrUYVoOE1dMJ2LfFrVrhvbTu6Sxw+TwuPLo9hG9zkvj6oz6xnwxDWZXStLQYowdl42kO29LnGyso5FhKbUt8uf8AwHNspr3XJJ23512ORgXDU/xxR+e/7UiA6sVRJzh3Q3GbPRo/rlVi0INYKQEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEBctT/ABxR+e/7UiA6sVRJzh3Q3GbPRo/rlVi0INYKQEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEBctT/HFH57/tSIDqxVEnOHdDcZs9Gj+uVWLQg1gpAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQFy1P8cUfnv8AtSIDqxVEnOHdDcZs9Gj+uVWLQg1gpAQBAEAQBAEAQBAEAQBAEAQBAe44y4gAEkkAAC5JO4AICzxaucWc0OFDPYi4uAD7CboCJwzRyrqM/wCHpppchs/IwnKeY23HYgI2RhaSCCCCQQd4I3goDygCAIAgCAIAgLlqf44o/Pf9qRAdWKok5w7objNno0f1yqxaEGsFICAIAgCAIAgCAIAgCAIAgCAIC7amqZr8Xpg8AgFzhfnaxxafUbFAbo0/gx91SP6LkYyAMbe/BXLrm/jtJtayAgu54zcHXZ/H4Zubrs6+7pugNH4jC59VKxjS5zpntaBvJLyAAOU3QFwptTeLPYH8DG24vldIA72ciAp2NYPPSymGpidHINuV3MdxHODzoCQ0W0NrMQLvwkJc1tg55NmAnkLjy9AQEppBqvxOkjMssIcxu1xjcHZRzkb7dKAitFNEKrEHPbSMa4xgF2ZwbYOJtv37igLH3mcX/wAmL4rUBUdIsBnop3U9S0NkaGkgEEWcLgghAT2p/jij89/2pEB1YqiTnDuhuM2ejR/XKrFoQawUgIAgCAIAgCAIAgCAIAgCAIAgL3qS44p+qT7bkBa9d2lVbTYiI6epljZwMbsrHWFy59z17AgJfub3EwVhO0mRhJ57tKAhdR+GMkxarlcAXQ5yy/IXyEX67A+1AYmnus/EYsTmbBNkihfkbHlBa7La+e+03N+VAWrXxSsnwynrMoDw6Ox5bStuW9V7IDPxivdhOjsLqWzZDHCM1v2pgC99ufabXQEbqO02q6yWemrJOFtHwjXOAuPCDXNNthHhD9UBrTH6+fC8SrIqCZ0LeEI8G3i+MBtG4ZtiA3Hq4qqyGhkxDF6qQsLM7GPtZrAL5iALlztlhzdaA0PpxpI7EK2Wpc3KHWaxvM1os0HpttPSSgJPU/xxR+e/7UiA6sVRJzh3Q3GbPRo/rlVi0INYKQEAQBAEAQBAEAQBAEAQBAEAQF71JccU/VJ9tyAk+6E40Ho8f1SIC3dzZ/YVn7xn0lAQOpfGY4MWqYpHBvDl7WkmwLmyEgdZ2oDK031RV1RiMssBjMMz8+ZzrFma2a7d5sb7t6AltfeJRQ0FPQtcDJdhtyhsTSA4jkuf4oCUloxjOj8UVO9olbHELE7A+EAFrvJvbf0oDF1PaBz4a+eqrXMjvHwYGYEBocHOc524eKEBU9EsBjxnGqmqdb8NHJnLT/ibxGOgHLmPRs5UBeNbGjGKYhkp6QRMpmWcQZMpkdyXaBsa3kHPt5AgNB6U6OT0E5p6nJwga13gG4s7dtQE1qf44o/Pf9qRAdWKok5y7odhGJxm2w00dumz5VYtCDVykBAEAQBAEAQBAEAQBAEAQBAEBmYTic1NK2ankMcjb2c3eLix39CA+mNY1UVcnC1MrpJLBuZ1r2F7DYOkoDJwLSmsow5tJUPiDyC4NttI3bwgIp07i4vzHMTmvy3ve/XdAWmn1lYsxgY2ulygWFwwn3nNJ/VAVuvr5ZnmSaR0j3b3ONyfWUBmYFpFV0bi6lnfETvynYbc4Ow+xAZuNac4jVM4Ooq5HsO9vgtB6wwC/rQGHgWklXRlxpJ3xF9g7Lbbbde4QEx3zMX/AD0vsb2UBAYzjE9VKZqmV0khAbmda9huGxAWbU5GTjFJYbnSH2RSXQHVWVVElL1naBNxOFuVwjnjvwbyNhB3tdy2PPyFWIg0XU6p8Ya4t/Bl1v2myRkHpHhX9oCkHy71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20A71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20A71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20A71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20A71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20A71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20A71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20A71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20B6j1VYwTb8E4dckQHtL0BuXVRq1/o7NPUOa+peMoDfFjad4B5XHlKi4NkZVGyD9Klg+SrJP1AFACAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCA/W8qkHsLNEH6sgf/9k=', false, 'MOBILE_MONEY', 'Flooz', '2022-01-15 18:04:18.706138', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.706138', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FLOOZ');
+      INSERT INTO public.billing_payment_method (id, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('0f9ceffe-19fa-4e75-91f5-7d9248bdca62', NULL, true, NULL, '10dfea50-8ce4-4be2-9c4b-aa8b4daaceb3', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOIAAADfCAMAAADcKv+WAAAAyVBMVEUEBwf////1giAAAAAAAAbu8/rU2d/1+v92eXwwMzTCx8z5hCAABQcAAwPZdB39hiHFaRszHgvGx8fa29uyXxkVFxdhYmLtfh9SLA3nex9lNg+/ZhpvPRHxgCDScByWURZBJQ14QRKJShRbMg/n5+cXDgjo7fS1YRkODgmpWxgkFgpMKg05IQw9Pj6Njo51QBJxcnKARRMmKCiYmZknGArx8vK1trZEJgydVRZgNA8vHAq+v7+CholSVVdOUFMdICGeo6enqKjN0teIO9n/AAAOFklEQVR4nO2dC1viOBSGKwmiJrboMNaCFITBcnMUxxVwdFz9/z9qz0nL1TZNLzhLnn7PsztCr2+/5ORCkhrldVX00AZT2VjjO7h5fznSQD+fypUwxMrN+y3RRhcnN58QD97/EHJqaCKE/KhsIh7eE/K37ytXnRLyax2xcvhHHwcXIuS+skI8vNXLQl+n5P5mifiqIyEyHh0EiC96EmJaPfERTwxdEQ3y5wYRK5omUyHybwUQD/ULpiuRt4OyUfmpsYnAeFI2bi70RnypGIfHeiPel40PfeMpCmKqcaJztAHE40NA/Nt3sVMViDqoQNRBBaIOKhB1UIGogwpEHVQg6qACUQcViDqoQNRBBaIOKhB1UIGogwpEHVQg6qD9ReQ0EI/ZcV8ROR3OB1XH9K7GlMp33VNESlumxVAWG4zkRu4nIn2uMlYKxOwrKeNeItKRswRExlJHllb3EZGOzHVCZLyUMO4h4paHgtEcRifV/UP85KFgnETbuHeIIR4iYiM64iRFPE0xnUA6cInzuKJ7Q3Qa4iEy9vNBFPebWBwPi+CDyon4nypmuIcg6zkypSZAJOTh5Vsq/b4PhQS0K8913WpnGFdDWRzRDvcQENs5IJLXp4P0en/7dBHam5WCGorlxdRQgiPqER4C4ll2RHL0TwbCg4OP7RGhtF21VlnJkddQ/CPmkYQlq5c5L5JfmQBRmzNB6Iht1FBYJ46RXpUiCXOIqOQ2M+HBx3papY/uVg2lOZLnR9qN9rDEJFU4NUTy8CM74sH7OuLA2r5LR2qjzEOs3WRGPMqB8OBgFVY5DbnRa4mNUg9L1lXmOio5zwVxNaeHdkIqYV60jfSqKSFkrcwtjVOSC+HB7xViIwTRjCy+adeWeTiLDqeqiOR7Pojni7oc59WwW44KOHIPSzGxWA3x4UsQrYhWX4yHcaXN/8nFcEROJzLCOA+/OC+mQeT0jsk8nOTUyZhTRE2ByGlH4qCCh8qIL38JET2UACp4qIz49u2vIObgoXod9eJvIMZ5qESo3tL4+fWIEEuze6iOeJpHNTUZotxDxhRamIkQgfHPebZGcUJEuYeseafa4ZOo7+b11+/zKKnEoySI4OF2cyuVh4l74E6/h6v/plJyJkDkdJaPh4n7USO7UZXqBuqIUFrIPCype5hTbzgx1Go/yoictmSRBhrPCfqX80BU9FAdMU8Pc0Ek/LcaoSpirh7mgUgelCt3aohAmKOHOSAmIFRDzNnD7IhJCJUQYzx0ZL8H7wQxWRNEAZHKPbTniQkzIpLjRI2seETay9vDjIjke7JmpAJiLW8PsyEm9FAB0fBy9zATIukn7QqIQxwNZB42U3mYBTGxh7GIzN2BhxkQY/JhaNMyrjd8Fx6mRySv0vbx+WsaxF14mBqR3Ep/cPz4HtqdlRqROd3UhCkR4zwk4T12aRGZGz1YYUeIcR4+5IvInGkGwlSI5FVKCB5G9LumQ2TuOAthGsQYD88fSFTXcipE5kSPGtoRooKHeSIyNyNhcsQYD9/9BddyQ8zsYXLEGA+fgkEZeSFm9zAxIrlQ8TA3ROZkizQpEMm9tDx8Wg6syQeRuZlKizSIMT/Bva8WPswF0XKHlIdqZ4jKHuaDyKo9GqnddBXHePi0vnhlLoiNWpQGc6o4SDcRYgIPc0qoLFpNZyIZ2JcSMYmHudZuIvAtU7V5pfxDuNzDX1tjv3eOiAWKYiM5n+EMP7dHt38BYok1H5UYFUdPJfPwaxAhHikVHyqIcUMZPnn4RYilklJSVUA8jRk79dnDr0Jkg3wQU3j4ZS42lcqCOMQ0Hn4ZopXHALFUHn4dYvRkMGXEdB7uE2JKD6P6BlaINB9Elj0vxhAeRb7wh7x9hHq+2C79oVSdsJo5osbUae4lky9D51itZhTRYS6IsskrSogxv8wcyaaXho2Y/712nbCJGokJoyd2KCNKZ7vJPDTC0viP9alvtC2bIKSIqFYPlyDKh31JPRRHbw842nxrB61bGRktpbqNHFE2ASXGQzycvK8f8M/2e0lkEy5VLFQdVCxFlMxZjPPQZ1xrn5x/flUXHVUtScNeLstUHkQlQ/yTwUOfkVycf/vx48e3p+Pw6dJnNddMI7fRVe+hSoWo4qHQKSFvx8fHkZPeKVCmUU+9cypVXoRcleAtKiR6Vj+KR/cjSpTXSEbyPbxzf9/eZ5S4XPwUGf/3kiLehvTY7B1hTB310xSb/fMwDpHIayj7oZjG1On7OuC3fSSMa/UT8rJqbTw97COhQt+NcfH7B9ZQfj3s6Rtv4zsZg6I7bvWh/68UO/z31EChvVteK7kKRB1UIOqgAlEHFYg6qEDUQQWiDioQdVCBqINiEXmanxGUFJx541P+V4lHpPRy0qrNJvV+DmPtN8SHl6hglkLw6XEHjDGIdNhw8HdOq1S9Jvlens5tx3HsYFwJ7YhP9bwfpBGDyOl1E5fSE/9ZNen6lYlF6zhzmDkjf9UJ8au4dJ3TtJIi0pHNgK3pmjj0QG1opLJ8xGAJXjp1Sn8DkQ7h0TKnjr/l4oR7q4sLRKwWM19EIrEvfsXX4kfw9/KLjdiyjuhi4qAztkJcj0PL6y2PXW7kGzule00BLkWL85Q53rsLf1c5b19eTim9bnTwCt2Z53mdNt7EGcQKSie1xmwqrgZ/e43ZGR1BQEEEOm01vM547U4CxBI7g8P7jSUinnfgNVpneP90itczOg0PPvvnHbdg4xiYnruXl2LSGIWLd1Mtqs37VbZcI1esLG/PaYMx99FhVsOgV4547wpjVbibFvxRN8VgClyP19/Imi3YtUY5bVf9gRa11eyKBaIFV6BTILQFIqd1298XJ5/Ck2XmRHwhBqHQaXCixiPekUgCmI+ZnWoNfz7EO1gEdRx7aHUQ0YHLWg3abcIXDlCVrCoVK7g4loV51oKUfSkysSUCSg3SuXgaFiaEpY8CEc9lUrEQU3PAEBFXlg72NSG9wFWbJXFe1oQnOTWDjVajJ7Zh3mkzHGaUBpG28Q6XWWAgLMUExZqmOTA8uNA152cYCvv+yESvfmXCXi5F/0vV0XjW9BEBxG6dTRu+ZytE5s5E2qBw59WJQHyGZ2Z32iNPnAgxWHM27zjiAfeQqtWeeuLT3BKJDPNxU1LayBBHiLjYJjKmJxCb133Khw3TdDGfzxaI4BD1Uw+9xDDS9zcC4hWQTghkH0B1F0nVR8Q9Z3Rqw83eWYBIZvBtB/YVqaZNELFDKbmGr2ukC7sEG5lDaRNCBZTW8MGUTGdQR0SIASLCk8P5dT2DGr3n6TXcfoCIsQKv59Jryw+O9MxGxAGmKIhHI3wc8w1Ego+Ew9H2o38Q+GniLH5aR3hEtIaYGPFEBI536sGJ2BTPa53Rro2WRhJKEccioQaPh3pBQl0W1uOZVzWbYrCej3hJxYjoABGDHTec4LlgfsIsxazrTUTIxNYIzmqSCSIagChmmIhsVxWIEFLoGXyqEXftRGwC9SN8CpCPLdm8G2m4cVYPnQ+x1JggotkTZeIdxDnLdsxlXtxCHC0ROSI6gewtxEs4sOGUrGsf8RER8bEKqBXi2EFEZ/1EE9rHhE8XR6RBxCWEgiXZOQQ6MTsbEQ1xB1iItLrPa3lxhXjnBwK4MxtdhARgj9uo8bi9eJeQjygiCJYYYzpZJNQqFgCY/pi3hYhZsBucaDz0AzGuMCodXSwt+utNsXg86swWuCtEP5yBvBDES1sM+aV9T4QbDHmXuG9vPl+W0QGiX69hHvcRMS3aOG0Pw5t1t4UISEycaNjtzvtQIxHFaczoYhki2IjVtkanflXDqlxzSPkSEW7QwigJPn1C5Jg0mTmbYdkBiFBKsuojpY8NyzK3XKRjjFdQrgcu4qOrQg0HgmyJ9ekGIu6LIRmstywbawIe80teCWFMNXyIr5IBC7C9IV5cskIc4QOczVuihdDbQoQAyEQJHpSLuOCSU61iBaC+WS6KCgyce7hAFE/Habi2iG5biKIQEifyh75j9pG+1yYW0aDPNUvcK1RVcEbkCpEbNQyPENrg2qURVuCsNRdxOC3IrTsCEXK1r9JsvQKHNRsDYhPGCwMQGdZu2o1gIC7UEjhWGtYQOR8sNooxxVQEQTPTGv6Uz6s2yplgeufcsx3XEPXhXsuB7836HUS3DrZo7ZF4BrZTxaq0MYJ8N6Si0OC8X3fxLG53VUTTedNxoEFMx6aDlRMI0f6//YmJ+za6mBLhdE1RaLiODY05yuvifty6j0X9qoGMMLZjA1ss7dGoH7Rb+KrdAn8+t/siFhFsNJFFCwf+eG4NBh3cMsKSSyxDSPm4vdnmwR1FQ4Eu/l2eot8eB/vid3xzI2+P+0FjjmB9KW41HIUeuMhXXfGoVhoUohZr3vX7Y0i29nJJUPXOJ+m+i43QwjDN0nrNPly76WTE/FWyTBeysTWTP+P04tTCIFGKW2hkN4j4goiSaPTYLWMXHYf+RbCC6cROKtpRVzGnxqTmeYPr3k66Rn3R0bw+ih8Iv7PecL6rHuY1qV1glx3+CVc02ZWK3zR0UIGogwpEHVQg6qACUQcViDqoQNRBBaIOKhB1UIGogwpEHYSIH/s8jTZe5PbQONzPyeyqIhc3xs0fvRFfKkblSG/Ep7JR1jreEFIGxMqbxozkqIKIT/u68kK8yMMhuli+2cslUJREfpYFYvnQ0JSRvFYCxMqTnsU/FPvlABEY+/oxngJhZYlYrpzs63o2kSLk1ScMEMuVm6O9XdImTIQ8/OsDLhFBJxdR78feR70cLsFWiODkv0evt8d7r9uLl6dypRyGCJCVm0MNdFOprFP9B0KAoDCjKJkfAAAAAElFTkSuQmCC', false, 'MOBILE_MONEY', 'Orange Money', '2022-01-15 18:04:18.708824', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.708824', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'OM');
+      INSERT INTO public.billing_payment_method (id, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('8e64bb40-16f2-4f48-a115-08b3578c20b1', NULL, true, NULL, '41dcaa5b-5300-4120-b758-d367c2d720ff', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAR0AAACxCAMAAADOHZloAAAA5FBMVEX///8AAIDUqgAAAHzq6vZvb7chIY2KisX8/P/y8vnSpgDUqRpVVaT068WFhbrw4qXatzwWFofT0+r589oAAHja2u3Bwd5gYKLev2A3N5KkpMsFBYjIyOJ/f7NXV6AAAHOTk8FsbKpCQpYdHZG1tdXi4vCamsP19fqwsNZ5ebLv7/nR0ebHx+CMjL4YGH/Dw+FMTJ4oKJBHR6AsLJs6Opujo9RCQqQrK4xdXawYGJRBQZImJoe4uN51dblbW6oyMpxTU6mRkcoAAGb79+jy5bL59eD17MrfwVjjyXcwMIgVFX8+Ppd6fKGvAAAIvUlEQVR4nO2dfX+ixhaAYQcVel1b7KDXlxXMgiC+RJNsTZpkk3Tb3rub7/99CgrDGcTzu7eLRPs7T/4SeZvHmTNnZtAoNeIgDWWgMqKYwUBRzcZLg9jn5VGtK2ytK0QRnhnZqWtvfRsnSpvsIJAdDLKDQXYwJDu6bxAxfpEdy2kRER/6WoGdzoa/dXJ6Ethdq8hOj6uEqvIDdthb39hJQHYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdjAN2vtpv/bW6k6D4u32zcZOIWLW8AjuKTuxQiuwQMmQH47Tt6H7EG/78zcnaMaxhJ+hPIvru3Arf5ibKtxNqoYyR38MDGIo1TGi3Z7O2t60pfttddF9NdfuTWyrbjFqBVXQtbSZoW37RHt9H+Xbc8QeZVr5pNMaCqaUvXi+2rEYxQbSz0XFGJuOcJbkpY5zVu31v/1qLUcZ4VmIhEsq3Y7WYlFPag7ydp/R9zheGP+bi5yW4PbLiE7yqLJ+0M252g3ztsC6yY+21W2IhEo4Qd8K+VDb+MWcnWKZvs66neF2wM1sovjviheMZxu8XuSu1TPB2/TzsKH5fBeXL2/EuhJyLTuTqa7Yv63X0fm+v3qTYz/J1pGEhM4NSC7HlKH2WNgW/NpK3MxVyTCd6ZwGrRzd0N4d/qMRuSCcKx1AjU8/FjjLcZDeesxPcCzvjqJ+2YMP65nivUA6zY0RD4w/SRfpL2U6/5EIox7ITtrJCyna8UdauhgqUFW359dIBcqJ4flWb1p6vVZvvyi/1WtYo1wIn5aeNx7FjOIfqTkvIWTrRS30BQ0d3VgdWVUfzowGhb8ycGx5t53fwRNGRsh22KD/hqdjOg4jBvBtvbsMKcP/iZnKY2s4O84Mbm9nP0I6bn6ljrb2087upwM5d9plq3bT4rLdNfl0TNqz2oy1e2Y/yGRvstwawIwX+3eHT8sdDx7fDBlm4WIiufvkpfu1LDasW3mRFtp3cOR/qMOxKSUNipyCZ/k6qsCPO/iBaA6/trt4ENWDZ19bAzlU+yHpgKCodmJxyfN52tHFaJN7bldQdwFQw9ICdqPIc7oN8Zz9jFFPlJVKhHX2StgbGL7dbYMcfVyfvSerQGwfDbEdoBPGt2T60+9/mOHb8IjtDkemlSe/sAtj49qBoTTkX/Dwr7qRFJWRXa3GhXf5ULkeyAwaiqZ2sl+GvSZtxwUfPNr5iLORoYn+cFN2Znh7HWOdZHMF652JHB11KYifbxM2kCWgfYJiJe/C5KccTzrrz/eZlrZLjeFf5nNnZdEouRYV2RCti3En2mt3AMBN/8lIg2u28meS7Ij8dbjBzptQyO/XztROKemLXkmCiw4bFn7bbrNFekse6HTn6iArGo7HDY2ZnUP4ET0V2MhN8k3a8UrqbBGp9PspP7zDem8BJdyPNt/lrdKaXzI56tnYs0a6yaRgLZDeMJc702dTMzw3y9QLoCRJ90Zmi4P4J2Cl/gqcaO37WX03TKKsHQIJ9I47V3K6a88O+ZXq8NFjxcXzXD9nI7AhTGFXY8bKum69EQqvVYMP6BA723DGT/bClmHFvJDqiIByvBF6C+ueUPoVRhZ3QSD9vNsj6FesOJDuqdAe61rllUnjmvcTqUOTbZjde8mkChYvSpzCqsOOnn7fKHSPbBVad5/wJtKAO2kx0ZDJ7c5Vt3S7USLuUvmJagZ2PgWhXo2ygGDZB6e39gKp7V1APX2/Tnk+SMhle/gTP8e2od+lYiMN8zQLDcz4o+tT9J6CCqZ14lXSA/LT6EaYwKrAjIgUDnYo+gVWnpisFJdOgC9aPYm4NqTrHmMKowk7RZ+vDUQSfK8rT4/5pGkAGn/jKUMQZsBKd7dE8Yzu8dwn2sGCx6lG1uPntea95DWHdcXVFTP8wdbvSPojJTnNR+nMGldmRV+N0WC3sVmTnF9uu52MzXKIYWGLUwNRpO8bTNM3I4jS7OWM7Uo+if4RrM3GpfuEq51euAfJd/QpMM38OvXSBNX44QZAly2w9L7kYldlhK2luCrYZfhU3qet4C2c3i5lm7Bb5vFuY27h6mluze1jHgB3zXO2wpbzK/ZiLt4pyt1sN5rZ6/bnRDwLndgD36YYdUXWmcMQwBFMYpU/wVGSHSyVS9IEcUZTUzlZQhG1zG1avzcxIV03Zrwdq4RGmMKqxw3Kd7SUs+e326liex9aB7yyTF98c6VTnb0eOFBG3MAvub6vV9eFEj907fnuVVp2RfLMwNeiXPYVxNDsQO/dgpQ8X+da7fji4L34gLm5Wk1Cfpq/u5Yd4FA+M6CZlT2EcbcWG7x6mjf/4Knf+F/DYpZ12z/uTXrsis2ZgKMHX5PFJu5ebpmjbPMX+UPYg/Vh1Z6CKNJbVL+V3retlXWCKPMjqj0yem/XirLeY6Yo2NtP9X3P3Oqz3UjatsstxpGfdPTcm6G/JB0uvAwHrnZa7aNZVURc4q48m87g+hHOxe359K5wPh/Pt33BunUfcSZG+zvO/EFrzYDEerXqbi1W31Z8f4wH2/4PT+56EbmieZc0sywvf/N8nn56dU4LsYEh2vvz+IxHz/kuBnfc//YuI+ffPhXZ+eEe8e/cD2UEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA7GQTtETKGdP//zExHz3z8K7Hz58z0Rk1Qd+sY1CtnBIDsYZAeD7GBs7azL/89T/wysbd2xQo3YJ7yM7KhqnSjEVGM7jChGrf8FcNIlqAisfssAAAAASUVORK5CYII=', false, 'BANK', 'Carte Visa', '2022-01-15 18:04:18.711232', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.711232', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'VISA_CARD');
+      INSERT INTO public.billing_payment_method (id, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('6c868d94-65fa-46f1-8f2d-ca1444d7dfbb', NULL, true, NULL, 'f59938b7-6f4d-47e5-adbe-7f4198f8d23f', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAP8AAADGCAMAAAAqo6adAAACMVBMVEX///8AAAAPC0j4tyngHwD9hhCqqqoXBnn///3//v8JAkZubm6WlpagoKDZ2dnq6u/v7++lo7YkIFYhISFMTEwAAD0AAHZ2dnZmZmYAAG0PCks3NWR5dar8ixw8PDz4+Pj+8ubLy8sAAEnFw9taWlrm5ub9lDEtLS23t7fY2NgAAEvCwsLmHwClpaWJiYkVAHl/f38pKSlSSZUUFBQ3Nzfrchnl4+/1qyUoHYMAAGf/uycAADkAAEEZGRlTU1MAADD6lTyBfqxBOY7mXRj4zGbiKwAAACZcPyvraBePAADX1uXXAADvsCjkOCJMVXJdYYOHjKjYXSbup5ius7343aCjdzX96+TPJAiRHAB2Ljrrgj0lDzd4hJYpHDP87tJpT0oJABr33rbkSR6wHAdpFBmwei8ZGz5LDizzxbAAI0MyQF5CTWTxnGhaFiHHkC6OcEv52IO+tp7fw504Lo3brleLAAlXUpWjnscXACK9hSn6x0/wj3xDMU96X2E7ACnfrqRSZ24sEDTmYFC6AAC7V0oiABoyABRkAACjcWrBlFiId4OWXSCHb1B0UWDRu7VmboEiACqae0qrRxiEGx7eQitLRF9iES0hAADjc1vp3cX0w4/8ynH71rFBL0OhGhv5tnxZMjD7plvTnSOvrsrSgSH1miVSFyU9Eip4VTM9JSpXOCiHXyyyiIuoMAB+GC2xWy2FbmG9all6O0zQtn5WLEfplIm0nG3pdUzti2KePDxRQFk/gTH6AAAXXUlEQVR4nO2di0NTV5rATyCNNyGQiwkBUuQmgUhCLgQB0SYIvoIVou2IQrtYOoqv2pZxxwqCVqfSzs50p4Mdbdeq0BbsKmWm09lut7P71+13zrnP5CY5AZMg4SuWm/v+fed7nXNPuAhlEt4XbO/rMr2o4my2B31CRsIM7MGKYt//85F9HUFrzvRBFz24pbm90vKiSmV7n5Ni1IVzavp2clBFsCpnvW08CVmaCU0lqyMIhL7Wl9e7KqyE64gGmPa1wJ5dbWuNGhtVeDuOBNm9IID93lKAGyq4CFgDdVnaNQj7dGy2tpeFBy/oyujW4PnOzeT3yRLMbNzN2Q3kBRe+0WRqT7PNCq5vL+jdFENqIbUZb3Ft0sCXJODjHUbrm0sDnyjAwMzbSwWfoAaT1wVLwfdlgY5dSL8mAJG/OPdSDBG6TU59l9Bl2rW5E59eAkkxEGr+zVz2pIpF5wFCmpSwicVlalQ/QEAsJevHUqXJAbzJ1FbMeymK1Jqc8mK7qauYd1IcCagGwDoysrmkQo4AwdLzfiwhk4kOb/al6xBtcummPWGh1HK/LG0mE/4VpL9KTwLUASpMFcW+kyKJk6R9g85giUi7qZm4/2Z4yrMWIZ7vK1X3JzWwAEpoSV7f0awKr67sCygHupr7NkPOwJnPjp1AL3bNw2M5NkCwVAeI8APCzVAydQFeX+p4eEDDL48KVcLyLnkH/Gy4YDeZR2k0WUAHqcV/n0YBkgN042VpyCBs2iQlkwvYjYZ9KzX8dKuPLEuWAurZV8jbzJtUAJERv9YBaHSopR/IMs/8KJ1FBJ43DiVCmvXPUXDpZzjs36xRAI76wj66TKy+kq4MV6ZIusfrIeNNQqiyztXY0tLoqqvU1SCBcG2fq7ul29XcEcb+Z21LvRYcYNF8tAR9ITk/+VL3xmLnk28gLX+bhh83dVBaJqOETpOpjxycIq40/LtMBkUGX9moPbZPGY/01WnXO+2kRksR8MWW5HWNHUSNdoPd5ZZk49c6AIZSAiIi/WaSFWtZrkAEx8uUEbbgruSDaUjl65LXVxjyu3D4TpU6/nnwozrdYao6wpQbafm7KmolqQsZnIo8WDUlG0CHfHRtuMpHT9WI/d0neZqpuzJU1dYiXVS5frd8qdoKXuV3ahKWk0dBekMuVSn07tjtn0wCksWuUWgFSf4dOv6U+jFJQnQ33WWUg8MaDfFynjHJdQf1uw6VXzdSo/A3I161xm55s5rFjM0yEz+v4W8UutUP5JZCev4Ar4jRVaRg6tSsapePpXkkbJL4FUOjA7JCs6R0tSUF5VKCll9bs8g8aqvlzq9zAG05EHbJdaCqcacsXUYDaVXybmo3O6QcSRVGm3mXgBSTpXoRKKHG/rt2ydeC0+n4g8o+sgGsi189nV7wHbYl8Wu0Y3gRSVQ/UdKrXF1X1TZ2VwRkO9DccWXzrr42w/hn4vX8VdotzPy16fj5faa0IqTj32Vg/5pUEk5ZpXY9BEGrF02wxOuN+CuQnl+zj4+d356O3yi9a66m5d9VFSBS1WZ0pnb1QPmJm+pP+gN4Zaa5U38Ola2Op9fy2X1J/KqPPB9+1RaTJZzE35KpTtUGUvnGapNXSOJL0VQKv67bmVd+3pmOH+XCr6tFaH0oqHWLvl5QVb4+/qrnwa/zb20GaE/enokf37lGkaRlBHWFnl+tutfHj54Lv089YR2v+Q6IfDImflxHBdSD+/LHr8Z/OQmvk59XuxdBTTmg3BoTvxPnOI31VOn59f5vSb0IO7+asGXadfJrCnxB45qWlM0Z+KViUeXHCd+q+r/+yYN6kaSSmoVfKZ2UUcr18vvkwzvUAQCTSZk3xcLfTWOeJghWaY9MmnLnU3fLmV/tTymb18uvlP3YSztSTs/Ajxs0rLt/AqD6g75eVpWcI7+zWQkxGo2ul19mJllLbhvVYxn4XXIxrjGAgLYm6NPvr0YZfWDIxq9InZZ03fxSN4X2RehwhWaiTHZ+rLOWPixqV5z0nevS3JlPWa8UxgI7f7ddf7Z180uFCq85m8a8svM3m4yE1+YqedpdwNQd1h0hn9OOv46Sjb/bXmnxpXzHb938tHaX+mhVGl0k8ac5WtMj0wpuWjXTBWV+sqjWGS71Ko1s9U+KrJ+fEMi9NhwNtf6q8DvDPll0lgA7dMljr20aW+B199ZObg6HGqeg7Rp2kxAQojpS1jYrlwoVgB9fwSkztZn0+Trb+KfuiaG2G0xWagbYdrlcqmJ4jVO7+lqkAwwu1SgUgN+uiUSYQLstG3/SQ1K1P91FnCiQPM7rkg62JK2H+zMc/y0Ef5V2coRLP0nYaIBAcyGc5LRPVjUGID08CmgfADRrMl5Qq1q7YDz+Ae2vFOhJafT58eddQkFLm8USTBk358NB/AXmsOGA6nOT4vMXV7b4t/i3+Lf4S1W2+Lf4t/i3+EtVtvi3+Lf4t/hLVbb4t/i3+Lf4S1W2+Lf4i8zPcQhZCyccp31MvCH4CypU4bIUn197NwUSjQFo+NN8ZyhPos4T54TqwsowMuRvN3jEmD/RTGNw2GI1mSSWspB+16y7xGpi2wVD/nTfGcqPKPO+OOTYbitjEY+HabdsZ7G9nJbf6SqMdK+BnxXek0VPmfgL9QfwLDnxA05vb01NdgPwtNpsfptts/B7yL9Y/8D1i+9juXh9IFYjrdXvCG1us8X6x1ZWvj/yzcpH/bFef1odvDD8mCA28PTc4tyoWcRiHp1bPPe0P4a3eHT79fb2r6zOLC0lEuXlexJLS5OrK2O9vZ6kHV8w/jJP7JN7c6OiWTQTieP/iea5e0/79Y1vi62cWkpEo+WqRBNL51dirUZR44Xhjz19Y0hm14poXnwaU8Fsse9nElp2RQWTR7AN5MovHGjIq7Dxe8rGrhnBSxq4dp3uBOFhZabcgJ5ooHzym1QFZObnOOGqO5+yjYnf0//+aDp6ooHRc/2EpX81YQwv2cCpMVuSD2Rpf044GNmWP4nszc4P4XzgWiZ6agIDHk9sZTJN2ysaWFrx59T+aAPw17w1kQUfa2Dio/4jRo6fJIlntlz4i97+nrKapxltX1HAXEbbV2W1V1sRbXT+sjI2fLN5NxM9+MBqjSYRbnB+T9n154yPLUB7gQ3N7ynrZ/B9LGe/w7KHTQHP/Iz8RY///deY6BUtsPEnFvyyC2xofk/sfUZwyUhENi+ITto8L0T7v8Xo/ENE8C82D4gqIWBD89cwWn98jyJsDgAe0MoU/4pa/3ieMlr/7ux1T7IBnPczxv+99fkUdwZ+T4w19uvIGA1ghYaAbPzWpvxKJv5PGJs/vvvVV3cr8l1OBpCNH+VZuLT8nppsvR5DGTrEaAAXbAzxj96gcnNEH/KDI3Ux9aGSDEOXyW/8Iy3p6NPwe8oujK4BHxSQUwrIbfwH4oEsVvIRWZGVfpLWYmChqWl5eblpsEcmBDciWzmuqUlINao07f+fCpKYduwDy9lDkpw9Cz9n42wOUL7kXwO/o+FgJ5GDy1K7ClPw6aqjiayfgnNxy50Q1/DP3oYmK7UYoYFshb0OHuDY+D2xRQ10Bv54uvbOFgnpUIAnp/E/TnA0AFrE7Z7Gn6wcmq53u+sPoAN4NAd+I0enW8qYkYi7voEawHJ9BI7Z1jM91TnFIbb278fmHz8GAr/xr7gx/yFD9ujslUez0XQqwOujtBeQ8/gn1+AGOODHz47RoDsCnMixF0O7m5BjG94aIbktss29TKy9J0JU4m4CK5lmtH+S/MVL4HAjsODF7mOggHgcOn4JqfLZUy6bQvSRF5zN6r2SBn+c4x5FZ2w52z+ijSnzAwlWRn0TaqoHwoibR1NEOQchs02DG0yR0Ag7SfyoZ5CzsvH3ngOvf5OHw71m8VN8Me8Q1siQ7A/YJY6NCN5D8WPwHxGwEfxvR/SkQKZRoCtRsIQkI4BVPwUQdzi6FFsb/yBBPECi+SBwuw8idKB+Gyw0gB7wtil6yp6GQRIjmySPqJ9WMkJ2/rJ7wP/fmF8wz1VjTxsZEu/f+PnnByTI33/w840Hx/7AofFfYQ+BT/exNdyH5fv7f6pCdGLD4Wj5oytXDmMNzGLy2fLo7KNE9McQ8iZoDbwW/nqV/6AbbN3BIdn8D2Dd1C8jdW4FpIhO9zaFn0sNf2naH8Lf0LzAQWYRrwXwmW6LIzi8ohEgvS3gE934DIE1/dN8fwSbyT/jx2Dh4Q1h+DTs7R22D38VPcPhQ7yz0XJO8D7iTpafgT3PNAe4cTCDt9fLj5bdhAr11JN456D87garmuchQrrxNrz+deOCypA/Bl2/uQ58Eq/4f5BTOXTjf3HAtVrRpaETEIhh08enkdXq/QWoyeV+if+V474SuJd5hK6cOn/+7vnDAewFcIro/ziQ1+tNnIFTIOuwQPiPrJOf44CLdGEo9hQi4YA2tFVuacdVsJEGbCDkGFZ+HP4nqhGCex2tRj6wsTvHgZqHFhdGeeJIlyawX4wfuo3zEnA9Hv0U9MH55sEroiTGf+6T2mH2Rx40N/6TQMOPFZ2M0gSwZv/HT25I8ANjV8yftDVWQIMDyYY+VQ+aGcQGgI9h5h8bFcVrwxw6LXiPBtBpaPb45Xe33+2fB9YPgenT2DtzR8OIC//9joDGf+zH0KAPOEE1aO0KCXrRH09fLot9AdHgcC1WhNcCbhKuBm8ikXF1PfwQ2nvqSczjJPN3Qxs5pFBH6gOO7g020uS4GqHHsPJ7xiDCn6tCaJ7jPuM4oOaG5uJ3Tpy4LHDCF3CaSxDvf/Ah79/n/orQw/sfX3Cg8b8NI6v33YEQh2ZprJ95Mnvl8bwF+MH1UGVvCHEfnP/+ONzEI+A/tSZ+TuLnoGWhVXvgxAcI/1US61+JbIsQbUyR7oEVIiToqAdbSKTTIPilb38S/oXjnFCNbtsRNzJ0Z4TswfEXsLXzN8T/4pH37GiQBPsesII3QF/vjd4C95f4Z8fxAVCVfwA2ceb8PI4E0cQX4D6HwTpOrdH/pfYflKzfKpn/NIn3gxHZBKYEkvtgJ0iDeBglstfBbP8e4De/JnCBLwTBgf4xjKDBaUS1opHfV5OwBuEfjRybGKQz2DjrwzdBH4fEuw6E6KOQqBdJHbY/wgkeJU4jHBgSdRAL8dbVtfITW4ZCl1gBJGjJ/Gl2F6YjUhCAeNCDywJcKlP+HsP+dLr4P3qaQ3++CVr0HvUhdOLPCAWq532QCCdip3H+++pT4BfPhTguUBUKhXy/fAY2cDZ+lyeJHwB/C+cL4XAw/vkg4mY/eJ3wz9YK+Nea4x+15Skc6l4ZxM1Pgh6YPyJpD0zgIK2BDyArTgyRpp6eHloXNrHHP8+EOGHn0AngR5f+DfLYH0C/H0+8DyHxhDhx952wFbSBuEuE/8NP7t69/nsI/+hMXPwohDHBv2dxIPz3z1+GtX+CmBf9I2n/6BKo4QzmX1P+4yT+vXsjNAkgdDVCEyJpf5xfejoj1EVIOYg7QkoBzMwP9Q8O/w8+AgXfuQjrb8LCA/FNaPgbD+Lxa68hLhCG9r9/Dkx7/L4oxh/8xQ6RMB6/WA23MP7o8MmqYZwIsOufrMNNfgpH0ZOPvnKQ8L/G+kfixxVNxG0lfXsCCU7OYWMggNO4HIYqgFR+ESJSXWAkxvZ/D8K/gO6PcYgXvwC1DkDtg7zYwG7gv44LRj7sw5f8zbxU7I7/BXi/jYvXLkulR8CCowSuGB7N4yZfukxnO+PwD6VwYgFPBlgrPwC+MoibmzYylEHcdIM8wkProUFS+ZF5DvXEAEgHgJHf86V4C8J/fEzgbg9BIBj5jzCiY03CcVrUjbwZhOLa+6uxQXrR8Tcgvf2L2Tw6UE0KRRR8DeFfuB/wOgcVT+KtYdJlhzWzV67MJsZs62h/3MsjuLTmw64w5Y5M45NZG2g+HLxKO0dYBqVOM3P7ez4auhngT4hjgZE7c9UCf+PoBahjAh/6uNuvkV5EaPTocegeXYoffWcYZxrve+cC3Jmz0Ak631+Nb2N8cgAMgvttNRr/YBiNH4aEtx1Cg/dfq9B4+eEr5ZOta+v/8bQ/Q+odEBr9cY6DOtddH7m6t56Gv8EGvGKQKqlJ6jQy85fVTAwM/HpIfKv/qDgRG/i1KL7f/+7loxf7Lxzt73/3+Ls3j4rmW+/M/27OLE5ctx2fn788evHChWui+dih6MxA73z76VPRU/3HT7/9m+2Xz3+w/fjbOCOswoo/fX/8+KQc/tfQ/pzQSZ35ADXmJjn6L79C4wINde7lZVjCJR+Ji3IBzGz/ZbZFOuwnimS+H57lMzdEVphH5+boXLCJiSGz+dUdO57MzDzZuePJkyf7d+7c+R2e6jQzs4Snu8xM7inHEwHhHykIlmaWonuWJsmHhTXxQ4N3kjGfTgf96sQBqAJxroOoD14eoeG+vrMJgh+E/SZEh40HYTlSP8Xe/h7PxZSBP1G7INJxUdH8Kh7iSBnpikrjYElbotL/EtL4Z+7jX0hoOIhFymXcFP5wFXMKy1N7cajb1jndZEVNV2F1A0ECDTg68W5T7PUPOMCoIXvqGFiaQb7MQqrf7M8/cn0CIvT0pPzdxfTCZXj+Uea5l37QVye7v1NlD+Pod3niLZbxb2uO+Lk+L+IyPP+BEphRAfjhtyjSh+BDjM0/2cry/MvKfbszn7IfpePHE/cXc38ANrSTsf2/YeLnuP0v5VN2pOWX+sC5CmMwgBRZw/D8FxWX3/MDowHsxgP/Cc0DgKxy5PsVlud/ReZnnQFgZuaWmn/1m2dHWOJfcfnLPLcyPvlUhXHil4y/5L+wMLbx7R97AKsCyBNgthmw5Ymbfo+fbf5bkfnLcskBzLH/SKt6/g3OD90gZgUwToGNss9/3QD8HlYFiIyzwKKrfub533nl37F/hzF/WZleAUwuIC6yTP8HWfXrzl40/h2Pxx8ytD8Wlo7AvRr/wlJWBUQTR3T4ReT/+uHjr79m4/d8OZpxCozZPHoRbNo/NpNNAUsLrWUbhH//4/ce72DjL/OMLWbgF82LMfKdDn/rs0w+EC0/ZfMnnzlr/b8jT/LStw+/fmknW/vDz8UJ0VgDonniood8+Q328m8/n+H7bwutHk9O3//C0wryK2ztj2+05uKEWZQGftQJ70D/pfZ7nbbWhfMJg3lP0cTk27ZWg9Nmmf+c5xmgGfr/BkZw655GBSKB/+FW8jegW/03n00mNNN+YDExubrgbzX6JnjW+a86fqO/oJK0Od2uRvvkwE8t3NM79uUPi6NE5hbvfTlm9J1mj9/mv3nk1ORSgsrkqWcAb9D22fnzLRnmv6YxAfJ9yJpYrCxWk+LLmp1srX6/bfvNhYWb221+f6s/3Rkz86vvFs2nCG1r+vsX2cUD6LYsJ8vE3+UsjOzLEz+LZOIv2t8/KaD4e9PwF+nv3wD/y9sLKsn8++jrSAKhqsJJSH0hCcc5Ciu8JsO5gL1P95aWwkvh/wCWKo1g+/Y0b48pmBh8oSRvgvSzsfHLrYLS66yLJFwh+ZPLW/xqQ1/yywZLR6rwC6qE5Lewlo4ESdMnv4W0dKSDlPy1BfvDPxtNnORN9sFSDQAB6XXEyW8bLRVpkxq+T/9WyZKRbqnyC+reU1gyElLeC6i8kbCkpEJ5y7hd+1rfUpGAmvd5E0kEpSW1Jqey3F56EaBKW/YJyW8i3/ziUrwfi6XUaoC2pF6PS33PcSlIwKR/ly9eUUK9AKHFtCtp2m7QVORxsEJKnfa1zpK0l04S7DDs8teVypsw2rXvZdeIqzQsoD059slidZVCDKhIh4+ICzRv7jQYaMzYxmAbzs1cCEGWyxzk8A61m9UEAs0m074sg90BCAKbMwwK+BFvRfa2hb6Aqatys9lAANM7w9l3lBRlqmDa98UQa7AZIzGPcvF0NkSdZTM8GfJZ+kzEpHP4oh4Ewj46U8HZ11HZZnkxpc1e6+qiGHW5W7MQrC3YfJC8irN9za4s+IL2upZiA6xZuivagllc+P8BCS0BGxQPyBQAAAAASUVORK5CYII=', false, 'ASSOCIATE', 'Visa / MasterCard', '2022-01-15 18:04:18.713825', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.713825', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'HUB2');
+      INSERT INTO public.billing_payment_method (id, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('c440ef2f-b612-4551-8925-d0b5036a6870', NULL, false, NULL, 'f3e5436a-1e38-43e5-b9c0-a3105a900673', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWEAAACPCAMAAAAcGJqjAAABDlBMVEX///8VNU7qYgHqXgDqXwAAKEXpUgD//PuUnKXqYwDpVgAALUjpWwAAIUDscjL52c4OMUv99PD2waf3xaPraxjypHoAK0cAJUPrZxHyqo7Dx8v98uz0rXrypG7viUT0sIH86uXvjWL64tpRYXEAHD7a3eBqdoP1t5L0somwtbvN0NTr7vAAFzrxmGD62cDz9PXsdTjxnnzwl3J4g47sekMrSF+rsbgAEjiKmaUePFTIz9Wqtr6cpq8+VWlBWW7xnGrnQgBca3pugZH74s7tdif4zrf0s5Rkcn+CjZc1S1+2wchMXW0qQlgACTTug030uqHwklf4zbHufjDueh3raR7vhzvuhFXsdjzyombxmFc0PvSsAAAWr0lEQVR4nO1cCVsayRYFu1kbTLs1iImi0ChgJBPEgIAOqMOik6hJJsn//yOv17qnemGTCS+TPt/7vjfprq66derW3aowFAoQIECAAAECBAgQIECAAAECBAgQIMBq8MeXdRtfdlctzH8S71OijdQfqxbm/x57ecJRPubVZAOa5Pe0B++FNRsBw1NxloombUSfj7ya3CVZk2jydShgeE7si4yuNfGVR4PYbopaZG9Cvy3DrzYJnqrogwPgL3XsYSZubmkNhH39yW/K8G40ZSEpbM3x3UYUdPg2727wilsC/cnvyjARkZ2H4dBnMBPJvOv1xg4wnDQeBQzPxzAqceqNy0zkE2AkvhqPftNobWGGY+jqPrsYPoIFiJpvd7+d2/j2G2UcizOMZiDqdJKxH2QSxMTGEgX+5bAww6F8EszEd8fLGBgJz1Dj98ELGN4mEsWE4+UZ0O/hB38nLM5w7BOaiRv+5Q96Jz7nlyfuL4jFGeYj3tf8OwzlNpck6tbTyaGBna2tmezO2YnZ2tH4bOsf4/GEL/NbT+/NsU62nmYT7thovnXmeoMMz9YXw9EzmIln7tUTGAmWU5+w4uX6OzbUJj1cP7GlPdD+keV5eXpcz2YTgoG1bHZ93yHsxi3186jXmUJn774kzNbrb6Hh2cds1nrsdB42Dva/ZLOiOVYim3333bFB726dMh+vm50K2e1z5DirV2qJijWq365f7/nxCtgEU/CFe/OWIgnh0Y4zdgQWD28zBdoUKUg+MJ6caFmm9q8oMryVSAqwLbTxhOQ2x/FGgvrZ39OXP8k+EFNMOv5xwkuPv0e14fmxovtcrLS5RmO9NqRLga5F9/OsZVTku4IP387C8F0Cvn2Db9YhkmBGYocaA8PUh6AxHNvKWuoPDJ8BLSBsahcWYQP62d/YeBUVsK2QMJZj41WKe6yttMOCxI7XUmtuCCksboHMGsN7uw7pUlRrjDo7oh5nYjh/CKp6CC/2vpCibN9NZhgGPdBy7TX7S2J4c42jhRAFijmGb946p5Y61CaUf3Q+Fm75suDGjuCxljr+hIaoFa/vbpPOtqn9ZTEc+gs2x3menl9Dxvye9TRNh8XXN3+QAjGGN10zoDaUGgLD4u2te0lSO7Gbfbd6pnYxG9p476XAJpJEMcr8nPBY/qitVS9m+AlC4sQJPQfdFv9iT6fp8Nr+O4z/YlMJ1hqxQYHhNdFLD7d3zr22QgIsbGwCwWtilm3GTRzLs+32shiOHXqWy87IDIu35I+m6fBaAsW1GN6Eh2IyqiGJRCVtz40Mz4PUCVmaayBYMMfC4svHGw+ZvSGeLYlhJE08ZzHNCRiJQ8/G3gxzMBm+eUd9JW/v9OPBo/0o9G9HiYsyLH5mM92C0Cj6eKSfLj5to1Z/mp3hR7Pln9oqYQ+pKMPjbAw/bdPXgi1ACKzp2s40ht3SGbAYxqMoZhHusqBaW54Ma9FsKiU4zYKoPxZ4ZxbN293SUOAA34Az37/xYtgYytGr+NFsGQu9KKfT8RHCMtvi3tH5kfgF4u8ZdFjUQnajxrmeNRi+I0MvHFNP8Fh868GwsP1ojHuS5cgUvnzXH5+9wbaMYeJSfIYUA0xH4s5LZit3OPiK8zinDl7I8GuwkreWXFCvsNdyAsMoV+Lj+y3zzc3xYYw7TU3t4LB/EBsfYy6GE4e28d/CLZo4tJf7GJTbjhFizHmIt3c4Fnna1CfbN8BMduzVyD/CctIEX8rwDfQqmIJtgJEQD6YyDJHP/mbe0Tvl5VHuxXGWfWSldly0RhEYl9gznxaDIzD7fIa65EL7UOgrWw7BSu0wHobMG01mdmkMh+BE2YotzyCES6E5nyWn43EHiQuXfO19Y28sqbmMg0a9S8JjRnwM8n2b4fckNbddoBArPrsYxorXHkRWWbJpL2X4NSjstiHAHRYusekMOZ0Dr9jkBEeV5h/iw3SAPgzno/CYVPsItr7NMKPHwUOMukiYFsWHYfTwkB28lOE9CPmSOsN74BpSHGdz6zB0Ja4fcqCClWDG4S9lGMPCc34siPlXwTCe6qd2tDkcgRtIclt7bh3OoxUVONBXqeUwvAVG1Hes5GSGYYLLZBhO9cXEHu5s66rPFIYn6PBRwjMn5bEkHT6eJWOZwvAJtVwmw3sgQfQotPFIax7lz5jnZ3iGSS+L4b9mWMxpDMMqLZNhPNUXfnBRU4JPDOe2EkeTij7sq+UwvDuh6MOwGoZ5HjA8cp7iz6/DAcOmtBD/Js/2yUgkHddU5tdhrtblg+j75TCMztNvrD9XwzCe6ov7Wfpv58Xtl9hh4fGVH46WwjDY4eyB71gbK2EYU4w1DNWcp/jzM0yRoCMscWOJsUTi2N09h5/O8M1Xbz9852g3fzwMHQtThHgpw1BUEK+njPXTGcZiGvD10Xlb8CU5nTPyc2GJOZ2j8uPGz2fYs+af+uRsNn/lB7OXr95jHx2ZvC2xLuFHRMz+0dXPZzj/j/uMUeQvjOiYv/JzBkuX8vo5zt6rzwmz6PtihkE64dDrhOfoU8I6+fn5DId23YbYQ8r5dXhvByt3boqPrlPC+pIYvoFbNF4Ub35M2vd05mQY1G8ntCCwbGITcuJqNb8OhzZBOnH9rzy+i23tngva0yUxzP1+TTjkte3oeDchsPPh+RjGSyUfuRnMgZjbTGy7N8T8OsxfERHXzq+tQ6bQ2dP1P9v64ePyGN5Dfy1kD6+frPOhra3r84T+cjGGtyhFWEv8FVoQ104zIfzjbrQAw46Slyhms9/eafj2ZVs0F3V5DIeeuZBIELe/GGO9y2atKy6LMYzXdtayb/OGtAcf38x2ms96gXUy8drdaAEroV/YdHRsHfazfy6P4dD2lLEWYxijFP2OoZ5+p1Kz3b0EvHMocdZ9U3khHdZ/I7Y2CctkeGN98lgLMrzjlZDNeueH4Q0vm/jOo81COjyN4mUyHMqfTxxrQYbx98euvmbGDX9Dy/mjAwOL6bD2ndf1Rsbw7RIZ1u88TKjELxatcQfeizPM/QhXy3G9Pl+U4djmc8pv3kLSygKWw3Aof5LwVeOUeLxITqd/4L4hOD/DnJkQP3s1WdBK6Onq8eekx8SFZPLxVd5ssySGQxtH12LSY8+kookTK0Gfn+HQnetm/fwM7/1J1wqjf3r+HYVrakB/BuATfOZlWkzE9vZeJ6Mp+o2AkEpFU/t3eSbmRpL6eQaGQaxnYBgev3X80GAj/2o/muTGSkYTb/P0l2A2QWb8ccUJyZB0aMvNo5CkHlNajzPevUQSEFNbTHvq9Xn+4OBHImn+pYavB8chvr1PP/M9tt+Gzg4OvlpDCT9en4X4RjN06u716eCH/Zcmvh/chSZPNkCAAL8QKjlCpbZqaf6LaBTTNk571VVL819EOsyQuVi1MKFhyRvDcVtdtWyL4gMxnK6sWpjQfUTyhPzQGnWbq5ZuIbRBh6WVMzx+CPtA1iCd/oocNxWaRHflG7Hdkv0oNu1Y4dfzxT2JGO6tnOHhZIK1bVb65Shu0JyU5sqlr0sT2DW0INxZtYxzogaGL1NetTTV3jSGNSX+xSLKcYbC4eLKGb68mmYlwuGH8aqlnA/VCmDl2jFuTCU4LK1cD35ldNDiZsydlZF4vf4/SIt+YcQjRPCVFdjUmvcBw0vDkIJzqceeVnucFjutRK1arao2tP+edTDrq+rEAIq69mznGPrfiMXYCHNMzRdqgaiUBvQc8xC5kcMv1FyuWerfnxZNyL1+vVxxhfUxFQqIptyV3ODK+Ko/9Kso1rSvSoOG2Xe31MlxHdfUSi436A9a1tin3VK/6a5O1i5pZPZ5reKUR5+L/vCS+7iq5soDa4TTbr+ee2nCctkFZW16P5cLNEr5oldQ0ooEllqWlHR4UHZIUh2csojpb32GuWEjbX0lRVpNL+VQy8OukmZ9y1Ik3Shc2B3XLoa9Rlp7DQmbJEUi3aYj1Ll8YMHahzrru8DkKT6YT8adQquYPi2g1ONh4TTDRtCmViw4ZzYnxmgM2iAlMKwMSYJRWvaK7jRRemVOl9R7aKd9WG8o8ECW+y6K1XghrDg7l+VI4cJs2v5b8R470qpz1Z02JRwyEx0mJOucVtuDcEbmZxcql1puCZTCi2pH5Qx11QJjgFI2SEdyDd/oWWrFkeJKi96UQs2CIzyRJWc227735E+joGvs4xp4DCcyXdzqTXrRYukoqJLU15Zz0LIkKpKKlh48h1BGFy+w9sjwAzyPg3kuIfH++Yms4HaqUAFR6vfCrsRRljklrtZ9C1CKudNrk5JPBbc6LAXlShc0UaUTatI8Ptjs5UY+S+yY2XxQsQrVBX4o05Mxo2t6SmC3lIA0YDjsKXkEy6Lqvb+C2gxPrAHqemmjzvqSifgLikqVdgFtgcVwOzJBeVoLxxQq5MwgZC1OE1aQCbtMJCtmkd6RmVDT6mBqQemKur0c+RMcls1ea9aSybIxtMMmy2QnnBbXnCgXfqJHsELUJsgrmwPABxEw1vOhAoNFbJtVzfXYgst83yVdDinz0K0bKIy4hfcPqL2gkBRX3HJoMYQOi0L5wXTAalH/h6J0C+bY3Ra3Kg/MTY9HxDCLP1W/8ovp6God2iGy3B3oA+Cqy62FGSbrFJbq47KOcY/iIc0hcc21AEGRS/GypTDqON7gyCGGW/hYYyajgVfrD6wxZyLkyFWpE4/HO/ctY53lkTlYM6Jl9aN4/NKyiZea40ddjNu9XcBDJn3Fz8akDRsIHly5urg0bEIOK+eni5oJsP8axVZVgjrONPjS8FjT2X6OG2yMAXWRGC4iaenGUF+7AdhmTWi7bQcfp7tlqxxWycV1NZXvTUPZjyjdOJcdVJtAGwVdHagDMMXO4UT1uWasuZ7qC1YtsTWODChJAZcZWbBGXutPspbyQ9zhQzvhvqsaOAZ+SC3HMKNio6IaLFW5edoMX0bgYfEChqyp2sxtQyl3O06PjuEFY7gGjs72YpoVwEGUdKt3YZQ2L7ppVa/DsLcKHjpVSLPRk86D6sTicMt1xFXzyNNVUCSJPYXlT5PScxGXvRwF3ASOGpOmAvbcVI99CvuYWQnOp7GJ9sEQ/T1ss3kY/1ElG9zAKUNX4GLmQtU/gTA57k7fHCr1AfEeUNkCoVWM4cxHWAFJu4cbfJhw2O2VW2CgycKVKi0jKbaN2IDRn85xb0jzMfKZB+rpRII1t5pu+aYzsVpN+1+tQvuPtlKMHJ18BcqnFuG5+agHJ+8znwvHjKFjJXLJIztqz5H4JI8K8hScnVX/Jpl4AV7OcIVzPd4kp927s6aX9yrNfr3eOz2FLsgdxOjSjdL3zkOs6WN6Psq5hnLBqCy26/1+v/HhFNMlmxvwCyQPqJLbopIzkns5FZArvNhK9CcE+mzUhkOx1FynVEgX04oG3shQSAO6GunQLojBVZGM6efhiVQPTUG1UjFqmxltaL7QQak9hEdUcrhMO8cFgPuV00VA2jMdmwvoeGRWbMzwvEkD3OblzlU6Inmb7wxrCK47A4qJ8Y+5HNUSiDDF6OfKw1Za8R6bMYw+jYJHChbcka1a9OrQgchiV58w1Zd7Y7s+PS7IGMRBba160ZMzvs5RbjDhMQqEGBZiCavyAwex8mhiVH85HCkTtpzNAB4psFACYxjZOcosG9lD82djGBwdlh+quQKXZdm6pQ7cNTKARDd1Ib5A51HDuMNofAF+bqIz6YxclVsECyU8fRqokjUuoDs5njJxulj9MgYMFzlre4n184gVaqoPriIZ929lyMQgs8fFBzUwun2jMVjNiaZu6FdZtPBg7xTwpQrrsEaGwH29ZjQLw8XQQgAvE47w/gxLTYrJsAqG37iXqf1fC8sPcFMXHAvmEFVa0ohRgccSnDRhIw65CpOs2WKZG5sicWCYLC5sVtc9tjGaSj8o3dBC4IrD/NJ2QHyT4WoRJik9jAr1drvNWdwMY7gDCT0yDA7QXA5MwBT/m0XgqDQWGveFTrt9yeUWNgO1ktOX6gBT67qw3YaZjgo+uF/wji/muwMHwzSsxTCkf3JrwK7Hg2WlsA52QAtvAsBymBen1e4sDOdQ0FFzbGkhaB+zMDVYspaX45WdDOOhwtLvhUCYglGrDjwUM1J+zMZGsNPgMVlcmqZdezRx5VyOSmMGhqEwE5YK1B8eW7DaNji6HpPSx/EawMx72QxjhdGxebgbmUZxG4MgOPIE4iF5g1OGe+zYlSBfIsN+dlgFLwdFjhq4kYi9OjAny5fqIDPsTsyxerTsa7xtSGYU/l5GGW2urgsqJLdwfSLUoT7Ip6nknhUuT6Nc2kpoUYclH1tXg4tfePSugpdM22RCzkxVHC7DdHYPOhyJO1++EGAJ5AanwypGMEa6BHYZZ4l9MD1CA8kJDdO3Lk7jrQr53iWhWtdWF+piXEKG30Y85KH4E1TJfWEbZsbpDqHWHMxakXLA99cOfS7Obem7t++zl2D2D0xnMBDBxmBPreXgirktp36pV5GCxjBQgJXHCtbv7IcDr6op1j5cxr4NU/W8MN/uSoUFz5BAUaW+WrPQKfzNZU/mGQNIzjEcBovLZlQH2tG4Qs7csKwSHmPh1ZeQXmEoynoSA0F0WAaGYUfQtmp5+bSCj+N10RA+dVb3Yu1WWlbqL2c4LBVPLTivDciGTAOP85pQDE+UIVmixjJ3GYeugbD9WOaGCnesw4daVW3qB6H6TkeHTDu/moONQi6ALL1EjtdjXAB3zlMsqOw+Z7Wqdlp6GSY9Q1XVC9N+5mXCMqSoww3rwEztNDApZKoNManM/agYLlrZWqHyN3nS3YHxY+94T4nYjCLDGkNmSa5SwgyTnQ9Wvaqm8MMZqe6uL4y52pp82u3HjXua49L9qVnmiizIMCYVvkhbngovmMit+87FRTnOX5ZgISleCcEbWXiil+n4SCGbh8B2zy0Hw2Gp0S9rY/cVbmEy9p/W8KyajmllPaMFx1GafuXTAKuTttymZSb0p6uwXLQlqnON5Ugmk+HNidxiFhePLTBY63h5y2phQrlO1l0Mf/VCWwLXzQuqSmDVlBwvtPSKeHPTztLuFwwlpt57Csukl53WtLZkcWFGXHjg7QDHHp3ZMGzp9N+jUVUOUp0uiz9JlUANEOXJFDsrCstjOIN3Ar1qfJEGFmPZQlNMys8IzDM6wM6p72bKmBdyPE4TZWUEcrBcBbwFydPzcbwMtcHEY45Fb6PkJtZFZVkKczfWLjOuJsqwTdOEPAQY5op+BR+X3o74FH/lorHTq3XXKYQkj4fEZpHpGBwDUo2hNzGUMFD2vvxtfhRZsFzhfxVYv93YunfWw5v8+YYsd3PYBzEMv4Hk0rTLkUdjA7VCy336JsvyyMqltICDP/Zs9bgtyI7DO1BKZbSM4U6a71nruOe+/a4LISkPhfqCZriZiXjjodvtDT3sVafHHLishK+aqp6kMUhsK+UarOc0noG3W6xx2nFZtHZRL0igybKsZEb3QzYzddiw/ao+515bPxhio2TY+WAzTQIxhtth9iwz4ZLqRX3EXZnV9CwijUqlxX8Pm4v7oH156W3Zq53+g+7I0w/3w45h0MbwGXMsKjxE8S7huTvAVDvx+8JD2uhf6haG8TGnOeP4laS/TF/1Om1dvBr0xn4E0KZndMlt8rg4RmdYKDQyJtLdwiDe+ek/N67mjPuvuX/nz45UVLP7cvlSdScGFfOV+3dlS0RNZSJoMqz8F9EBAgQIECBAgAABAgQIECBAgAABAgQIECBAgAD/Ev4HfD8RSN4sp/gAAAAASUVORK5CYII=', true, 'BANK', 'Virement bancaire', '2022-01-15 18:04:18.719393', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.719393', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'VRB');
+      INSERT INTO public.billing_payment_method (id, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('a9f01102-5533-4397-a239-d6fba953e919', NULL, false, NULL, 'f3e5436a-1e38-43e5-b9c0-a3105a900673', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWEAAACPCAMAAAAcGJqjAAABF1BMVEX////rYgIVNU7rYgEVNU/qXADrYADqYwHqWgDrYQEALEfypIYAKUXwkmv0s4cVNEyQmKH98+zpVgDxmV/62sLufTH3ybnsaxn++fTtfUn52Mz73cnxk1z86NwAHj/87eDrbiPtfT375NMAETgAI0Hc3uHtdijz9PX86uQAGz3qUQD19vfxmXV4g4/Gys4AFzr0qYL5yq/m6etteYbviFszTGGjrri5wMYlQFdEV2n1u5NVZ3jU2t/wj1IAADBhb315iJTviUOJlJ/0spH2waTxmWnnQgCZprBKYHI8V20oRl1baXett76iqLArQ1e/xMjscg/2xaLsczT3xrH2tpr0rX361bbviE/vgzcAACUAACruil/zqozcKogDAAAeE0lEQVR4nO1ci0MTSdLPvB/O7kB8EEGiyAQkSJBkQ3hEiQjLw7i6Ppbvbu///zu+ruqq7k4yCUPU9eRSt3oy6enq/nX1rx7doVSayUxmMpOZzGQmM5nJTGYyk5nMZCYzmclMZvLfK88Mmf/Rg7mV8ntZSf3Fjx7MrZS6xeJ4/+MIf/m9nisvX3568HT6buuW4zjyz/86wr+GjjUsQRA4nh+GT54fTNvtbbXhg+dKfilogHkIRw5gHESRF/pTYnxbEb5b9nzfQ6nfK/aKQNjRO1r+CQQugfg/8Sfyni9PM5LbyhJ3vcCBPS6wKRdHeMSGAVz4KxIIB97a0hQjubU2DAjLed0c4QBeo7eFDVvCgi34ywumgLjuKLllCMO+vCnCcjcD8wby3/gPZgzh9K5uPpK6pyS8VQj7gj8l+93Uhh0HCQaRjQJH7YUgspxbhdHXiUR4WpZwHF84SiGIsHwc4V/Bs+877p9HAOGb8zDHEFbw8DeUtYUwAleH3g7cZvjl+47755GvYAnh2fwFiqGfLn3+wI8dERw7/pPvNuSfTKazYebhaEEHDZVTT4YSYMoi4jLeqFRKBwdfHkq5+vVgSTy4qVQq8wcHsocXB08Lvb90cCVaP7o31Hj+4BE8PiiN78TUtVRsrDsvoPnpwUhriCWC6VhiCOFSCSAOeEd4O/Lh08VPL1/Xy2GIhB2JP2FYri/cfTA8lKUHWkaql5UHr/16GEZI+l5YLr8YalN5MPz64ut6iK3L9dNFQ83zMg7FC+v385NY0CXG699E16N62ZPNwxdLgw2vfIhoMWLz3uj3JoE9xobF4BciiIvlh5w8f3DEWDHWAFcYYfhhiezauxrKrl/WdfVyWP3nK8+PYN0CsAYIVrxwZSBznF8ToITydaCu5UeRB5l8ACPyFt5wsxe+J1hMBpj6sSknV6EHTAc0KIzPR10nQ7qUBLBKp4GHGRcMLPCCB9xwGSqykeVwlBWJEdIY6/83DcKlvz2LIwrHp9HXcaAinoO9Aj5Q/AC5SeSXgwEg7/oBieMNIvzACT3hRyNkeEgbobPIq780tsH8fVg8xDR68rR04oe4GgF5GYoel8U2AP1yGFZUPx2e3GJQ9rEXXE9HNnT88qAuHysE0Ap0hSHlAWKI8F6d12O5LBYKZu1w7MUJdOC/noxwPkuUvngOZndmbaHuBJSRgEWgBeMMxUz9yHz7rqey5tBEuHLiIfa007An/G8gr4FZW3Im/se/PksgsVWEb/gw65OFKJDrjdkoDMfgD9Ql4k40XzlUtGJMrryriqmLQ9zoidAlZwj4BXL9eA8ul9VwuebCYHvXIDzGhr9oGw40wqAkIAPGsFkmKqKpb1qxzC7l6hiPK49CNDeZT8OcI5wetAtXjFnzYydaWPMQGbJUnH5kCR7yZA1Qri+am7c2QLGPQoIhkLvektUs+Ld330TYolw2ELokBcIOo1eiaG2ZEJZj5oxDrKtPaF9nw2MQxmiCPvQOGGFL1t3kqC3ZIpDe1V8wEdaVH41w5UuZihWWysojft0JT9mygCUC9tmRtCon0Hmm43155OE2kuUUlrLJsG/KTkTFFsCLFcsePEOXr4bqRDKrxZfYvpzwMyGMHMzDiCRT4D+nZIm/fSuy6DP/T/msjHyGvg0qDj56K4dtoKzdXb4NP/BIFTz2F4JgwQfSkGiLXnmXS4R5J6KBIm9zZiRgt3w0XstxjF3rB3r4i2AAYJDCGFFXEHk+j0mAonX5qmqL3QE5IHQOZV3RB0IY1jpCD8hVXi5uTWXD8w99Jgnh6cjV10G58Gorz++ArKyVPQe3lDTiFUVvuTb8FOAUDgQMyj/FAHDpzUefQ3jH/zCEMD6mWrUq/CG+xBvIw9qGnbKiiadhhGkUAKZ1RaQrCgxdhg0j50UWcXFEj+vLEmFYZ1BP40A+KeTp8hF+4KEe2sAlRlhEnnc/PX0sf3y8/OlDSPNHpQrMXIRfeo5EK7LKKoJ+FhoALZkIBwRo4If1ugjCWQmGBQIkDx6LMNlA2PuVdT0KA+xDqNO65v2IVs2KtC5fL54IikR8L/6nipTwNMRel+FE07N0uFbWp5qa1nMRzmWJxTJuQPmZ2gW/B38P5zlfvEi5oPCTRniUJe7B5vNxwzuG11+G4Fjufu/URJhYwpfB9uNfF3zFEhCt+r/9CRb7ZkHtcmEJz5UuCrcCZ8HQ9cyTukRrrUu9D87y4QGAsPQocFQFN/AfqQ6gAh+QrhvX1hwD4coJ0BfsRmkFlNKVPuX0+lwlkpaJ8IgNV55jegBxrfeoMtABtbT8h/MGwuQ/n5zQ1t+R0ZqMIb37nAo8LUfKiL3nSlckDcTyBqLkF57csJahS2+CaIF1lX71IvZpgf/QQFib8M2rl9HCvco8yK93P3rMQTAjf23StZ0dn3dURF43H+HlDxEHf/WBDk58rjIFdJxi8HD0RG+sO55mZ0cP6aUPW2MA4eUFYlzHqVdydCGH39MIU6eGrtJ9X9GEifBU9WG5w4R5RUhsgvG8CKMbi6Jf72RSD/cw/5C+XCVLOSzxrK5YJxjqIHKowkSbgG0Yopgnut5w4svTF2uwi8UyZzCO93dlSJc1pGuB83Wty7do/JGhq7QTBoolBhG2pqteYm5mWZSzqLgafvI/jitI/bmz8+KXhyrMtPTuz7HhFx6H18Ou9yPuUwC1/MBAWOZ0xqzvyaRDNjYQ9iT5QOuVxzQrdr7DgZTUBRM0ELY4pzMQni/rmsHX2rCiA5m6yxOOIKKZCFj+Gn5peXHx7kvw41DZiuTa4AQnIRxwWCZMfXFAeNai7WcD4WAY4ceBSlQjR4/maQAbUD4mhFVsF+TqQmcXsi6DJQyEn5V5vMM2PO0pElo/XQWQeYREOAqHL6Wc3LlfLovoHZtgDEmkHUy04bKjQkm/PCC8xpHjSZoZY8OlBUvFj0MIs0EQwqHK9JwhXXIxwXKULuXpBnTN60h7hCVuivDIjRQr4HQYUq+dgfbzJwt+GFFVwZLFJhVZmQiP8HA5GNEz+AfykEGEh3i4tCAzaFwM/XR5LeI+mCU8SewT9RkIOzm65j8EET8ftuHpeNiUwJGeXUS4V0O1xydlqlgGVBbU3DiZh++FurKQL6MIj9hwxBY0hLCyQonwPUX5E+Q6G/4QRfk8fHMbHlWOKZNIvXzr5WDrU9/3KcCQeXkkV9S/HuG/QhVqFUR4hIelDRdA+K9QpZnFEHZyEL7PvX69pxvZQdiHIGD/avDOGpTGMB13HCqG+54H2SyfNvkTWAIQnrxzi7GEVYAl/ropS1g5LHHfd/JZYtpoDRdLX9Qp14M3y0OJxqIviyJyRJ5I31/evbv4JuBM4hob1iwReXkitIffyIY9zUf5ujxD1zgb9oN8lpg6lhBG9NsvLAd5r4PDxtqdsFpv4TlVNHf03p/Iw+UgIiT8J7+MkzfX8nARhJ/qE+Hoel3fH2Fd+Zl85/heWe8y71S13VEVoomxRKWsdqj3Mq97Q76WJUqQ9Eui8K/XNZYlrG/KEqMV+BF55OksxzhU21GFn8k5XTlSwWww0vfwrL+OJUoe219QQNdYG1bkmWfD0U1ra9cjXFnxdV3JYOiiCKvCj2XVRzofnvXXRWultYgzpgK6xkRrYxGmEYQjqW6+jD9FGpalJ7IgCFWiD0MIF8k4oP5Ouso7I70PzforMw4o41J8Up5YtpqQcYxlCa5FF0e4oA3fW3Asrtnen8KGn5VVsO4/zK8lPV4cqQ9PxxLPyqpCdL2u6VjCCv+chJaWGyAccDnIioYQdopUfpYXVCkl8kYuj4CcrEQj9eHpWOIZHHzIQ2xnjK6PjlEfLs4SnjKnoreqi7PEPTjFIZYIhhCOCrBE6bOnarZB+GjYsuZ31jxvwUR4pD5cnCVKn2Fa6FojJ3yZp8tXum7EEh4dMYv1+HsSWlqK2/AS2AXfO9TktvS3p2oAE1kCjJjdj4jYfhvg4qVPK6EIsRa+kQ2Xlp/4jjzKEClo+NvO/KCusu+YCBe34R11butEvtocJ5P8yg2iNX28LxpTn5XPgadvy01GuPRFZTfCiv3o4SncjK1USn9+ebjg47lYAYQL8bDQVZZFbiyheP5HU1fkQ9XQRLgwDy+WuQQLtn118KxSeXa64l1zM7AgS5SufLqDAfXV8sqLBw8enHoh3Q0swBKlypovdclRwmVTOLSqwwVVDOT9AixRKOMQ8puHdw5lhdWJ4GIrnpCFfoD0EZksUTjjWP4QWVSFhbs+2KlI96e7VTUiB3AlQzaGsyWvHJY9rK3pG3KTbVg4S7QLLB3hXxZdzqLvR/rfzoZLS4GPiy+XVN4Eo3MyVOdPZcNwss7+mr7TaU19b21UsKxmqatigR/QDUWOMa5DGCCminJkVhflWIVtfUOEEWIUa0gVld2mQ/gE0q6h4V+LcFGWAAcNEVDAOT9YRuQDxnzWPJklAOInIXzXFF9RdQoZn0B/Qwh/DUtIXXSQYOqCYiuYylQsUaqAC5W3M3Ul9JvZcOk5XqFSNgwnId6bHdBW0IaFPPK9wBoqkOPGFah7o/clprdhGIXv4ZeHDVVoDcj5wVQ2LEJtD8/OIqPTb4fw/H04YlQ3aOEbuScyay6OcOnTVV3fTCZBOwvL9z+ZOd3XRGskD4SuyBpcTYjghJNd+zRy56cQwqVnayG4yuIIC0+O9ejQC6//AnPlTkjlO/gv9F+LUe544lUq2+sbKWVdyx+uQVXuvbYiiB/USWPkeaLbL+o3As2vhep1s6RqhUqV8e2o5Q+hx48/DiJcqiy9tnxTV+T7oOt0UFc4qsscwwDCpfm7YoV8ZiboMJyE8F93tPynwC86OPktDCXlhcEdbL9k9HDCCJ8YD3N6rez853TlfkQn7Gsrz+/smKtbeWMMysDM6NRIWeeN1p9z7n/t/OeX+yta19WdkyK6zOefh3p8/PnO1Rp9SyZYuX/nzc2/7zZBKot3F+Du1esXX/FLaqCfx4/5lsjy4+ubfztd3+ZXZ80vc4+Pv/foZzKTmcxkJjOZyUxmMpPJ0iSp/eiB3Fo5fLWB8qrzo0dyW6Vmp64tJD780SO5tdLP0lQg7GabP3okP5M0t0ha/Wvbbu7HtitATq5vOhMltdUYJImzs+sbCyO2BVHEre8/rtsjuwlQq+26bhH/tR8DT6TtWThRXI5iRFgAVwS1hitMWNDELJooLpepLY14r0jrzVacuqkbH33vYd0iySTAdnxeqPmmaA9M/J1HdYukIWnYTpPjYi/MJQJhN9v9vsO6RUKOzrar3WIvNPdWhbyaJR1F5ThmhJs/eii3VLYI4XRvhvB3kfXD2JWO7nD9R4/ldkqXg7Wiju4nlO7uVqvVOsuppXQ7Zy0pu/1vYWDdzhz2dmZUFRou0TCXGvo4mvdjumjgx61WZwyl9I/Fh71vUrXon40MtqB0/7Uq5dWZ2KSNy40MywKrFw3dZrN7fJSsVjP8SEiWbVfPGwMot15RN1kTX+hfiAfjR1PrHm5Xs0SWILJVu0cJXKNKCEPOvP7+YlWOpro3mrTVztqvqjQiMZ6z4RRws3G+ihqSrHrULZ3TAF9t0bxtnrcOQ87+Tc/+NbBim7XDZFUN9lW7cTP7epe4ZDeNUv8oc11ZELRjW+PTXU3i1HahygJVAJFE2W6cvTXWQPCnBCY+F+o7rTiLXXevkaMPpDnXrsYp1R/grzSJtzA6m0tScnTd0vtWFtv4Y+q6WWe4i72MB469ZPbgem62kljMBZqIrHpvS7TBvjJq1thz8UMzlO5xMJ6ZCHdaCQ2W8vnq4Y2qpQIaV2ap3R72hD8JMA2AGlXZBOYqq97wzzgz1qAtX0uTXmn9OAG40/jtGJVnduJCmiAVYf3Rdqt9ORoCvl3rxeD05Aq4CLkhuykYhrQFWHpY9cSssPXTRK0flJFi2VpuDmyQSMTtRFNQiwOZtrbS2mEc24QKS7x3E4jF0OjtdgLj1KuVtLgfubbqE9dGO4dFUWtA9Rpha412Ruacj/Bmi+rmNnWDOLhJk0Yju77cRwRSNTfT9W1uZXKJXPgr5dmv6j0zF6P5AqyptAwYNGzQSxpzP5OqU21IzX3qKdZG2rVjeBf3r4YZd2pR2eb3XNw1KS08biimtnO0LPXcJfuzky3u5b1EVcxnf49zBmHOedKWJpFSHwi0mHyG0G3zHGgsahXEltCTEiGd3P5unCQJ60vjNm/us0zAInWk9sA6uPtNWme21wtF4N090pW9049cF1ddatLQFA91Gpm2f1xxBZ9YKa5YSY6Is6oQYBK2ZjfhWVOiAC+7jElurWB9P0EtOPMYOpSAu5fwab+q+05dWlMazirr2jxKcKyCnNut4+O5fS4W2Qlp7OMYpVXAqDPwInJeXKxfv5A+JY2VlZTeK9tg+uu+oiHEyWHveO7Q5hbuRmGEYbPQpITLhlggTpVV29RoW3jr1XarIaTbO6rGag22edbnbBEGzWznhVCHCcAL+MTVy1YXOkzA68nVPE40F6Xgug36U75uCzhVLKObnDVhNzfnMqL0+Ah39zpsIyT3NMmO3jcanaMYuBq6ZkCbXP8wEealcomahQUjwaRZuwGTadbaNKC0Os6Lj8hxTEScxudnQFENBgtWTrbpbLdbfYPbe8rMGeFN3vKuNHYhSVzNU5dJahUA76vooCG8bYIbs6V1J3vnIvxsxwpyPlXqb9jk4niSKpBJXRyPcJeudHB2j5o0N4gEeWPVOCxM9GGVdnSSq/EYEGaUzQ0tgusWz4jAIGREw1nE5pGaZiw11TqDseYme3xtw6uMcJpsXx51hPT23VFtYBTob+xkICvuJauo4m3Ma+vOdcFqumq9Uyq2NYnHbVeT0Jn0xK67AZ12KUgTPyo+PU6Ikzeaxiuw2DoM3LzgzUyObreKTQS/a/O6lKyRFq75N89pmeJz1UtHIzwml1KmtkEwddT+aveam7KnzRx3O5ewt74Y+gCdVJM3YazCpffDjPSOuoh7+u1OliLC2KZ5mONqj8g3uquDU0htTaib7JKYq/+Q7O26RqDIh1yFEe62uQ6gNkJpnV2VO4pwrdtt9Dsc1biXtCzHqqo78XCtxgC7e7ntIAvA8SfKPrsMOq3m+h79nBk9vM8k9SDCNQY4fqtN7xyJ2CaHKmTfpQxEn47UNnhlJAMIM8cwIm4ZDMnGVRhhGceKbozsocQmbMcmnTf7vaOj/XZ7L1Phh4obWa8ykXzpKfeSz2L9GGMRwZZKsfAtFDRfIsK7ytCM9+QWEhADwqzEjTWNiM0xdD3okvy5sZl2Ew6CEAtgd3wrNmMilbsWRRhXH+Npw1x1uMZ2st5oxVgiwJV33WHD542pTCRfqozWmHPkd5CLoDmqfamKbbSabZUUrWrJKJBPIXpcpaG4f+hYpsGRLvu1hvQ9AqmeatRj45dm0q1irgi9rq5uk6ZttUH0e5NFbG88D0//MLhGRWtsJ7tHmY6COc+1dQCl+XNcoizHzJHhmFPOTYiqof7h6vsPDWYFGWw0dd5jCKeHqbDz7gbfZjOsrB/L/MPlIKvvUj+ZtiwuTduY/IDPwIiPigU2FmRU/ljkvgwKu+p43wheFZbyQL17jmmTq3rHyWDk2xiGYS5HhxJ06Bj9vMv9fP2CYhSdK2q3K1ez41IeYpRiNNAQD4NLwDqFmfC8Y+ZgpzXHDxK9m/ZlVcYl4riECBorI3m6snEF1SHhOHbANarURppaYy/GBAmiLMgdsyqGlqmOG6WJoN6JcfiWCkHyy7lNtk8TYZWwYddzsYTXzTFlsZ3PyCUAJttGLNNTkW5tAOE0vdQ58yVVWyiU2KYWunBjymSHo2Wd6wBmDWFXRTvgj7ptTDmFljjea2/NHTdqbSIJdV3sXcL2PQnhdRVGxWMQzskCGBtXruaxrIhRnWBYtjuG0800wk21Vd/Khyqii8/VUDoIKCRwaJ5dGVkIU8rTlGQFEe6zhZhbaovzCTS1rYRYId5/J4e3ri6NcI7POYp7MSlYq3GQl17mI3zGzjwxsgDao9LRNYkr3bR9PJcjtRLntam7Z1Qg1eagGKam/KfeLRRou3aCZqI2T5KrqSgNqzjWqCE091Vg0FRFPsj5uYk2fBpv84KKr5PvQIrYGyuO6TiEVdaqDWSdvY/sGo0RHE48jvAp9hB77tJAmDcHv9bleRuO413mylqRrMnuUnVzgG1uLipBNkpFUG3DUaL3vkgl66V6Z58Rh6kYugmBI06gN0mZmDyXR/MRviB2TXWs29ygdFyuZvNcVhfcsUfRUG5Er5waCKuzqZg2x3t6kGqE16kUkBJx7FIImE5Ooq4TVRIz4tgtOg7A66VNsiHXuMm/BZfxIGDn1W1uUzkymbh3ahdcxB5z24SDVtfIAjK5mHTW0zzn7Lc95uxTRL5YGU7NerLiZpueqdBXjxgiTqyzE3Hg5gVdX3XqreNYHUrsVjFCcWX6M+j1pOzHsp6dbmsYpP+ZfMkU4HGH2U9OGMsQXZstrac/kTkn+27B+DKKyYla1nsQXGIVHVfSsD1Vc+T7nJyZ6WsZm42E4lGaaaOaynOqdH9kJo3zojSs4ljt6PopVRdtDM7nlPtXCDf3+HiMDb8lWUJES5Pv6Wypcm9s7rzG2yqWnfqDoS9BQcpoNdVJaRoPbt5aZ78Kpo91DFnfv6DRbHbY0alMh6towr3MQatav7UhjyBTlSS/gp+BI4e5r9FKCn+tQc+JLWKOek0pgz9WoXqbWpzJQkGaar92IXN8N73mjulZos5y9pQR1Lb2YhkrnqnRGFkA+XdW349T9qptw46avbZI6aEXPGuj3HwfWtSOz2OOJdXeUZeUIUQ6OjpqJzEdigg+JCzatFPFtA6N1Wyc7yVuXPDaonCfNjNfDw4wjuwsJVdCRMcICzzdXdGiJVrgIohZK8MnCzb5M1eama1mVt2D7jq9yw1hldJoVZ6lr6yJPS8tS62mMtE0zeKjDoz6fcvehjBZFpAxreELB6urq9VEZyeqvKUKdpAh4lEKBYXADAxOkrrsV7clPp2tw1dVuCNgl4rJpt62blKVx1l89Ei3SeYSPrAVLJtV4RYEBwTq/mmNT9Ou/cLKUZLS+QT4rmomNYo5AsIqqh7IAlIZGSjieL8tT5nR1cJhihw2HKZKw4Kao0RYJrxYj+ADA+74MFb1DfQ6NhccBKjMfbLUz7QWV3G4MY5GbejrpMl0JGsnZKxYQIxpC3bx1M7MGlWWrm4w9GObvM9116TB19nqlJl3R+riCbs6A4u3VD32XUwncBlvSziB4RsbRh+AE2XEVXU8TcNS+vR9zrPM1skwFnQ4qDKcfiPmIsiAADpFv/vU1G+rqg7GvmlVcdxl7OrZwM0O+5LfYE8yF9M51PWRY20P658DK2ZTcNvlDZXoutA7ujZi3Edp7sO2zynHsOnDSb4eL5jfHj3QtxxqroyaqZVoc8hAGPWDftU1T3Z5vAOu+Jr5ciBuxwaI4idXQ9V19eE97Ofz2uVQBgolM/Jf11/5FVtvCGG4KoEmodMC5ajXlcEapb/181gfj6pe7LjKGaY+yk2hqHCojkmMw4o5WIaUuTdpN1RYappJZy/LKaylyZjK1aiwa7HtQ94lONSW2UE31WRd3euXahnWgVyVcMoZQd3tvIDi9XduNmDCcWL30Hv3EtmxeQmnTXd+Bg5yNvsXWTw48ThJzudYe22/ygaRVtu7pYY6MNCbY/2oypaTJu13WFJyjbtHPPmenQzQhLCxjb25ftFLVS1G2N1sHm4nibzmeNEZfL+2J68dJlm8K7R3/12Vsk2s27U35IPVYslP891lVeoSfSYb+3NkNBfbspuNP7Tq1Wpu183+0WqWcR9ZtnFxXDOAaZ7JW6I04kbGcZgRxa7rNi0YwBap2hjaiDUR7bAmMdxqfFS7QRbNp6AYoDQ7x1tbW708hunOwfeMx17ivbmsv+/38LvL/em/adjtnMnvP591cqaM/Z/J3mXxKh25C9o/1m0mSuc9fdW6c9PhqkC82FfXflZRteD9f/or/Mp5Fz7V+zlF3Yj+x78RpnPmb7f//xtlmy5hDdebvr/MxRSubNzqb7Y3qjIlSSfXVr+HHCcyFBp35HBLhNPotOi3TL+ZrL+l2uuNLnT/fAJxNgb6RY+Hv5noOkDvVv+anLfk0NPLfz6UoGg4yb8fcktkfZ8qEP98KCGvrEEkfqt/DxFcWXON06F/UFqr1Y3qhvgvKXxh/meU/irMEX7v3T8ekzZrLLeahtfVNG+1P5/JTGYyk5nMZCYzmclk+X8TpFMPPv7rbAAAAABJRU5ErkJggg==', true, 'BANK', 'Chèques', '2022-01-15 18:04:18.722776', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.722776', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CHQ');
+      INSERT INTO public.billing_payment_method (id, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('911ca285-7a80-410f-800a-983268f2fd51', NULL, true, NULL, '8732a69a-904c-465c-9a42-a53122b7582a', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAP8AAADGCAMAAAAqo6adAAACMVBMVEX///8AAAAPC0j4tyngHwD9hhCqqqoXBnn///3//v8JAkZubm6WlpagoKDZ2dnq6u/v7++lo7YkIFYhISFMTEwAAD0AAHZ2dnZmZmYAAG0PCks3NWR5dar8ixw8PDz4+Pj+8ubLy8sAAEnFw9taWlrm5ub9lDEtLS23t7fY2NgAAEvCwsLmHwClpaWJiYkVAHl/f38pKSlSSZUUFBQ3Nzfrchnl4+/1qyUoHYMAAGf/uycAADkAAEEZGRlTU1MAADD6lTyBfqxBOY7mXRj4zGbiKwAAACZcPyvraBePAADX1uXXAADvsCjkOCJMVXJdYYOHjKjYXSbup5ius7343aCjdzX96+TPJAiRHAB2Ljrrgj0lDzd4hJYpHDP87tJpT0oJABr33rbkSR6wHAdpFBmwei8ZGz5LDizzxbAAI0MyQF5CTWTxnGhaFiHHkC6OcEv52IO+tp7fw504Lo3brleLAAlXUpWjnscXACK9hSn6x0/wj3xDMU96X2E7ACnfrqRSZ24sEDTmYFC6AAC7V0oiABoyABRkAACjcWrBlFiId4OWXSCHb1B0UWDRu7VmboEiACqae0qrRxiEGx7eQitLRF9iES0hAADjc1vp3cX0w4/8ynH71rFBL0OhGhv5tnxZMjD7plvTnSOvrsrSgSH1miVSFyU9Eip4VTM9JSpXOCiHXyyyiIuoMAB+GC2xWy2FbmG9all6O0zQtn5WLEfplIm0nG3pdUzti2KePDxRQFk/gTH6AAAXXUlEQVR4nO2di0NTV5rATyCNNyGQiwkBUuQmgUhCLgQB0SYIvoIVou2IQrtYOoqv2pZxxwqCVqfSzs50p4Mdbdeq0BbsKmWm09lut7P71+13zrnP5CY5AZMg4SuWm/v+fed7nXNPuAhlEt4XbO/rMr2o4my2B31CRsIM7MGKYt//85F9HUFrzvRBFz24pbm90vKiSmV7n5Ni1IVzavp2clBFsCpnvW08CVmaCU0lqyMIhL7Wl9e7KqyE64gGmPa1wJ5dbWuNGhtVeDuOBNm9IID93lKAGyq4CFgDdVnaNQj7dGy2tpeFBy/oyujW4PnOzeT3yRLMbNzN2Q3kBRe+0WRqT7PNCq5vL+jdFENqIbUZb3Ft0sCXJODjHUbrm0sDnyjAwMzbSwWfoAaT1wVLwfdlgY5dSL8mAJG/OPdSDBG6TU59l9Bl2rW5E59eAkkxEGr+zVz2pIpF5wFCmpSwicVlalQ/QEAsJevHUqXJAbzJ1FbMeymK1Jqc8mK7qauYd1IcCagGwDoysrmkQo4AwdLzfiwhk4kOb/al6xBtcummPWGh1HK/LG0mE/4VpL9KTwLUASpMFcW+kyKJk6R9g85giUi7qZm4/2Z4yrMWIZ7vK1X3JzWwAEpoSV7f0awKr67sCygHupr7NkPOwJnPjp1AL3bNw2M5NkCwVAeI8APCzVAydQFeX+p4eEDDL48KVcLyLnkH/Gy4YDeZR2k0WUAHqcV/n0YBkgN042VpyCBs2iQlkwvYjYZ9KzX8dKuPLEuWAurZV8jbzJtUAJERv9YBaHSopR/IMs/8KJ1FBJ43DiVCmvXPUXDpZzjs36xRAI76wj66TKy+kq4MV6ZIusfrIeNNQqiyztXY0tLoqqvU1SCBcG2fq7ul29XcEcb+Z21LvRYcYNF8tAR9ITk/+VL3xmLnk28gLX+bhh83dVBaJqOETpOpjxycIq40/LtMBkUGX9moPbZPGY/01WnXO+2kRksR8MWW5HWNHUSNdoPd5ZZk49c6AIZSAiIi/WaSFWtZrkAEx8uUEbbgruSDaUjl65LXVxjyu3D4TpU6/nnwozrdYao6wpQbafm7KmolqQsZnIo8WDUlG0CHfHRtuMpHT9WI/d0neZqpuzJU1dYiXVS5frd8qdoKXuV3ahKWk0dBekMuVSn07tjtn0wCksWuUWgFSf4dOv6U+jFJQnQ33WWUg8MaDfFynjHJdQf1uw6VXzdSo/A3I161xm55s5rFjM0yEz+v4W8UutUP5JZCev4Ar4jRVaRg6tSsapePpXkkbJL4FUOjA7JCs6R0tSUF5VKCll9bs8g8aqvlzq9zAG05EHbJdaCqcacsXUYDaVXybmo3O6QcSRVGm3mXgBSTpXoRKKHG/rt2ydeC0+n4g8o+sgGsi189nV7wHbYl8Wu0Y3gRSVQ/UdKrXF1X1TZ2VwRkO9DccWXzrr42w/hn4vX8VdotzPy16fj5faa0IqTj32Vg/5pUEk5ZpXY9BEGrF02wxOuN+CuQnl+zj4+d356O3yi9a66m5d9VFSBS1WZ0pnb1QPmJm+pP+gN4Zaa5U38Ola2Op9fy2X1J/KqPPB9+1RaTJZzE35KpTtUGUvnGapNXSOJL0VQKv67bmVd+3pmOH+XCr6tFaH0oqHWLvl5QVb4+/qrnwa/zb20GaE/enokf37lGkaRlBHWFnl+tutfHj54Lv089YR2v+Q6IfDImflxHBdSD+/LHr8Z/OQmvk59XuxdBTTmg3BoTvxPnOI31VOn59f5vSb0IO7+asGXadfJrCnxB45qWlM0Z+KViUeXHCd+q+r/+yYN6kaSSmoVfKZ2UUcr18vvkwzvUAQCTSZk3xcLfTWOeJghWaY9MmnLnU3fLmV/tTymb18uvlP3YSztSTs/Ajxs0rLt/AqD6g75eVpWcI7+zWQkxGo2ul19mJllLbhvVYxn4XXIxrjGAgLYm6NPvr0YZfWDIxq9InZZ03fxSN4X2RehwhWaiTHZ+rLOWPixqV5z0nevS3JlPWa8UxgI7f7ddf7Z180uFCq85m8a8svM3m4yE1+YqedpdwNQd1h0hn9OOv46Sjb/bXmnxpXzHb938tHaX+mhVGl0k8ac5WtMj0wpuWjXTBWV+sqjWGS71Ko1s9U+KrJ+fEMi9NhwNtf6q8DvDPll0lgA7dMljr20aW+B199ZObg6HGqeg7Rp2kxAQojpS1jYrlwoVgB9fwSkztZn0+Trb+KfuiaG2G0xWagbYdrlcqmJ4jVO7+lqkAwwu1SgUgN+uiUSYQLstG3/SQ1K1P91FnCiQPM7rkg62JK2H+zMc/y0Ef5V2coRLP0nYaIBAcyGc5LRPVjUGID08CmgfADRrMl5Qq1q7YDz+Ae2vFOhJafT58eddQkFLm8USTBk358NB/AXmsOGA6nOT4vMXV7b4t/i3+Lf4S1W2+Lf4t/i3+EtVtvi3+Lf4t/hLVbb4t/i3+Lf4S1W2+Lf4i8zPcQhZCyccp31MvCH4CypU4bIUn197NwUSjQFo+NN8ZyhPos4T54TqwsowMuRvN3jEmD/RTGNw2GI1mSSWspB+16y7xGpi2wVD/nTfGcqPKPO+OOTYbitjEY+HabdsZ7G9nJbf6SqMdK+BnxXek0VPmfgL9QfwLDnxA05vb01NdgPwtNpsfptts/B7yL9Y/8D1i+9juXh9IFYjrdXvCG1us8X6x1ZWvj/yzcpH/bFef1odvDD8mCA28PTc4tyoWcRiHp1bPPe0P4a3eHT79fb2r6zOLC0lEuXlexJLS5OrK2O9vZ6kHV8w/jJP7JN7c6OiWTQTieP/iea5e0/79Y1vi62cWkpEo+WqRBNL51dirUZR44Xhjz19Y0hm14poXnwaU8Fsse9nElp2RQWTR7AN5MovHGjIq7Dxe8rGrhnBSxq4dp3uBOFhZabcgJ5ooHzym1QFZObnOOGqO5+yjYnf0//+aDp6ooHRc/2EpX81YQwv2cCpMVuSD2Rpf044GNmWP4nszc4P4XzgWiZ6agIDHk9sZTJN2ysaWFrx59T+aAPw17w1kQUfa2Dio/4jRo6fJIlntlz4i97+nrKapxltX1HAXEbbV2W1V1sRbXT+sjI2fLN5NxM9+MBqjSYRbnB+T9n154yPLUB7gQ3N7ynrZ/B9LGe/w7KHTQHP/Iz8RY///deY6BUtsPEnFvyyC2xofk/sfUZwyUhENi+ITto8L0T7v8Xo/ENE8C82D4gqIWBD89cwWn98jyJsDgAe0MoU/4pa/3ieMlr/7ux1T7IBnPczxv+99fkUdwZ+T4w19uvIGA1ghYaAbPzWpvxKJv5PGJs/vvvVV3cr8l1OBpCNH+VZuLT8nppsvR5DGTrEaAAXbAzxj96gcnNEH/KDI3Ux9aGSDEOXyW/8Iy3p6NPwe8oujK4BHxSQUwrIbfwH4oEsVvIRWZGVfpLWYmChqWl5eblpsEcmBDciWzmuqUlINao07f+fCpKYduwDy9lDkpw9Cz9n42wOUL7kXwO/o+FgJ5GDy1K7ClPw6aqjiayfgnNxy50Q1/DP3oYmK7UYoYFshb0OHuDY+D2xRQ10Bv54uvbOFgnpUIAnp/E/TnA0AFrE7Z7Gn6wcmq53u+sPoAN4NAd+I0enW8qYkYi7voEawHJ9BI7Z1jM91TnFIbb278fmHz8GAr/xr7gx/yFD9ujslUez0XQqwOujtBeQ8/gn1+AGOODHz47RoDsCnMixF0O7m5BjG94aIbktss29TKy9J0JU4m4CK5lmtH+S/MVL4HAjsODF7mOggHgcOn4JqfLZUy6bQvSRF5zN6r2SBn+c4x5FZ2w52z+ijSnzAwlWRn0TaqoHwoibR1NEOQchs02DG0yR0Ag7SfyoZ5CzsvH3ngOvf5OHw71m8VN8Me8Q1siQ7A/YJY6NCN5D8WPwHxGwEfxvR/SkQKZRoCtRsIQkI4BVPwUQdzi6FFsb/yBBPECi+SBwuw8idKB+Gyw0gB7wtil6yp6GQRIjmySPqJ9WMkJ2/rJ7wP/fmF8wz1VjTxsZEu/f+PnnByTI33/w840Hx/7AofFfYQ+BT/exNdyH5fv7f6pCdGLD4Wj5oytXDmMNzGLy2fLo7KNE9McQ8iZoDbwW/nqV/6AbbN3BIdn8D2Dd1C8jdW4FpIhO9zaFn0sNf2naH8Lf0LzAQWYRrwXwmW6LIzi8ohEgvS3gE934DIE1/dN8fwSbyT/jx2Dh4Q1h+DTs7R22D38VPcPhQ7yz0XJO8D7iTpafgT3PNAe4cTCDt9fLj5bdhAr11JN456D87garmuchQrrxNrz+deOCypA/Bl2/uQ58Eq/4f5BTOXTjf3HAtVrRpaETEIhh08enkdXq/QWoyeV+if+V474SuJd5hK6cOn/+7vnDAewFcIro/ziQ1+tNnIFTIOuwQPiPrJOf44CLdGEo9hQi4YA2tFVuacdVsJEGbCDkGFZ+HP4nqhGCex2tRj6wsTvHgZqHFhdGeeJIlyawX4wfuo3zEnA9Hv0U9MH55sEroiTGf+6T2mH2Rx40N/6TQMOPFZ2M0gSwZv/HT25I8ANjV8yftDVWQIMDyYY+VQ+aGcQGgI9h5h8bFcVrwxw6LXiPBtBpaPb45Xe33+2fB9YPgenT2DtzR8OIC//9joDGf+zH0KAPOEE1aO0KCXrRH09fLot9AdHgcC1WhNcCbhKuBm8ikXF1PfwQ2nvqSczjJPN3Qxs5pFBH6gOO7g020uS4GqHHsPJ7xiDCn6tCaJ7jPuM4oOaG5uJ3Tpy4LHDCF3CaSxDvf/Ah79/n/orQw/sfX3Cg8b8NI6v33YEQh2ZprJ95Mnvl8bwF+MH1UGVvCHEfnP/+ONzEI+A/tSZ+TuLnoGWhVXvgxAcI/1US61+JbIsQbUyR7oEVIiToqAdbSKTTIPilb38S/oXjnFCNbtsRNzJ0Z4TswfEXsLXzN8T/4pH37GiQBPsesII3QF/vjd4C95f4Z8fxAVCVfwA2ceb8PI4E0cQX4D6HwTpOrdH/pfYflKzfKpn/NIn3gxHZBKYEkvtgJ0iDeBglstfBbP8e4De/JnCBLwTBgf4xjKDBaUS1opHfV5OwBuEfjRybGKQz2DjrwzdBH4fEuw6E6KOQqBdJHbY/wgkeJU4jHBgSdRAL8dbVtfITW4ZCl1gBJGjJ/Gl2F6YjUhCAeNCDywJcKlP+HsP+dLr4P3qaQ3++CVr0HvUhdOLPCAWq532QCCdip3H+++pT4BfPhTguUBUKhXy/fAY2cDZ+lyeJHwB/C+cL4XAw/vkg4mY/eJ3wz9YK+Nea4x+15Skc6l4ZxM1Pgh6YPyJpD0zgIK2BDyArTgyRpp6eHloXNrHHP8+EOGHn0AngR5f+DfLYH0C/H0+8DyHxhDhx952wFbSBuEuE/8NP7t69/nsI/+hMXPwohDHBv2dxIPz3z1+GtX+CmBf9I2n/6BKo4QzmX1P+4yT+vXsjNAkgdDVCEyJpf5xfejoj1EVIOYg7QkoBzMwP9Q8O/w8+AgXfuQjrb8LCA/FNaPgbD+Lxa68hLhCG9r9/Dkx7/L4oxh/8xQ6RMB6/WA23MP7o8MmqYZwIsOufrMNNfgpH0ZOPvnKQ8L/G+kfixxVNxG0lfXsCCU7OYWMggNO4HIYqgFR+ESJSXWAkxvZ/D8K/gO6PcYgXvwC1DkDtg7zYwG7gv44LRj7sw5f8zbxU7I7/BXi/jYvXLkulR8CCowSuGB7N4yZfukxnO+PwD6VwYgFPBlgrPwC+MoibmzYylEHcdIM8wkProUFS+ZF5DvXEAEgHgJHf86V4C8J/fEzgbg9BIBj5jzCiY03CcVrUjbwZhOLa+6uxQXrR8Tcgvf2L2Tw6UE0KRRR8DeFfuB/wOgcVT+KtYdJlhzWzV67MJsZs62h/3MsjuLTmw64w5Y5M45NZG2g+HLxKO0dYBqVOM3P7ez4auhngT4hjgZE7c9UCf+PoBahjAh/6uNuvkV5EaPTocegeXYoffWcYZxrve+cC3Jmz0Ak631+Nb2N8cgAMgvttNRr/YBiNH4aEtx1Cg/dfq9B4+eEr5ZOta+v/8bQ/Q+odEBr9cY6DOtddH7m6t56Gv8EGvGKQKqlJ6jQy85fVTAwM/HpIfKv/qDgRG/i1KL7f/+7loxf7Lxzt73/3+Ls3j4rmW+/M/27OLE5ctx2fn788evHChWui+dih6MxA73z76VPRU/3HT7/9m+2Xz3+w/fjbOCOswoo/fX/8+KQc/tfQ/pzQSZ35ADXmJjn6L79C4wINde7lZVjCJR+Ji3IBzGz/ZbZFOuwnimS+H57lMzdEVphH5+boXLCJiSGz+dUdO57MzDzZuePJkyf7d+7c+R2e6jQzs4Snu8xM7inHEwHhHykIlmaWonuWJsmHhTXxQ4N3kjGfTgf96sQBqAJxroOoD14eoeG+vrMJgh+E/SZEh40HYTlSP8Xe/h7PxZSBP1G7INJxUdH8Kh7iSBnpikrjYElbotL/EtL4Z+7jX0hoOIhFymXcFP5wFXMKy1N7cajb1jndZEVNV2F1A0ECDTg68W5T7PUPOMCoIXvqGFiaQb7MQqrf7M8/cn0CIvT0pPzdxfTCZXj+Uea5l37QVye7v1NlD+Pod3niLZbxb2uO+Lk+L+IyPP+BEphRAfjhtyjSh+BDjM0/2cry/MvKfbszn7IfpePHE/cXc38ANrSTsf2/YeLnuP0v5VN2pOWX+sC5CmMwgBRZw/D8FxWX3/MDowHsxgP/Cc0DgKxy5PsVlud/ReZnnQFgZuaWmn/1m2dHWOJfcfnLPLcyPvlUhXHil4y/5L+wMLbx7R97AKsCyBNgthmw5Ymbfo+fbf5bkfnLcskBzLH/SKt6/g3OD90gZgUwToGNss9/3QD8HlYFiIyzwKKrfub533nl37F/hzF/WZleAUwuIC6yTP8HWfXrzl40/h2Pxx8ytD8Wlo7AvRr/wlJWBUQTR3T4ReT/+uHjr79m4/d8OZpxCozZPHoRbNo/NpNNAUsLrWUbhH//4/ce72DjL/OMLWbgF82LMfKdDn/rs0w+EC0/ZfMnnzlr/b8jT/LStw+/fmknW/vDz8UJ0VgDonniood8+Q328m8/n+H7bwutHk9O3//C0wryK2ztj2+05uKEWZQGftQJ70D/pfZ7nbbWhfMJg3lP0cTk27ZWg9Nmmf+c5xmgGfr/BkZw655GBSKB/+FW8jegW/03n00mNNN+YDExubrgbzX6JnjW+a86fqO/oJK0Od2uRvvkwE8t3NM79uUPi6NE5hbvfTlm9J1mj9/mv3nk1ORSgsrkqWcAb9D22fnzLRnmv6YxAfJ9yJpYrCxWk+LLmp1srX6/bfvNhYWb221+f6s/3Rkz86vvFs2nCG1r+vsX2cUD6LYsJ8vE3+UsjOzLEz+LZOIv2t8/KaD4e9PwF+nv3wD/y9sLKsn8++jrSAKhqsJJSH0hCcc5Ciu8JsO5gL1P95aWwkvh/wCWKo1g+/Y0b48pmBh8oSRvgvSzsfHLrYLS66yLJFwh+ZPLW/xqQ1/yywZLR6rwC6qE5Lewlo4ESdMnv4W0dKSDlPy1BfvDPxtNnORN9sFSDQAB6XXEyW8bLRVpkxq+T/9WyZKRbqnyC+reU1gyElLeC6i8kbCkpEJ5y7hd+1rfUpGAmvd5E0kEpSW1Jqey3F56EaBKW/YJyW8i3/ziUrwfi6XUaoC2pF6PS33PcSlIwKR/ly9eUUK9AKHFtCtp2m7QVORxsEJKnfa1zpK0l04S7DDs8teVypsw2rXvZdeIqzQsoD059slidZVCDKhIh4+ICzRv7jQYaMzYxmAbzs1cCEGWyxzk8A61m9UEAs0m074sg90BCAKbMwwK+BFvRfa2hb6Aqatys9lAANM7w9l3lBRlqmDa98UQa7AZIzGPcvF0NkSdZTM8GfJZ+kzEpHP4oh4Ewj46U8HZ11HZZnkxpc1e6+qiGHW5W7MQrC3YfJC8irN9za4s+IL2upZiA6xZuivagllc+P8BCS0BGxQPyBQAAAAASUVORK5CYII=', false, 'ASSOCIATE', 'Visa / MasterCard', '2022-01-15 18:04:18.725661', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.725661', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CINETPAY');
     </sql>
     <sql>
-      INSERT INTO public.billing_payment_method (id, guid, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, '439804fe-55ac-40be-9601-329a016b2872', NULL, false, NULL, 1, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAjVBMVEX///8BAQEAAAD5+fn29vb6+vrz8/MZGRkREREjIyPw8PDr6+sbGxtAQEAUFBQmJiYJCQnPz8/i4uJCQkI0NDQ8PDzJycnc3NzW1tapqak2NjZlZWUqKirn5+efn5+Ghoa6urpwcHCBgYFZWVmTk5Ozs7OXl5dLS0t4eHi/v79eXl6hoaFsbGxJSUmLi4tgD4zdAAAgAElEQVR4nO1daXvquq4GZ4AwhrnQtIXSAp34/z/v2pLlOQMp3efDXTrnWbtAEue1ZU2W7E7nH/2jf/SP/ncUx//T5qM/bz4ZDv+6iUoaPv1xA0k8SP64iUqKB9HfNpBEUfS/RBjzF/jbFtIkbjcRYk7Rr6dw1EnjVj0cx/zGuL5zkjRNklZDmCYR/3+U/A5izJ+RtBnDmA8Mb7y2eX5JkvL/tWmBvxfv/HoGWA+qnsIbj9s0L1ibv0Jd8wkf5oh3Y9quBfmSlW2kB/Zd+iMfBM7pLZrXrFPDRHEsBjG6XZZi1+FtcdUbbhmnWcmPwD5JcrssNXu1qnmOLo07bbiEvxe/m8NM3PZselgw1u2yZdlTRPNR2gJgIkZHNV8GUQCEUby1AZyDcFusPwcuexX4OLHn0M9RlHa4nAs2P3uvaj5q1Dx0An98fPsIggJL5J+yzcBl70wC7DIWMJr4AAph6N8a7w/8zvK3SsQMkfIfbw4rVCFo+TC30WfA1vKhcQce47/P/EcB5BA/vd/TmPOnP0E2J3Efp3V5+wKhfG0hz6MSfSq0ZdJKUGMTCCoRXZT4XJK8Ej74D2MfbvN8hkTODI4+LgAObruUNx/rMUxE7waZVLwY/3/aFmFCE0F0n88ke41vmQPEifuS3FYUVpH6Zr49M3PUs4rmRXsx/iXmS5ANU/FucVuTC+9L+f1pCOD8qPCxq9AX4q836wHA3WoORrNrxkx84oZ5efMRNR+XAgQ5yq2lm0cQZZzqmTgAMHkjRmPsKF5zxzxhI5uHxzxtH2108u6g/O2YzcP7h1k0FTyatGDROWPbDvI4PCjQwsdUDWBvD9/McCoe9RsKBk2EGkwe3hYOOk5TuP5c+haya6DpMMBBFMWt1MRTztv/6oD8glf1Whh+6gF8oZ8utrARzM2ZtDPYf488eN3P9+EA+brcnI2Qb0pZdMBb6EAbN9JwAl18UhAjNwDxLN+Y/7vQ8yjF73rYYJoKe33zvLB4Ez5kLzN4HvL1vvxNqPkwQCFf+Djfbu2mIzk6V2ojtufgLNMDaNkk7/jtFV6O23uzS8+VK4ydv1SfXAFhucFOzZe4ffxHPgduFzJRRq/EXvExkQVw8K1NmIszOxZMicf59rPIRqvcHr3Lh3nHA6vRF8CopfamULVtABYGSwl1nNgT+VmrwPGDe/NGCpvZS8b4XJ6Oc6bh/Zw27vU4Eb3HWO9ToeviNmGDZCUnGL7Xwfl5ttQqcBu4/ZWp4epnDEcQPh32IYFygN/fAr80o+h2nz45y1csJNBH89f0Ww/gITjBo1z1D4fIPwh042vZKMHEZatb3/I39CkBfnV+JESt3sDL7eXAWLuyd97L0aex635uK4K0Ul/8dRzVoEcJS9gZRwn2LGWD8HL5VyOhK8vtkI5gAtbtA7zly7rG6x1De1VO4n3pIAGe4JO0OtlCvGWKTgRnuz77rgqdP4nrOH/m5y9PsPh0ggYf6y+8D12QZ1CfdWhEu2wXd95zNQGnRjQmJGxeuEbvoknk0Pri+lZcX0CTfxwqJpKxCNCCSAeJanXWKvCkb9iMjWsVJQIgv9CW8YOtsPOO3tWIsCyEdV96kSxqKoiLsl3kf46aQSPxowmY6AMfZDxn9laA1AlAQVv26n79F/QmWdS2oa6WwdwzuAyjM7xDfI10xK5CcTuEaAzxeOFeDd3B+vdGE6AvKUfcSX9SEC3ndv6j+La/JTduu8L3f8JBXPJpdrKdJv/5MfZTuRt8L9qS9vNG5Jm6/6y1VvTC8q5Gzo5vX19vXPRSH5yQqY+204QXfzo22A80HBJZd6V3CfAcMIK2chL2lJLfC203yg2IinAsksKcvg7E0d56/FeNG3wf+pBzcBG0cd/JF0QxgdEZ1u3lzH15NpHCch3Api8rTg+DwWCDk3qObf8HAIVSKPG2SaiI2KaKznSZD5GrCSmLHssRqjHvIsOAs+ZFIe9KawlgWRpO+CCH/mM9UhIGDDjrxYWiz1F5DysGUaFEmwfUcFXY9Nf0IAFmFbbYWilEy2E3R5E/ADSeVG3P1QjhDrRuIYDlxlnvSRupJiaVBv6MINrv2OuqEcXImY4mFrUQ2Q4u/Gt98SRHMC9pgQToJiQXu2ykIKrg4oL6pBah7IxPMOcDxtG9AEIUOic/4HI0reD0rFZO5iUQpcs7VfOTfKFDPcQ9XMgFWX8SMFnvQhA3FBDJXuRWWr5XPwshqoJ98zyo3no5w2eor3LUOWmNsFEGzpMAyNjtQcEGNMhQxqiBegNhMX3Zz4fz/UsPrWXyT59GoXcGiJn1jXQ4tnUQSQueoZ195/6ULrWeA3omxadUFrwHmVTDaYhRudLIupaIpeDZshbhjJq1fZF7UbyTePbyi61WBtCr6m+CmBb+sPArC1v1M/aDlz/UDiKqlhkTXNq/e8JWskA1objwveyFdFwmXrnX8AdkrnWjHnmpQ4ipDUk/n/DnVIZN29DZ4cGPKluSHKdk4UGcdg2lQRBRbNQJG9IX3yBr7q0vjpJFaXhmIU9Av8qL7hjbVJsCQ9sQGRlhpWxB173TZRzi+N4AUaRQ/GBmCvzQu1z0nVoxkKJnDqMq9fNThVBFFFIGEO+a/foNc7BrAGTVEI0lIr0yQ6Za1zTg8CNaZEFTSF806ctkkx8wa+4ZNr1IY5RCZQ+M1UFkOpPkoiOLBliHUWU08bWC9ft9UlQn4Kg7hk3RYckV523IvaiGeLTu54Ayi2EtZ4qWduN+qYDuCwH6Il9AfNO7W9j0CqaK5rt5n8akhlHPxhMY+IPmr7bXT0/flzySTSaiV6d41X3Dpm9yBIgphj1tNddAXJBWvnoAu47Xr973HHyiYNGu9powbBqIL7chGTfMiecGJq/VMeqK7ONTAKDt9dPa7lPQmhUsCn+gOv4AhMVdAMrEnom0rDqxZU/XQiwG5nO8n3vmqrZUtdeApUcAVXLK/dzgdzA42UilgjrWdC2jjqogWkpDufvuYIOaUBeheAFeDi3n3EoybtiTE7yT7DwrrA5iTuGOgAyxlQbpF9celHNQfviQ/dXtdu/gBq9lqDOjwOhP4C3rGFXxUsCStZSGcsuO9kRQLAof0WvCcBFrmYCnaIZqojcieXEMQWkOcR2wZc25SAsxVmzRBqgEUg8Q/jJsinG77mhCBuBjGElAEVg/j5SjMyvz+ulP6S+8mUEO2wagsOn1DvoC11vzUZ+G4FDqEHbdcDZ9D5aMoZsDTq5tgcuFDFOeuRMfPTOcQPlvAMpsnj5TYbVyXiwbW/ESGfgka/3UAKPqP/2FDE+wYvgxwon4CzdYmmb6Ga+1sTD3VXJMNcHH0IwJRRlNsLULGaRU4IqqLI/OsDIcN+w5AF9uBsh6fdP62dOTJ5UQ+wFh41yCXhPqi0U5hHRYJWljyjekCfR2O8Dl0hb6FP4YBKOM6jIZHShfyJA2+hOyaenyUFXBSJSkI+kfGXHDFgAL2z8ijjJCcGYYkr7ZoNWyK2uR5TjMEHws1RcimbrMu4qT5Ke/XPbtuOGtANmuWNoBUB07iigEx8bn83lcmDCFDyNy0ZOgZsHnIGOhvigLm8ZJaVVQ3Il3edGbrPr1ccNygMtVf+WGEnWUJ5K2Edlp8ez9BYsO2GTFtiJdP+mULmRIfSGzh8Ig4jTqlAFMIqxO6U9p4pQ5pVUAl9mKrZYeRArBJUcZkTIW5NOPS87yVY6VP3FCwsZPX0CvKQFhGNQXVdnAnEWPcg5+yRKbqsBoCcDRopstitxbE/RDcNpJhjfbHwQesFRi9Ez5FY9ebjQa86gvAtmmkag3iNNgKi0H+MjySQ6ZIFhMWJVFUAJwmmXj1WRJyxwWqXlDWXArQx7w9uYHWs+OO3IZYZhsTksTo5w+e0Doh01jUeEbhachcH+xWCwK4CdR3lYZ+Q0DXC7HvWyVE6ZJsTgej+cdlr/oCNm3ZFSdD4DldE+vU+TdhJKkxYfNq7FKgpZPSXUCHyVRdBBUFpxxL5zDxuPx8lX2acjKqgFYFGw1nk6FhBy/7DdGT85np08jCeciIU6H1HyEtW8PP1IEvDDDg4ifu2pmqrBp18s2FbV3olA6OAkjYZotOcLlFasuksoIbRjgqM92Wb4SefZBlfvwdiTQMl7B+ggxxmIJQSeYadFA9gHd+8XkF6inwSpwwqZi+okq6RJ1/8bFNUe4fOlAAVk8b8GiuzHXpPlxH24BSPGVzIKTLgUWvMkXjVI+myj5SuUipujfSK9JusHmaAkWjctr5a9ZLuTg8tLB2qBkkN0KMCtExv13g3RfICkupWzRJZKRLDqX8Rgj5LTOwS3HD5g9ZBRdYvFpVFaq/sxWorH+gQBGNZ5AYAQnrJctHpoHoykFUKg13CYixmplubWJFDY/+o74U0A0w6ZqnasTpaIEnf9b1piYPSIVXdYPiutOtyEsxqz46NxStkGJftwUk1WB/AWN+sFX7AFTnJzUIh+GTXfqF5h/pSa3SKRYjTAdT9cPxs0HEZXB6/AmgMokFNIjkiKIWBReAGPdE/Ot97Qm4mUPRaJ+sQTgHuyGVb6TAo1aqE9zUQCzbCRcpFv3KaCSC64U5Pyxqvv2pmyRtCbxgunFqFu4ok/52AxKAK7JTgTBnegW9g0RQsRt8oDjfxupLLh3CdEurzsG4hUzP2wqVCBWMQeJ8tB6Q3i2MdJNZQ0HWByHNw+g1TqHCA3bM2nOAt78x6P+DcwaLjyitHzfJ2pimgpOTszNCBoiFEP4KZyWFgBVCA6qLtKOa49cEYad+fyO1xTkBqf8naOwsQ2XG7aCKJU1pH3jMZwsk7RFjTTShiDm14FfAYpuUjDP6wV+ukBVZ1yy1QQQpf0Kr97ebqA+Z1COYTHoRHVzMBqWhVUoC46xgDv0gT+F3Pk1IOxB4V31hi3GbLepoULkPg63syo1/f4gvIv8+BzMTH1S62ds4Q2WrMgIrfkiB2+EEVum6CWp2e4k+tclm9FrrdWODWF6H2kf8Qhy8cHuzMFIQZy464Lo7gdXRNENhirrumUaNdutIOua9RpMxMr6O0HJI810pO+BmOD28l+qQgLgxCd747cThR08EkWXXI/XgEOaE0QznWrH+qMGCOsW8hb07J/r8wVia2JMHXaJxwriNJ7tLKaclgmbIWYPVew5ZdATReC1KSsc63qItVWdn3IAj+hzrMH+9QtfIpWlIKpurW6TFsnRz4PKIMlt3whhZ0iRbmUiLSDAV8OotTy6lbEtbXm9MbcmDEiUFasAm90Bj8p6degNcjGbZptSnoW+AfLZJpWjyCbTqmeKNLTRhFlVYAkMYihcfVTixhmtoaHPLKoKmwYolqLTjBeJMEMFRC6K3EYdeoPQhlH5KbIBHsntdYhWYT0e/iJ96Y4iImycPQR5suKOTzNeJCCWYGS9vGTLLkViTvFRVIIw+RFx02du6IX0p1yHZX1XquwI4sC9odu9qeiSMmWtrLTSuSiW0GpyBNE6HmlpdMRp88Os2h6lTKkQderwKS1kuBl7GDat62aTVNm5mbJVwqiwRljzPHwDvU/ApxQyG2a7RFsaUblUySYORCozdjhyKOPGN0CkbQRU8d2pDCIAfKl8mNrBhFYoHlVQ+DG3FMJmSRDfyDqwbRtKkoaojcGqwbBpNcmcV7ajqQD7y/iMCgBrU68kQgnmoPl/5gxisTO6tKtDcIq2NIjb69LgnFDYtI4OqJZYRhC/QhAFwJrNVDyEF6bjZgNHq3/pAP+X1KAOxJ1SlqZIvVFfIL3KR6mp8C4lqguwgRCTCAEYn9IrbZ9PbQhcJBXUnooy4pxLDCzw/ePWYNOpGzZtQrLsnOXU5F7OReYArFdE0rvLEphgU0NDcOVr7brHeaRntqfVXyS140WKCHtmYMSxTh64ZAfcO2gZGoyKAJswx1w+aCCmc2GupcFuLYZJe2FdKwsOIYLpI1McE2vdoqMuhS68EaEMuHc1H81gLkpGlQCb6CEZcmUbwXmmGhfZFFaU8J2Z7VE1LkjJ8YEuATR2tlfboktnKsgMfZyLBLBRZpk0Rriizy2lJcSJVc87t+OGM3qBrdAx8i2gNqnvoDHDprcQVd0rnnggA04BbPTYbyUB7fcqXJdAuvJuFpyAeCGLYY7+4I91Ixbpt8g23ZNjTl7ARs7Fns7ZbWDxPhNCW/S/+w5U5rhIG3qB7Yty8F+wwNJS8DJ7qEW2qYpP7eUXc6Hi+4WRlNyA+dfyIXZnJH1/99IV9YXKgsOi2i4UriKLR9MebCdlwcG96tpkm86oE6nLhhziaDTSCBuYg5HsJ/sFLgGu+lTeoWpvImeKtlr2TBgatgBAfdGqSP9B8Yn8YjDK+1pphCInT16Gi3RXrEDoPpR0d9E9pwpRjd5USdKwrZTJ87N2+gJITQVy76KdqTT8DY1Sv6jsalg1RB/e1jMdGcGWD6b2BroabITfzLFAyOohFTZtQRTWVyG4ZKUNOH/n4jjzYiZzDPbSC1aQRmiE/OIdc766Qva+JcZ12LQFzSdyFMkCTX6U1++NYbT0CnSHfZJXtXP21bB77fbkV9IYnYgKDDlDsDXcq67tpi7DTEI0U7ZwLrrzMBp76wKihh+zMOs1i7UcawgTLERlSvpyGS8gArNgcy3cYJMGSzkICuKjtG7cSCl/FYcXRfhue7ClVSk51Q52FhzowQ/1WXwSXSazvlbMFME3U4wpaj2rMBStG2tyGzsjSeJcy7+BIEGv3sKzs2ZZ1+pSEC+y9AMi3X3IUZCc8Qad2L5IX+S8gkdvFoYCo5pWvthizWZFwbUvaET3csfUCpAbKLGy4EAcsB1ORdFnnFGfuTmDXhPqi18U6Uc/6NFbITgB0Qh375nHtmfk7CHuh1GnrwLp67pLX6W8kk5yxqAeKv0grXFj2DRAXs7ri+CU3OQLQGhGM89kW0NdTK0vGcii82ptOaNCH4K72meHK4mXw2/0hQmxy8bECWLxITfX9L6cMTwqLps2EnVbP5rHbxobUU34BqvhhAbknNsnAYZBy98VXVIIbmmF4EwLWPCxnpiPetrKDYNrbI5gGQljS2rCclJQP0yUbEhbusEWUTTaLAy17Ol306c14oZoUtfW8JSsHGiIKkXsgfCC0sAebxE29Ymi0SMjBGcZ9CLhXjKVGTdshrBkbxPOiBl1qUoRExIFCy64uMFOPrV1gy2iqdA3CkPN34UHjpOdd8ZYW3RFEy59KwHIR6lH7Zl5MTLKMVFF+qxRZKyGvBDchy2gv+Ta0JsxfTqS/+okTS84DaHAUicvmHEHGVukxS8surwxbOrTsxuCW9vh9EfQJ7wjCsNi3TdxLjwmhTHpyphe1wvB7TGVXb9LiyL9YA6VNduhScv4TgrOp1tnw7pdKAbo0rcLMMd9pAluIARH7/JF2G9k0yR8PJ81230awqpC3wRICy2VknzgDCFYTNZnM6rZRSd5bPrWGJi9YS/sJC1JNFQJoWGWf+oze8ZRT1dt+e8VOHI2z9xvvBDcs9zcVRpSNxbpizy8ymTUbkmOh5go7KzEZnygqyuDfQMXznTFuu6oku59okeeUP7KF7mxSD+uOJ3NC8FZAKeZcKuOaz6Ow9krc+dtmC4OwMmCTd2MM6MQlV7gFdP1UQnDMkHOxFE59bn0SSwOfCm9zgvBGeB37CG69HZdyvByZlHpAy0svXy38vZvMBh1OJIvIDMzUYhxZzRf5ftOg8MJk7rj+VRCqJMsFPGOX3eSzkcxzRU+/p9djb24s4VKsVr1d25xnxWIUXEHeQfMiisHOOFWVkXJhQYIR2FUZPzOaRRtfyV5kltcJ+9HpqhXF794cwDuoHrKre6zBFhqFXCil7hmHCCq3RqIcC5YzemATwTRDFvEePgZPmTzdp72+9niWncegL3XAn9utsrGq9XE25bXWgSNrU06QCSkKzjy5qEOouDPtP54vuFE8qBuF9KQ00ieUiJub5QWPehbAKfj6WgxYpm/tbKt6iJzLzgR14whnFNkqC+iqIwFE5H0ng46tSs5FI1W7oV/OmCzsMnY4tFi11+MskXfn4Xe1rpmbI4LmyR65zJ4sfpGLioVN+J4PlFkWi9wcTPMLq2S4emA5vF8DYR2R6/HSBYt2HK5Kkb+VhsBk+HTHMRNxLXIbjEeF2nl6YB4Sm6zo9fisYT4qRDq0wGTpNm5Nd8Wr0359CtY4cvRbjDtw1CjsEH8z0rUh64TOL4vjFCwaNTw3TpOFlyspAxUU4eP53Pp0RrBYsdVPZc0IWc4hPCsdQbYH9eCj+HqBdRdyQmaUGQ6aF7aY2bBQX041vXEZWefBe5nGmCesWzJHb7gfjeB9UECiF7FcsAthwWnHZwJFD4dUGjCuLZuwiTKcF7QWWSxrElpcpDpk12jPVpMuEbLfGMGf/YCaZSB9wyxxVHGuyCfLHcF6Itw/4pzauMbK1+o7Hyp7djyAxZtskv9hWkwnixXq5Idi7zM0m8J8A23wOajPxPxLz6Zv8rOlktFfeLg1mNqD3IUi6HcqKH0eD6b4out6Hv9Phf2k8DWvHSJbSJSLbjQx8L+YLtsBVGO5fgzPIJcVaetTgd8lU1lT3IWNgL44e5tN+mNemxSwqJ4jflUygDD2XkS0egddw75ZF6Ml0E3WBxv2ep0QArBQbELVNfV1690Nu7mtFmeTSDlvRSgrRGpW2lZAdb6dv30LBAGF/LwvOC0WWmGSyrndSMYtf605NnRQcL6vdFC6IkKfOIyZQRTXFOt3ICwYcVly/JxP+gGRygDWy5PqSy4B3Ees9D85f7gYJt5I8W6o3y8LMqEjBppc6/0ru3Qw0IGm27ZShh8gVmSiMK/cp+3jowsOLTV1uxtFnjafHtkAU6E7VuLoKI3AVIYgzrUXLiX22Scx5AVGoohRYOb9KBLXhaciBf9vG0f5uiExU+b/fN3n4XwiRu5sq8QMl0ZIjXb6rIf632/ZCC1PHLZ4rR4k7wQ3Fw5wFkxHdFeJ6UA8sqd+zBA6rTkrBLIJEj4p132UA2pQlRrbzbt6VcLkW7JBTokbOyVjg251UiGI902e6iGvEJUsSFvg/rFSgXRdSNCan9JX2CansYd9jYNkFeIOiisHaBLQOQVm9QxNgI1oPSEHijfEjeCrn91JJRZdg6U8rkROATCBjiq/BmP3HnRLSiEvjTR26790REfgUJUcTzCtJoNR3VKMGPOVuLyBy8/1dxJ+s+OhFIBdyMrrQoiH8EGIkhtJW6Zsn4W/UzHXf/uSKghbZppZqWVQhQAq/GJi9RW4o4t69jXqR0Q+SuEFIIzVvg/S+3NZgBJZjrbZjInrKHOTJFs9Cf6AiilgLvyBB5LJKoQMnUIdUbHwNtp2/SmZiu1hjCBfPE/OxKqA1lwcFaEFgUH2Gy3DcCuqoNMly7AR82l6UWvkRxSzDa98xEfFsmjng2dfAmMYo2akBfRnnzRjzMJp4Zx/a6XaIqZyjb97V7YlRBVFhzx0dWD2GwEKaMjWVjHYHELQBvRyptmZPkgm+7/EKFRiKoLQ7uWRG2gJoRBQx65yEXKNBDzDFC9CMs+h6qxbt2y+q/JOP8Y6dlSGs1YdEIA8ZwbSsc2R2evJWhP8S0e8fHHJ112DrJjzSw4XVnQSE2oSjDiCOvMREFzddyStcwn9zb965ORVQjOyIKTo1hrquE7Eyt+q2HiEM96OTm5Mg3QyhO4uUi/Hcn2reMRMNO0wRzs6vwbHVe1j5b9mBhcb5eQYtFlxV7Yd6ITZWgZhaGw0VATFlU2yYseJ/aqdfyTeYSCGw+XQZvm2UNt6VlHGZHWAmIjIeNvJc4Fs2GInayYgFesjtlDf34yst64xcxKm/aazEGSiyetIoz3XTuxf8+lx6LLgH91d3LOPxYubL/W6w/EDbkhr/lw6J5D4afr3OmIjya0d6OMc0NplALcy4tVJuTSEJXP3gGggYwrb2/Tv6MPV03Pa7z+rnfGorUH1qzwT0UJIHyFVm8t0m9HfghuUgnRD4xONbMNvkHp2xBZIGZxzyOhakkl+qnjO7MKiHrAqGtGGuCWHpVZqiJ03iNOxD87GdmmDTGqCsEtS+eiFzdkPSViHsZac2RKBHFH8T2QQd62SL8dYfQ775nHI4QlKnPjhnr3kfjVUIHy6GUugq6BBaDB/lsmL9ZWk92LRJm78Af1CaVndcKQGfL34ob6fOx3O3ou6jbZeesPXjJ//jHSItstiLagpxEbARjjhFI8QFk4fhmjjBFa0lWBV2nGbH6YM/Oml7Wv7eL165RZQ/1XYVOfhpQiZhSGCmDT04Z38+DhCotTZHw99eXVqAWiF5arQ8sFLU6BSNrT9tNeARIf/ixs6tOA9oIzjkcYGZIgOenQlUoBRlNlnzO9AwB/6ZBgWV939vqW+DQ+3f3U4CqKaVMIXRiaWbPkgQCm1gYZT2dcnoF3Lt4Cbm36fvAHjx1CHfHHtHBDcGGzMaKYMswhcX57DwGeQ+/8cFr5g1dc/9q/LyEKwVW6pkkhrxIAP3KG/jJjE19oDD4OE3/wPgMS9j8jgriqWFBfyGu4kfcksuZy3L726t6y+QKtoPUqqMfL+u5Hkt9GKgRXurxnHAAu6nC7ORwzc7TNr/jjRWoYCRE+HL/+IyOtkqgQdVmiimmUnztr0Gx5T8Sz7Q13LK0grZvRZf+fKfcaepUQi+BkeSSA6SOAABZ91RIpmV3HltyED6vTg8eb/0NmVbW2gTjRQQK8yvCHYNGx0mnp+2PuC5ag3d1JSvcOvx8lZcfzUcpW7s0amUzBdj9awZNN8HBa+EqvXCtUH513H0qfytrwQnCSXvXcov9eMJ9zf7HRAbzHbXm0sOSwoLtSXJFjqhxZy6iifMOucjogOrN5Pvvoeq+VIRg8CqKMGmWg15JIGC9vI1SIqlI4SQ0IBl2/jvyZd/6qWcFO4qSigyEL8xdZiuoxVYMYKESVrJuvVsteseSmymUjq+gvj/gAAAKHSURBVMMseJPDR22mTCoO0ym9KhYHConj+X4FMY4GpcfzIX0Qo0pbbEsAe2y0nPZWvR9bsMCH8dumwfQSFQflqbIRzdBfQRRMEkfVfLAmiKDN3wngBJkU/rAH7/u9mfyHip+So/NkUYh6y+aQ3DbSyhNDkMwQ3N4CSIOpB28ZTMcNNy7OckrLSnxh+kVpoj+0oRhPtSmtjiN6INGyXWtUTHjzoOzHPSl0jtsbzM1UHlYS5tGUj6AoHJXFoy2zvul4vvr+UWXnxgj2VosxuE+sKxK22ev6phQ8Uf3aiQclVXNQL6iOXOo0ra5zKI3geL5GvaMKUeEfATAXhxMupgxV+vOtvkIsCkPLq36AdW+vH3TaiKFwqmHK+FAvsnARynFNAaEIuTTQCh6JE7vE4YBl720gFEUhrZRiJIrck+ZSSp9/jMe+FYvxalk8CnMzuVnUpWBlVDSeqCpXPPanxTSMoW7tFjGcqmJKthTmSzF+FYOXNKsNsxvnQ8gxlp1L1pGqIoFTz/TZcjcRnEnUqMLWeC8qAxYHk2CMPpKHE95I8ui8ivvoYDc4cLgNQNFG1EiKWs2eUa6wb/AVImkq3Nq8kJJwTG5VU6TBWgJs0kbwviPE6Aekw5I2LDoYDER9bwWLCiJDoN0cTGUbLbrmGXyFJHQ6YNPG+ahwLVxbNIf936YFPFpTtPELczZSpwPe+hAxsZpVoAPEpGJXk8o2Ko7na0YIMa7f7cBrXRwN2Kz6lV+atIoApKKKv+botSbNV+qzivuSeNBw5G8oxrfb4NS0jQoC77TFbUJNNW28qcHl3jYo34jipue0MoY7txdo305RWnM839/SfaJL1dSu8//RP/pH/y/o/wCA063XByrVYwAAAABJRU5ErkJggg==', true, 'CASH', 'Espèces Test', '2022-01-15 18:04:18.684927', 2, '2022-01-15 18:04:18.684927', 2, 2, 'CASH_TEST');
-      INSERT INTO public.billing_payment_method (id, guid, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, 'bbd4d845-cf02-4b27-84b4-e187d6facb7f', NULL, false, NULL, 1, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAjVBMVEX///8BAQEAAAD5+fn29vb6+vrz8/MZGRkREREjIyPw8PDr6+sbGxtAQEAUFBQmJiYJCQnPz8/i4uJCQkI0NDQ8PDzJycnc3NzW1tapqak2NjZlZWUqKirn5+efn5+Ghoa6urpwcHCBgYFZWVmTk5Ozs7OXl5dLS0t4eHi/v79eXl6hoaFsbGxJSUmLi4tgD4zdAAAgAElEQVR4nO1daXvquq4GZ4AwhrnQtIXSAp34/z/v2pLlOQMp3efDXTrnWbtAEue1ZU2W7E7nH/2jf/SP/ncUx//T5qM/bz4ZDv+6iUoaPv1xA0k8SP64iUqKB9HfNpBEUfS/RBjzF/jbFtIkbjcRYk7Rr6dw1EnjVj0cx/zGuL5zkjRNklZDmCYR/3+U/A5izJ+RtBnDmA8Mb7y2eX5JkvL/tWmBvxfv/HoGWA+qnsIbj9s0L1ibv0Jd8wkf5oh3Y9quBfmSlW2kB/Zd+iMfBM7pLZrXrFPDRHEsBjG6XZZi1+FtcdUbbhmnWcmPwD5JcrssNXu1qnmOLo07bbiEvxe/m8NM3PZselgw1u2yZdlTRPNR2gJgIkZHNV8GUQCEUby1AZyDcFusPwcuexX4OLHn0M9RlHa4nAs2P3uvaj5q1Dx0An98fPsIggJL5J+yzcBl70wC7DIWMJr4AAph6N8a7w/8zvK3SsQMkfIfbw4rVCFo+TC30WfA1vKhcQce47/P/EcB5BA/vd/TmPOnP0E2J3Efp3V5+wKhfG0hz6MSfSq0ZdJKUGMTCCoRXZT4XJK8Ej74D2MfbvN8hkTODI4+LgAObruUNx/rMUxE7waZVLwY/3/aFmFCE0F0n88ke41vmQPEifuS3FYUVpH6Zr49M3PUs4rmRXsx/iXmS5ANU/FucVuTC+9L+f1pCOD8qPCxq9AX4q836wHA3WoORrNrxkx84oZ5efMRNR+XAgQ5yq2lm0cQZZzqmTgAMHkjRmPsKF5zxzxhI5uHxzxtH2108u6g/O2YzcP7h1k0FTyatGDROWPbDvI4PCjQwsdUDWBvD9/McCoe9RsKBk2EGkwe3hYOOk5TuP5c+haya6DpMMBBFMWt1MRTztv/6oD8glf1Whh+6gF8oZ8utrARzM2ZtDPYf488eN3P9+EA+brcnI2Qb0pZdMBb6EAbN9JwAl18UhAjNwDxLN+Y/7vQ8yjF73rYYJoKe33zvLB4Ez5kLzN4HvL1vvxNqPkwQCFf+Djfbu2mIzk6V2ojtufgLNMDaNkk7/jtFV6O23uzS8+VK4ydv1SfXAFhucFOzZe4ffxHPgduFzJRRq/EXvExkQVw8K1NmIszOxZMicf59rPIRqvcHr3Lh3nHA6vRF8CopfamULVtABYGSwl1nNgT+VmrwPGDe/NGCpvZS8b4XJ6Oc6bh/Zw27vU4Eb3HWO9ToeviNmGDZCUnGL7Xwfl5ttQqcBu4/ZWp4epnDEcQPh32IYFygN/fAr80o+h2nz45y1csJNBH89f0Ww/gITjBo1z1D4fIPwh042vZKMHEZatb3/I39CkBfnV+JESt3sDL7eXAWLuyd97L0aex635uK4K0Ul/8dRzVoEcJS9gZRwn2LGWD8HL5VyOhK8vtkI5gAtbtA7zly7rG6x1De1VO4n3pIAGe4JO0OtlCvGWKTgRnuz77rgqdP4nrOH/m5y9PsPh0ggYf6y+8D12QZ1CfdWhEu2wXd95zNQGnRjQmJGxeuEbvoknk0Pri+lZcX0CTfxwqJpKxCNCCSAeJanXWKvCkb9iMjWsVJQIgv9CW8YOtsPOO3tWIsCyEdV96kSxqKoiLsl3kf46aQSPxowmY6AMfZDxn9laA1AlAQVv26n79F/QmWdS2oa6WwdwzuAyjM7xDfI10xK5CcTuEaAzxeOFeDd3B+vdGE6AvKUfcSX9SEC3ndv6j+La/JTduu8L3f8JBXPJpdrKdJv/5MfZTuRt8L9qS9vNG5Jm6/6y1VvTC8q5Gzo5vX19vXPRSH5yQqY+204QXfzo22A80HBJZd6V3CfAcMIK2chL2lJLfC203yg2IinAsksKcvg7E0d56/FeNG3wf+pBzcBG0cd/JF0QxgdEZ1u3lzH15NpHCch3Api8rTg+DwWCDk3qObf8HAIVSKPG2SaiI2KaKznSZD5GrCSmLHssRqjHvIsOAs+ZFIe9KawlgWRpO+CCH/mM9UhIGDDjrxYWiz1F5DysGUaFEmwfUcFXY9Nf0IAFmFbbYWilEy2E3R5E/ADSeVG3P1QjhDrRuIYDlxlnvSRupJiaVBv6MINrv2OuqEcXImY4mFrUQ2Q4u/Gt98SRHMC9pgQToJiQXu2ykIKrg4oL6pBah7IxPMOcDxtG9AEIUOic/4HI0reD0rFZO5iUQpcs7VfOTfKFDPcQ9XMgFWX8SMFnvQhA3FBDJXuRWWr5XPwshqoJ98zyo3no5w2eor3LUOWmNsFEGzpMAyNjtQcEGNMhQxqiBegNhMX3Zz4fz/UsPrWXyT59GoXcGiJn1jXQ4tnUQSQueoZ195/6ULrWeA3omxadUFrwHmVTDaYhRudLIupaIpeDZshbhjJq1fZF7UbyTePbyi61WBtCr6m+CmBb+sPArC1v1M/aDlz/UDiKqlhkTXNq/e8JWskA1objwveyFdFwmXrnX8AdkrnWjHnmpQ4ipDUk/n/DnVIZN29DZ4cGPKluSHKdk4UGcdg2lQRBRbNQJG9IX3yBr7q0vjpJFaXhmIU9Av8qL7hjbVJsCQ9sQGRlhpWxB173TZRzi+N4AUaRQ/GBmCvzQu1z0nVoxkKJnDqMq9fNThVBFFFIGEO+a/foNc7BrAGTVEI0lIr0yQ6Za1zTg8CNaZEFTSF806ctkkx8wa+4ZNr1IY5RCZQ+M1UFkOpPkoiOLBliHUWU08bWC9ft9UlQn4Kg7hk3RYckV523IvaiGeLTu54Ayi2EtZ4qWduN+qYDuCwH6Il9AfNO7W9j0CqaK5rt5n8akhlHPxhMY+IPmr7bXT0/flzySTSaiV6d41X3Dpm9yBIgphj1tNddAXJBWvnoAu47Xr973HHyiYNGu9powbBqIL7chGTfMiecGJq/VMeqK7ONTAKDt9dPa7lPQmhUsCn+gOv4AhMVdAMrEnom0rDqxZU/XQiwG5nO8n3vmqrZUtdeApUcAVXLK/dzgdzA42UilgjrWdC2jjqogWkpDufvuYIOaUBeheAFeDi3n3EoybtiTE7yT7DwrrA5iTuGOgAyxlQbpF9celHNQfviQ/dXtdu/gBq9lqDOjwOhP4C3rGFXxUsCStZSGcsuO9kRQLAof0WvCcBFrmYCnaIZqojcieXEMQWkOcR2wZc25SAsxVmzRBqgEUg8Q/jJsinG77mhCBuBjGElAEVg/j5SjMyvz+ulP6S+8mUEO2wagsOn1DvoC11vzUZ+G4FDqEHbdcDZ9D5aMoZsDTq5tgcuFDFOeuRMfPTOcQPlvAMpsnj5TYbVyXiwbW/ESGfgka/3UAKPqP/2FDE+wYvgxwon4CzdYmmb6Ga+1sTD3VXJMNcHH0IwJRRlNsLULGaRU4IqqLI/OsDIcN+w5AF9uBsh6fdP62dOTJ5UQ+wFh41yCXhPqi0U5hHRYJWljyjekCfR2O8Dl0hb6FP4YBKOM6jIZHShfyJA2+hOyaenyUFXBSJSkI+kfGXHDFgAL2z8ijjJCcGYYkr7ZoNWyK2uR5TjMEHws1RcimbrMu4qT5Ke/XPbtuOGtANmuWNoBUB07iigEx8bn83lcmDCFDyNy0ZOgZsHnIGOhvigLm8ZJaVVQ3Il3edGbrPr1ccNygMtVf+WGEnWUJ5K2Edlp8ez9BYsO2GTFtiJdP+mULmRIfSGzh8Ig4jTqlAFMIqxO6U9p4pQ5pVUAl9mKrZYeRArBJUcZkTIW5NOPS87yVY6VP3FCwsZPX0CvKQFhGNQXVdnAnEWPcg5+yRKbqsBoCcDRopstitxbE/RDcNpJhjfbHwQesFRi9Ez5FY9ebjQa86gvAtmmkag3iNNgKi0H+MjySQ6ZIFhMWJVFUAJwmmXj1WRJyxwWqXlDWXArQx7w9uYHWs+OO3IZYZhsTksTo5w+e0Doh01jUeEbhachcH+xWCwK4CdR3lYZ+Q0DXC7HvWyVE6ZJsTgej+cdlr/oCNm3ZFSdD4DldE+vU+TdhJKkxYfNq7FKgpZPSXUCHyVRdBBUFpxxL5zDxuPx8lX2acjKqgFYFGw1nk6FhBy/7DdGT85np08jCeciIU6H1HyEtW8PP1IEvDDDg4ifu2pmqrBp18s2FbV3olA6OAkjYZotOcLlFasuksoIbRjgqM92Wb4SefZBlfvwdiTQMl7B+ggxxmIJQSeYadFA9gHd+8XkF6inwSpwwqZi+okq6RJ1/8bFNUe4fOlAAVk8b8GiuzHXpPlxH24BSPGVzIKTLgUWvMkXjVI+myj5SuUipujfSK9JusHmaAkWjctr5a9ZLuTg8tLB2qBkkN0KMCtExv13g3RfICkupWzRJZKRLDqX8Rgj5LTOwS3HD5g9ZBRdYvFpVFaq/sxWorH+gQBGNZ5AYAQnrJctHpoHoykFUKg13CYixmplubWJFDY/+o74U0A0w6ZqnasTpaIEnf9b1piYPSIVXdYPiutOtyEsxqz46NxStkGJftwUk1WB/AWN+sFX7AFTnJzUIh+GTXfqF5h/pSa3SKRYjTAdT9cPxs0HEZXB6/AmgMokFNIjkiKIWBReAGPdE/Ot97Qm4mUPRaJ+sQTgHuyGVb6TAo1aqE9zUQCzbCRcpFv3KaCSC64U5Pyxqvv2pmyRtCbxgunFqFu4ok/52AxKAK7JTgTBnegW9g0RQsRt8oDjfxupLLh3CdEurzsG4hUzP2wqVCBWMQeJ8tB6Q3i2MdJNZQ0HWByHNw+g1TqHCA3bM2nOAt78x6P+DcwaLjyitHzfJ2pimgpOTszNCBoiFEP4KZyWFgBVCA6qLtKOa49cEYad+fyO1xTkBqf8naOwsQ2XG7aCKJU1pH3jMZwsk7RFjTTShiDm14FfAYpuUjDP6wV+ukBVZ1yy1QQQpf0Kr97ebqA+Z1COYTHoRHVzMBqWhVUoC46xgDv0gT+F3Pk1IOxB4V31hi3GbLepoULkPg63syo1/f4gvIv8+BzMTH1S62ds4Q2WrMgIrfkiB2+EEVum6CWp2e4k+tclm9FrrdWODWF6H2kf8Qhy8cHuzMFIQZy464Lo7gdXRNENhirrumUaNdutIOua9RpMxMr6O0HJI810pO+BmOD28l+qQgLgxCd747cThR08EkWXXI/XgEOaE0QznWrH+qMGCOsW8hb07J/r8wVia2JMHXaJxwriNJ7tLKaclgmbIWYPVew5ZdATReC1KSsc63qItVWdn3IAj+hzrMH+9QtfIpWlIKpurW6TFsnRz4PKIMlt3whhZ0iRbmUiLSDAV8OotTy6lbEtbXm9MbcmDEiUFasAm90Bj8p6degNcjGbZptSnoW+AfLZJpWjyCbTqmeKNLTRhFlVYAkMYihcfVTixhmtoaHPLKoKmwYolqLTjBeJMEMFRC6K3EYdeoPQhlH5KbIBHsntdYhWYT0e/iJ96Y4iImycPQR5suKOTzNeJCCWYGS9vGTLLkViTvFRVIIw+RFx02du6IX0p1yHZX1XquwI4sC9odu9qeiSMmWtrLTSuSiW0GpyBNE6HmlpdMRp88Os2h6lTKkQderwKS1kuBl7GDat62aTVNm5mbJVwqiwRljzPHwDvU/ApxQyG2a7RFsaUblUySYORCozdjhyKOPGN0CkbQRU8d2pDCIAfKl8mNrBhFYoHlVQ+DG3FMJmSRDfyDqwbRtKkoaojcGqwbBpNcmcV7ajqQD7y/iMCgBrU68kQgnmoPl/5gxisTO6tKtDcIq2NIjb69LgnFDYtI4OqJZYRhC/QhAFwJrNVDyEF6bjZgNHq3/pAP+X1KAOxJ1SlqZIvVFfIL3KR6mp8C4lqguwgRCTCAEYn9IrbZ9PbQhcJBXUnooy4pxLDCzw/ePWYNOpGzZtQrLsnOXU5F7OReYArFdE0rvLEphgU0NDcOVr7brHeaRntqfVXyS140WKCHtmYMSxTh64ZAfcO2gZGoyKAJswx1w+aCCmc2GupcFuLYZJe2FdKwsOIYLpI1McE2vdoqMuhS68EaEMuHc1H81gLkpGlQCb6CEZcmUbwXmmGhfZFFaU8J2Z7VE1LkjJ8YEuATR2tlfboktnKsgMfZyLBLBRZpk0Rriizy2lJcSJVc87t+OGM3qBrdAx8i2gNqnvoDHDprcQVd0rnnggA04BbPTYbyUB7fcqXJdAuvJuFpyAeCGLYY7+4I91Ixbpt8g23ZNjTl7ARs7Fns7ZbWDxPhNCW/S/+w5U5rhIG3qB7Yty8F+wwNJS8DJ7qEW2qYpP7eUXc6Hi+4WRlNyA+dfyIXZnJH1/99IV9YXKgsOi2i4UriKLR9MebCdlwcG96tpkm86oE6nLhhziaDTSCBuYg5HsJ/sFLgGu+lTeoWpvImeKtlr2TBgatgBAfdGqSP9B8Yn8YjDK+1pphCInT16Gi3RXrEDoPpR0d9E9pwpRjd5USdKwrZTJ87N2+gJITQVy76KdqTT8DY1Sv6jsalg1RB/e1jMdGcGWD6b2BroabITfzLFAyOohFTZtQRTWVyG4ZKUNOH/n4jjzYiZzDPbSC1aQRmiE/OIdc766Qva+JcZ12LQFzSdyFMkCTX6U1++NYbT0CnSHfZJXtXP21bB77fbkV9IYnYgKDDlDsDXcq67tpi7DTEI0U7ZwLrrzMBp76wKihh+zMOs1i7UcawgTLERlSvpyGS8gArNgcy3cYJMGSzkICuKjtG7cSCl/FYcXRfhue7ClVSk51Q52FhzowQ/1WXwSXSazvlbMFME3U4wpaj2rMBStG2tyGzsjSeJcy7+BIEGv3sKzs2ZZ1+pSEC+y9AMi3X3IUZCc8Qad2L5IX+S8gkdvFoYCo5pWvthizWZFwbUvaET3csfUCpAbKLGy4EAcsB1ORdFnnFGfuTmDXhPqi18U6Uc/6NFbITgB0Qh375nHtmfk7CHuh1GnrwLp67pLX6W8kk5yxqAeKv0grXFj2DRAXs7ri+CU3OQLQGhGM89kW0NdTK0vGcii82ptOaNCH4K72meHK4mXw2/0hQmxy8bECWLxITfX9L6cMTwqLps2EnVbP5rHbxobUU34BqvhhAbknNsnAYZBy98VXVIIbmmF4EwLWPCxnpiPetrKDYNrbI5gGQljS2rCclJQP0yUbEhbusEWUTTaLAy17Ol306c14oZoUtfW8JSsHGiIKkXsgfCC0sAebxE29Ymi0SMjBGcZ9CLhXjKVGTdshrBkbxPOiBl1qUoRExIFCy64uMFOPrV1gy2iqdA3CkPN34UHjpOdd8ZYW3RFEy59KwHIR6lH7Zl5MTLKMVFF+qxRZKyGvBDchy2gv+Ta0JsxfTqS/+okTS84DaHAUicvmHEHGVukxS8surwxbOrTsxuCW9vh9EfQJ7wjCsNi3TdxLjwmhTHpyphe1wvB7TGVXb9LiyL9YA6VNduhScv4TgrOp1tnw7pdKAbo0rcLMMd9pAluIARH7/JF2G9k0yR8PJ81230awqpC3wRICy2VknzgDCFYTNZnM6rZRSd5bPrWGJi9YS/sJC1JNFQJoWGWf+oze8ZRT1dt+e8VOHI2z9xvvBDcs9zcVRpSNxbpizy8ymTUbkmOh5go7KzEZnygqyuDfQMXznTFuu6oku59okeeUP7KF7mxSD+uOJ3NC8FZAKeZcKuOaz6Ow9krc+dtmC4OwMmCTd2MM6MQlV7gFdP1UQnDMkHOxFE59bn0SSwOfCm9zgvBGeB37CG69HZdyvByZlHpAy0svXy38vZvMBh1OJIvIDMzUYhxZzRf5ftOg8MJk7rj+VRCqJMsFPGOX3eSzkcxzRU+/p9djb24s4VKsVr1d25xnxWIUXEHeQfMiisHOOFWVkXJhQYIR2FUZPzOaRRtfyV5kltcJ+9HpqhXF794cwDuoHrKre6zBFhqFXCil7hmHCCq3RqIcC5YzemATwTRDFvEePgZPmTzdp72+9niWncegL3XAn9utsrGq9XE25bXWgSNrU06QCSkKzjy5qEOouDPtP54vuFE8qBuF9KQ00ieUiJub5QWPehbAKfj6WgxYpm/tbKt6iJzLzgR14whnFNkqC+iqIwFE5H0ng46tSs5FI1W7oV/OmCzsMnY4tFi11+MskXfn4Xe1rpmbI4LmyR65zJ4sfpGLioVN+J4PlFkWi9wcTPMLq2S4emA5vF8DYR2R6/HSBYt2HK5Kkb+VhsBk+HTHMRNxLXIbjEeF2nl6YB4Sm6zo9fisYT4qRDq0wGTpNm5Nd8Wr0359CtY4cvRbjDtw1CjsEH8z0rUh64TOL4vjFCwaNTw3TpOFlyspAxUU4eP53Pp0RrBYsdVPZc0IWc4hPCsdQbYH9eCj+HqBdRdyQmaUGQ6aF7aY2bBQX041vXEZWefBe5nGmCesWzJHb7gfjeB9UECiF7FcsAthwWnHZwJFD4dUGjCuLZuwiTKcF7QWWSxrElpcpDpk12jPVpMuEbLfGMGf/YCaZSB9wyxxVHGuyCfLHcF6Itw/4pzauMbK1+o7Hyp7djyAxZtskv9hWkwnixXq5Idi7zM0m8J8A23wOajPxPxLz6Zv8rOlktFfeLg1mNqD3IUi6HcqKH0eD6b4out6Hv9Phf2k8DWvHSJbSJSLbjQx8L+YLtsBVGO5fgzPIJcVaetTgd8lU1lT3IWNgL44e5tN+mNemxSwqJ4jflUygDD2XkS0egddw75ZF6Ml0E3WBxv2ep0QArBQbELVNfV1690Nu7mtFmeTSDlvRSgrRGpW2lZAdb6dv30LBAGF/LwvOC0WWmGSyrndSMYtf605NnRQcL6vdFC6IkKfOIyZQRTXFOt3ICwYcVly/JxP+gGRygDWy5PqSy4B3Ees9D85f7gYJt5I8W6o3y8LMqEjBppc6/0ru3Qw0IGm27ZShh8gVmSiMK/cp+3jowsOLTV1uxtFnjafHtkAU6E7VuLoKI3AVIYgzrUXLiX22Scx5AVGoohRYOb9KBLXhaciBf9vG0f5uiExU+b/fN3n4XwiRu5sq8QMl0ZIjXb6rIf632/ZCC1PHLZ4rR4k7wQ3Fw5wFkxHdFeJ6UA8sqd+zBA6rTkrBLIJEj4p132UA2pQlRrbzbt6VcLkW7JBTokbOyVjg251UiGI902e6iGvEJUsSFvg/rFSgXRdSNCan9JX2CansYd9jYNkFeIOiisHaBLQOQVm9QxNgI1oPSEHijfEjeCrn91JJRZdg6U8rkROATCBjiq/BmP3HnRLSiEvjTR26790REfgUJUcTzCtJoNR3VKMGPOVuLyBy8/1dxJ+s+OhFIBdyMrrQoiH8EGIkhtJW6Zsn4W/UzHXf/uSKghbZppZqWVQhQAq/GJi9RW4o4t69jXqR0Q+SuEFIIzVvg/S+3NZgBJZjrbZjInrKHOTJFs9Cf6AiilgLvyBB5LJKoQMnUIdUbHwNtp2/SmZiu1hjCBfPE/OxKqA1lwcFaEFgUH2Gy3DcCuqoNMly7AR82l6UWvkRxSzDa98xEfFsmjng2dfAmMYo2akBfRnnzRjzMJp4Zx/a6XaIqZyjb97V7YlRBVFhzx0dWD2GwEKaMjWVjHYHELQBvRyptmZPkgm+7/EKFRiKoLQ7uWRG2gJoRBQx65yEXKNBDzDFC9CMs+h6qxbt2y+q/JOP8Y6dlSGs1YdEIA8ZwbSsc2R2evJWhP8S0e8fHHJ112DrJjzSw4XVnQSE2oSjDiCOvMREFzddyStcwn9zb965ORVQjOyIKTo1hrquE7Eyt+q2HiEM96OTm5Mg3QyhO4uUi/Hcn2reMRMNO0wRzs6vwbHVe1j5b9mBhcb5eQYtFlxV7Yd6ITZWgZhaGw0VATFlU2yYseJ/aqdfyTeYSCGw+XQZvm2UNt6VlHGZHWAmIjIeNvJc4Fs2GInayYgFesjtlDf34yst64xcxKm/aazEGSiyetIoz3XTuxf8+lx6LLgH91d3LOPxYubL/W6w/EDbkhr/lw6J5D4afr3OmIjya0d6OMc0NplALcy4tVJuTSEJXP3gGggYwrb2/Tv6MPV03Pa7z+rnfGorUH1qzwT0UJIHyFVm8t0m9HfghuUgnRD4xONbMNvkHp2xBZIGZxzyOhakkl+qnjO7MKiHrAqGtGGuCWHpVZqiJ03iNOxD87GdmmDTGqCsEtS+eiFzdkPSViHsZac2RKBHFH8T2QQd62SL8dYfQ775nHI4QlKnPjhnr3kfjVUIHy6GUugq6BBaDB/lsmL9ZWk92LRJm78Af1CaVndcKQGfL34ob6fOx3O3ou6jbZeesPXjJ//jHSItstiLagpxEbARjjhFI8QFk4fhmjjBFa0lWBV2nGbH6YM/Oml7Wv7eL165RZQ/1XYVOfhpQiZhSGCmDT04Z38+DhCotTZHw99eXVqAWiF5arQ8sFLU6BSNrT9tNeARIf/ixs6tOA9oIzjkcYGZIgOenQlUoBRlNlnzO9AwB/6ZBgWV939vqW+DQ+3f3U4CqKaVMIXRiaWbPkgQCm1gYZT2dcnoF3Lt4Cbm36fvAHjx1CHfHHtHBDcGGzMaKYMswhcX57DwGeQ+/8cFr5g1dc/9q/LyEKwVW6pkkhrxIAP3KG/jJjE19oDD4OE3/wPgMS9j8jgriqWFBfyGu4kfcksuZy3L726t6y+QKtoPUqqMfL+u5Hkt9GKgRXurxnHAAu6nC7ORwzc7TNr/jjRWoYCRE+HL/+IyOtkqgQdVmiimmUnztr0Gx5T8Sz7Q13LK0grZvRZf+fKfcaepUQi+BkeSSA6SOAABZ91RIpmV3HltyED6vTg8eb/0NmVbW2gTjRQQK8yvCHYNGx0mnp+2PuC5ag3d1JSvcOvx8lZcfzUcpW7s0amUzBdj9awZNN8HBa+EqvXCtUH513H0qfytrwQnCSXvXcov9eMJ9zf7HRAbzHbXm0sOSwoLtSXJFjqhxZy6iifMOucjogOrN5Pvvoeq+VIRg8CqKMGmWg15JIGC9vI1SIqlI4SQ0IBl2/jvyZd/6qWcFO4qSigyEL8xdZiuoxVYMYKESVrJuvVsteseSmymUjq+gvj/gAAAKHSURBVMMseJPDR22mTCoO0ym9KhYHConj+X4FMY4GpcfzIX0Qo0pbbEsAe2y0nPZWvR9bsMCH8dumwfQSFQflqbIRzdBfQRRMEkfVfLAmiKDN3wngBJkU/rAH7/u9mfyHip+So/NkUYh6y+aQ3DbSyhNDkMwQ3N4CSIOpB28ZTMcNNy7OckrLSnxh+kVpoj+0oRhPtSmtjiN6INGyXWtUTHjzoOzHPSl0jtsbzM1UHlYS5tGUj6AoHJXFoy2zvul4vvr+UWXnxgj2VosxuE+sKxK22ev6phQ8Uf3aiQclVXNQL6iOXOo0ra5zKI3geL5GvaMKUeEfATAXhxMupgxV+vOtvkIsCkPLq36AdW+vH3TaiKFwqmHK+FAvsnARynFNAaEIuTTQCh6JE7vE4YBl720gFEUhrZRiJIrck+ZSSp9/jMe+FYvxalk8CnMzuVnUpWBlVDSeqCpXPPanxTSMoW7tFjGcqmJKthTmSzF+FYOXNKsNsxvnQ8gxlp1L1pGqIoFTz/TZcjcRnEnUqMLWeC8qAxYHk2CMPpKHE95I8ui8ivvoYDc4cLgNQNFG1EiKWs2eUa6wb/AVImkq3Nq8kJJwTG5VU6TBWgJs0kbwviPE6Aekw5I2LDoYDER9bwWLCiJDoN0cTGUbLbrmGXyFJHQ6YNPG+ahwLVxbNIf936YFPFpTtPELczZSpwPe+hAxsZpVoAPEpGJXk8o2Ko7na0YIMa7f7cBrXRwN2Kz6lV+atIoApKKKv+botSbNV+qzivuSeNBw5G8oxrfb4NS0jQoC77TFbUJNNW28qcHl3jYo34jipue0MoY7txdo305RWnM839/SfaJL1dSu8//RP/pH/y/o/wCA063XByrVYwAAAABJRU5ErkJggg==', true, 'CASH', 'Espèces', '2022-01-15 18:04:18.689318', 2, '2022-01-15 18:04:18.689318', 2, 2, 'CASH');
-      INSERT INTO public.billing_payment_method (id, guid, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (3, '491cfa96-1bdc-4c24-8f59-c5aded990aa8', NULL, true, NULL, 1, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQMAAADCCAMAAAB6zFdcAAAA51BMVEX39/lSWmXvQCNNVWH//f6EiJNRWmdDSlfo6e75+vpJU2Cjpqr7+/3MzdNCTVnh4eRRW2NHTl6+wsWxtbtpb3iTl5x1eYDT1tnl5emZnqZ9g4uLkZqGipP4///1///3+PfuNxHvKwD1rqLvQCbvOxzuMwu4ucA7Q1H59vvDyMtLVmVGS15aYGtaX2314dz17ejwX0zsnZLuZFT17ef0jHvz08/tfWvwU0LxeW7ym5LvdmPvkIJscnrsRin30cv53Nz1wLb43NDvUDYxO0jyuq/zqaPxiHP0hH3zqpz1w770pqH0oY/uAAAk0yz8AAAHvUlEQVR4nO2dbVfiOBSAA42UlFCGlxFEYlppFV0WlFHH0UFdV2dGd///79kEUNtQWIp6nKT38Vst55CHm9yb9CUIAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL83vZTnk3f5Fh8LYaiYihb/6K/8xlBc3si5Kfi70TQsEnCrYVu51Sk4dUzF53qcM0b4cDAYDhmjnKftUb8PuFk9TGEgZ/VbdPJBtjO8P78NfEFwe7Y7oNrGBqnYaQwUnO9IKuCUPRz5YZCfEYT+6IYQxLUcKNIYyOWcTYpkM9nDrf8sYKbBv70SfeOj25MeWqqm6ggNEQQcMX6hGphauBhSDSXkCmkc9Iuy0++c5hMMSLzglOk2NJLyojAoWDGmpuym/JnZjZ9sQOLfUM3GBFxyFilodyK0J6e5JYzkULBEgZDwQHtaScDbyZXBYa6IYzSlhL78CL0OlynI58OBZg46yQ6sbRw7j+NGruCWqSiM0HjBWPA8Mo5Tzz8+lEUOcg1MY4gUan2XXnZOvHiLQ1EjhTEt4SX76HalAW8scGBt1qLsNaxc9UDkBHIaHwz80e7V9dXdeTRVdv1TqlEkLHSQs6pV54WqOK0/SYuj6E8e5K8YxkwwuA26zw680c5HNywFix3EEanRKZEe6g3iYSAmS1j+Ecojw0TXv9Zo7rCqA4HbpOpo4P8lIuDmaDx6ECqidrxLjQIhhQNLns+7ka4QnIuOcClGAs/fxRSfvegJuhplx9UdWG2RGGlsRPRv8NOv7w8xvouEiBgVP7ppK5PCQUl2hcdIfeT51xj/44dhGHS9E4y/RRyE97o5cFbArYnqgJ29dAXvZJdj/LAruPDy4Y+TaPkYnOlTIkwcOPVVaInT2dGLg/G0iBZDAv4imh/EyqTgiGkzIkgHBbuoFIXJiNNZpKXe3YCI5g8Ex/MziO6Obg5WzeYs2tjwX9EXjuRyojenIB/o1RfSOIi2NgxFN7jIj8fdhImkwQ7GkVbKGnEyHrCr+QWFsbEOdiJjYp5PxkOpQRYJYSwYgiN9CsW0cfDjxUEwHonC6HgkEAe9+/uoA++nsXFAdyO/diBrpF9+IHJFEP7C+D7yv3BXn0lT2ji4jvb88A7j4fSAx6WD59lz3r9+16/9pqRzwBG5jc6ZRoywez8MPP9BTKBHLysI+Vt9wiBtHCD2LTZ3lk2/vjy/HGCCo8nB+6bPkJjaARr63UgghKfTJRTBwItEiD98x+/81qR2wCKrBPmuGAunRQJ7iB0+1ygM0jsgX+IXGsPg5/3d7uU4ViX5X97xK785qR0g9qgUhZ4Xhl7Mi//IdLofI70DxEYJU6QImq0qr+WADxdddJ4NlN0vml1rS+8A7QyWOQjCgT5l8oQ1HPQQGwQLLXhd3RSsFQciOQyP/G6Chm7ePxrqpmBNB5yz4+R7cXSqD59Yz4GADS7UJbTAv9CuH0jWdiCHxsu8mC9NwiEQ06bxiTCgVUKYsb4DeV8SP308+xr6vvf1/PiUixjQqTR65hVxIKFsyg5j+lxXUnmlA4Sm0c/1uvsmzqsc6Nj5E3iNg14PYapvF3jmNQ5o2e3UD1oarZol8xoHpGxbzv6W9pHwOgfVXMEpZcJB0gVoCSm78k6tLDiglXKc5uwfmXHQI/V99ZGu/jQpZsYBYn8eqk84TG5YzZID3HEP448yOHZlEgiZccA5Km1/jjN7uDEzDgQEK8xanSUHGJMoGXTAi9tthQM8mSVmxwFpO5bCfiVbeaGH+3N389rlbOUFRGt2NVYh2fvfUcYcIFqsKBCT68Tk5mRrzqTctixKASTFtBRMzo18o6GwRTk/sO34eGBvcmPHA/q5mlOyoF2jCXlBPuuJzHSAN+beh1GtU7zpFubqA2Md0ErOjT+64jZkWtjeVKhRY/uCyPrqK4Bk+widnzOZ60A0S0Ee45maN9JiU2FSMdS3FJrTZpvogJbVlUPbKRLcsZUh0bFbxs6ZcDsxL/TnHnV0zV1PpCX1F7f2y5TOrSvbfWSsA0Tq2wryuc656wtlZPB6Iifq7GgyQ6S9WK4we87EEyqBhNxIZpnUSAekpK4c7skGqkc7JufGhDHxgCQcdcytE3F77p1ZIjfS+Tfn7LcmnzXRAW3acVy7UCS06SpH9zvTdyeZ6ABR3lRWDmUWpEg9avJ8YX7pcHJQzZhPnzXUQSrAATiQgANwIAEH4EACDsCBBByAAwk4AAcScAAOJODAOAdrfZaWbZMcUPWi+ypgk+LAVRcMV6NVc8xxkGpvpsi112rBGAevAhxkw8HTTizZdeDm2pvWgh1bsuHAsmoEY1R3M+zArchbDQg+WCLBcAdOabYvDe4s3tTOcAfu00aV9GDxkPAsSl8W7ssjm/f0sg9SWdwZDHfgFp/ioLnMgf59YWtJHOw9jQdbS/rCnvYOaG1Z4pvuVklaS7Y3tCvaO0DFJQ6shtyYAVcKS/LnJ/0VILy9ZDNX649Ovd5eWiLVtX8tjrxff9l2roVDx1laTBeMeE8U2Vv2O/8PdtOAroDkNpZrS7Br2hcHUzjes2Xu+5QGacCxyoYoEODiVs51qmlwXLtfWvBssI5wjjBq1tJxUCHYiPEwwiobNCXfqgkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADoxH9KvfN1MDMhigAAAABJRU5ErkJggg==', true, 'MOBILE_MONEY', 'Mobile Money Test', '2022-01-15 18:04:18.694047', 2, '2022-01-15 18:04:18.694047', 2, 2, 'MOMO_TEST');
-      INSERT INTO public.billing_payment_method (id, guid, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (4, '609a6ba9-5574-427e-8797-7df7b8c5a016', NULL, true, NULL, 1, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQMAAADCCAMAAAB6zFdcAAAA51BMVEX39/lSWmXvQCNNVWH//f6EiJNRWmdDSlfo6e75+vpJU2Cjpqr7+/3MzdNCTVnh4eRRW2NHTl6+wsWxtbtpb3iTl5x1eYDT1tnl5emZnqZ9g4uLkZqGipP4///1///3+PfuNxHvKwD1rqLvQCbvOxzuMwu4ucA7Q1H59vvDyMtLVmVGS15aYGtaX2314dz17ejwX0zsnZLuZFT17ef0jHvz08/tfWvwU0LxeW7ym5LvdmPvkIJscnrsRin30cv53Nz1wLb43NDvUDYxO0jyuq/zqaPxiHP0hH3zqpz1w770pqH0oY/uAAAk0yz8AAAHvUlEQVR4nO2dbVfiOBSAA42UlFCGlxFEYlppFV0WlFHH0UFdV2dGd///79kEUNtQWIp6nKT38Vst55CHm9yb9CUIAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL83vZTnk3f5Fh8LYaiYihb/6K/8xlBc3si5Kfi70TQsEnCrYVu51Sk4dUzF53qcM0b4cDAYDhmjnKftUb8PuFk9TGEgZ/VbdPJBtjO8P78NfEFwe7Y7oNrGBqnYaQwUnO9IKuCUPRz5YZCfEYT+6IYQxLUcKNIYyOWcTYpkM9nDrf8sYKbBv70SfeOj25MeWqqm6ggNEQQcMX6hGphauBhSDSXkCmkc9Iuy0++c5hMMSLzglOk2NJLyojAoWDGmpuym/JnZjZ9sQOLfUM3GBFxyFilodyK0J6e5JYzkULBEgZDwQHtaScDbyZXBYa6IYzSlhL78CL0OlynI58OBZg46yQ6sbRw7j+NGruCWqSiM0HjBWPA8Mo5Tzz8+lEUOcg1MY4gUan2XXnZOvHiLQ1EjhTEt4SX76HalAW8scGBt1qLsNaxc9UDkBHIaHwz80e7V9dXdeTRVdv1TqlEkLHSQs6pV54WqOK0/SYuj6E8e5K8YxkwwuA26zw680c5HNywFix3EEanRKZEe6g3iYSAmS1j+Ecojw0TXv9Zo7rCqA4HbpOpo4P8lIuDmaDx6ECqidrxLjQIhhQNLns+7ka4QnIuOcClGAs/fxRSfvegJuhplx9UdWG2RGGlsRPRv8NOv7w8xvouEiBgVP7ppK5PCQUl2hcdIfeT51xj/44dhGHS9E4y/RRyE97o5cFbArYnqgJ29dAXvZJdj/LAruPDy4Y+TaPkYnOlTIkwcOPVVaInT2dGLg/G0iBZDAv4imh/EyqTgiGkzIkgHBbuoFIXJiNNZpKXe3YCI5g8Ex/MziO6Obg5WzeYs2tjwX9EXjuRyojenIB/o1RfSOIi2NgxFN7jIj8fdhImkwQ7GkVbKGnEyHrCr+QWFsbEOdiJjYp5PxkOpQRYJYSwYgiN9CsW0cfDjxUEwHonC6HgkEAe9+/uoA++nsXFAdyO/diBrpF9+IHJFEP7C+D7yv3BXn0lT2ji4jvb88A7j4fSAx6WD59lz3r9+16/9pqRzwBG5jc6ZRoywez8MPP9BTKBHLysI+Vt9wiBtHCD2LTZ3lk2/vjy/HGCCo8nB+6bPkJjaARr63UgghKfTJRTBwItEiD98x+/81qR2wCKrBPmuGAunRQJ7iB0+1ygM0jsgX+IXGsPg5/3d7uU4ViX5X97xK785qR0g9qgUhZ4Xhl7Mi//IdLofI70DxEYJU6QImq0qr+WADxdddJ4NlN0vml1rS+8A7QyWOQjCgT5l8oQ1HPQQGwQLLXhd3RSsFQciOQyP/G6Chm7ePxrqpmBNB5yz4+R7cXSqD59Yz4GADS7UJbTAv9CuH0jWdiCHxsu8mC9NwiEQ06bxiTCgVUKYsb4DeV8SP308+xr6vvf1/PiUixjQqTR65hVxIKFsyg5j+lxXUnmlA4Sm0c/1uvsmzqsc6Nj5E3iNg14PYapvF3jmNQ5o2e3UD1oarZol8xoHpGxbzv6W9pHwOgfVXMEpZcJB0gVoCSm78k6tLDiglXKc5uwfmXHQI/V99ZGu/jQpZsYBYn8eqk84TG5YzZID3HEP448yOHZlEgiZccA5Km1/jjN7uDEzDgQEK8xanSUHGJMoGXTAi9tthQM8mSVmxwFpO5bCfiVbeaGH+3N389rlbOUFRGt2NVYh2fvfUcYcIFqsKBCT68Tk5mRrzqTctixKASTFtBRMzo18o6GwRTk/sO34eGBvcmPHA/q5mlOyoF2jCXlBPuuJzHSAN+beh1GtU7zpFubqA2Md0ErOjT+64jZkWtjeVKhRY/uCyPrqK4Bk+widnzOZ60A0S0Ee45maN9JiU2FSMdS3FJrTZpvogJbVlUPbKRLcsZUh0bFbxs6ZcDsxL/TnHnV0zV1PpCX1F7f2y5TOrSvbfWSsA0Tq2wryuc656wtlZPB6Iifq7GgyQ6S9WK4we87EEyqBhNxIZpnUSAekpK4c7skGqkc7JufGhDHxgCQcdcytE3F77p1ZIjfS+Tfn7LcmnzXRAW3acVy7UCS06SpH9zvTdyeZ6ABR3lRWDmUWpEg9avJ8YX7pcHJQzZhPnzXUQSrAATiQgANwIAEH4EACDsCBBByAAwk4AAcScAAOJODAOAdrfZaWbZMcUPWi+ypgk+LAVRcMV6NVc8xxkGpvpsi112rBGAevAhxkw8HTTizZdeDm2pvWgh1bsuHAsmoEY1R3M+zArchbDQg+WCLBcAdOabYvDe4s3tTOcAfu00aV9GDxkPAsSl8W7ssjm/f0sg9SWdwZDHfgFp/ioLnMgf59YWtJHOw9jQdbS/rCnvYOaG1Z4pvuVklaS7Y3tCvaO0DFJQ6shtyYAVcKS/LnJ/0VILy9ZDNX649Ovd5eWiLVtX8tjrxff9l2roVDx1laTBeMeE8U2Vv2O/8PdtOAroDkNpZrS7Br2hcHUzjes2Xu+5QGacCxyoYoEODiVs51qmlwXLtfWvBssI5wjjBq1tJxUCHYiPEwwiobNCXfqgkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADoxH9KvfN1MDMhigAAAABJRU5ErkJggg==', false, 'CASH', 'Pay Test', '2022-01-15 18:04:18.697627', 2, '2022-01-15 18:04:18.697627', 2, 2, 'PAY_TEST');
-      INSERT INTO public.billing_payment_method (id, guid, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (5, 'a3b6c142-8f5f-4dfe-943d-2385a40d7d21', NULL, true, NULL, 3, 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxASEhUREhEWFhUVGBUXFxUVGRMVFRYYGBkXFxgdFRgYHSggGB0lGxUXITEhJSkrLi4uFx8zODMtNygtLisBCgoKDg0OGxAQGy0lICYwLy0vLS0uNS0tLy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLf/AABEIAMwA9wMBEQACEQEDEQH/xAAcAAEAAgIDAQAAAAAAAAAAAAAABQYEBwECAwj/xABJEAABAwICBgYHBAYJAwUAAAABAAIDBBEFIQYSEzFRkQcUQVJhcSIyM4GhscFCcpLRCBUjYqKyFyQ0Q1SCk8LSU+HiFjVjc/D/xAAbAQEAAgMBAQAAAAAAAAAAAAAABAUBAwYCB//EADcRAAICAQEHAgUDBAEDBQAAAAABAgMEEQUSExQhMVFBUiIzNGFxBjKBI0KRscEWYqEVJNHw8f/aAAwDAQACEQMRAD8Av6+Yl+EAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBZMC6AyKel1gXFwa0b3OyHNWWDsy3L6x6LyR7smNS6nWqpXRnPcdzhuK1ZeBbiy0n28nuq6Ni+E8VC/BuCALACAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIGdzJHHFJUTZRxgk+J7AFd7G2Zzdms18K/wBkLNylTDp3IWj02wyWweJYD4gubzFyuiv/AExVLrDoVVW2Nf3FioKSOazopmSR9rmG58iOxU7/AE7bC1KT+EsVtCEo6x7muekDSk1DzSxgsgiNi0gtL3DtcDnbgF3GFiQprSic1mZMrJ6HbQ3Td1PanqSZKc5XObovqW+HYsZmFC+DTRnFzJVPRs2DV04bZ7DrRvALXDMZ5r5xtLZ0sSeqXws6zHyFbH7mPdVfYkhYAQBAEAQBAEAQBAEAQC6AXQC6AXQC6AXQC6AXQC6AXQC6AXQHaNhcQ0byttNUrZqEe7PMpKK1ZTOk7GQ57KGI3ZEQX2z1pDuHja+7iV9R2XhQxqUkcftDJdtmiIaLRpsYDqyfYl2bYGNMtQ4fcHq+9TXc3+1EZY6X73p9vUncLwkQkSU9DiNxukEkUZPm1aZy16SaJFdaj1UWS2J1WHVgENYyWnn3NllYGG/Z6bfRd5LxBWQ6xeqNk3VZ0mtGULSTRyeifqyWcx3qSt9R4+h8FMqtU+3cgXUup/byWbo10jseoTG8b77In7Du7fgc7Kv2nhQyKmtCbgZTrlusvZwqUH1b+N18/lsbJUmorodQsqvTqzj9Vzd34rz/AOj5ftM81X5H6rm7vxT/ANHyvaOar8nnLQytFyw2Wm3ZuTVHelE9RyK5PRMx7qFobgsAIAgCALIF00MExhuFi2tIPJv5rp9m7HWisvX4RX5GT13YEj1SPuDkrrksb2Ii8WzyOqR9xvIJyWN7UOLZ5HVI+43kFjksb2ocWzyOqR9xvIJyWN7UOLZ5HVI+43kE5LG9qHFs8jqkfcbyCclje1Di2eR1SPuN5BOSxvahxbPI6pH3G8gnJY3tQ4tnkdUj7jeQTksb2ocWzyOqR9xvIJyWN7UOLZ5HVI+43kE5LG9qHFs8jqkfcbyCcnje1GOLZ5ITS/FoqGmdK1rRIfRjGWbj9Bv9ylY2DTxNYxSNGVkShB6s1to7RSMEczRr1lW5wg18xG2/7Sd4433FWtsk216Iq6otaP1f/wB1Nn6PaMw0oLvaTOzknfm9zu3M7h4KDZbKX4LKumMOvqRmnektRRugEMbXCRxDi/JuVrN1vsk33+C2UVRmnqasm+Vem6Rz9OqOQGnxGldESPSbI3XZnu8R52XrgSj1gzXzUJfDYtDyloo6YspZSZcOq7CJzjcwPdm0BxzDT2HsXpScviXSSEoqHwy6xfb7FC0owGagn1CTb1opBcXAOWfeGVwpdVisiQbqpVS/0Xavw52K01PWNxCSkc1pjl1XFrC4G2YuADft4FVtsdybRb49nEgmR7ejyci40glt9/8A8lqNx3i6Nqpxs3HpieAcSfg5AROPzYto/JDIa11VTyuLSyXO5AuRnmDa9jdZ79Ai/YZiNPXwCrpXXafaM+0x3aHDsIXLbW2VprdV/KJ+Nkf2yOQuaLALACAIBdZ0ZjUmcKw61nvGfYOHmup2Tsrd0tuXX0RX5OTr8MTJxGvEYsM3HcOHmp20tpRxY7q6y/0aaKHY9X2IF07yblx5rjpZN0pNuTLNVxS7HG1d3jzK88e33MzuR8Dav7x5lZ5i33MbkfA2r+8eZTmLfcxuR8Dav7x5lOYt9zG5HwNq/vHmU5i33MbkfA2r+8eZTmLfcxuR8Dav7x5lOYt9zG5HwNq/vHmU5i33MbkfA2r+8eZTmLfcxuR8HG1d3jzKK+1/3P8AyNyPgyKJjnutrGwzcbnIKbs+u7JuUd56eppyJQrhroaw07x01tVqsP7KMiOMdhNwHO95y8gvp+PUqq9Dj8q3i2aehsHRKlaa6peB6NOyKmj/AHQ0Aut5myiWv4F9+pOoWtjfjoW6rqGxsdI82awFxPgBdR4rV6EuT0TZrqmxmOpopZK4l8dTPqQxNDS+K/qkdtxv93ipcq3Ga3PRFerFOt7/AKvocaH4SI6yejrYts9zGlkrxrNdEzIDP1d/zHYlstYKUegor0m4TWpb9M8ObLQzRgD0WFzP3XMzbbyIWimTU0Sr4a1tFUq524hFHSS22ktOyenkNvaNu17b+Orf3ngtyTrlvLyRpNWxUX6roQOhUBmhr8LlFjIx5De0SNGqbcNzea95UU0po84MmpODNNFpGTrgjIi5yIyI5hQtCzJHRkydcptm4h+2iAIJG94v7rXQwbP/AEh6676Sn4CSU+eTB8yiBU+iLGJKfEomNJ1Jzs5G9jsjqm3EHtWJLVGTdtbGGyOaOOS+eZ1ahfKK8lzTJygmzxUQ2hZBxdOpgmsKw21nvGfYOC6nZWyt3+tcuvoivycnX4YmViNeIxYZuO4fmp20dpRxY7sesjRRQ7Hq+xXXvJNybk/FcXZOVknOb6stoxUVojha+5kIZCaGAgCGQgCAJoYCaGQgCJGH0IzTvF+p0uwYbTVAztvbH2nw4L6JsDZypr3pd31Zzm1Mv+1GqIn6pa7ulpt5G66VlCn8SN1aIzgVtbHfKQx1DP3mvbvHFVty+CLLeiXxyR7aXYvM2amo4A0uncS/XGs3ZDJwI8V4qgtHJnu6x70YL1IHSHQZ0EjaygAuxwf1d/qX/cv2+HJbq795bsyPbjOL34f4LtgFY6eGOeSHZSOGbT6wzPbvt22UWa3ZbqZNrk5RUmjz0sqxFR1Eh7I3WHEkWA95K9UrWaMXy3a2zT+kc76eSiaw2fTwRHyc4l9j7iFYVxU1LX1ZU2twlH7ItLHt/WFFiMItHWDZybvRkIs4Hz1eYWh/scH6ElacSNsfU09p5QiDEauIZASuI/zAP+bioZZkl0TUO2xWnFriMukPk1pHzITUwZXTRW7XFZGg3ETI2DwNruHOyIHn0N0W0xWE2uI2yPP4bD4lH2Mm66p93uPiV85zJ7985fcuqlpBI8lGNgK9aGCZwrDbWe8Z9g4Lp9lbL00uuXX0RX5GTr8MTKxGuEYsM3HcPqp+0doxxo7q6y9DTRQ7Hr6FdkcSSSbk7yuLsslZJyk+rLWMUloiv6aaQmhpxMIw8mRrNUnVGYcd9j3VM2dhLLt4eunTU1X28NakHoj0gGsqBTvhbHrNcWuDi67h2bgp+fsbl6eJGWuhqpyt96NF7VCTDX2k3SO6mqXwRwNkEdgXl5Gdsxax3bl0OFsNXUqyUtGyFZluEmtCS/8AWLv1Z+sNiNbW1dnrG3ravrW+iivZi5zlt7p5PfMf09/QrH9LMv8AhGf6h/4qz/6dr95p5x+Dn+lmX/CM/wBQ/wDFZ/6ch7zHOvwT+henL66WSN0DY9SMvuHF17HduCr8/ZMMaEZKWur0N1eRvvRohoulZ20AfStDNaznB5JAvYkDVUx/p6LhvKfU1878WmhsyKRrmhzTdrgCCO0HMLmZxcW0+6J0Xr1RS9M9OX0M4hbA14LGu1i4tOZI3WPBXWz9kxyqXY5aEW7I3JaaF4wmdrjFI4WBDXEb7XF/qoOI668pcTsmbbN6Vfw9yH0p0FkrJ31DKxhLrarHNsGtG4XB+i+iY+0aHFKLRzN+DZKW9qU/EdA8Riv+x2gHbGQ4e4GzvgrGOTXL1IE8S2PoS+A109opGscKujaWuicC11RTHeG3+03h5LVOK6+H/s31ylon6r/yixaQsNeyDEMOeHTU5PoHJ1jmWkHcQew71pr+DWE+zN9utiU6+69DAqsQxHE9SkdRup2azXTSHWAs039G4FsxftXvdrr+LXU8OdtrUdNPJsq4aMzYAZk8BxUPuyw6JGvNJcbjq3HO1DTODpZOyeRubIo+PpWuVKrhuL/uZButU3/2o1nile+omfO/1pHF1uA7B7hYKfGO7FIrJS3pOTLloDKZ6eWk3vifHURe5w1gORPvUa9bslL+CZivei4eOqKf020+piryNz4on+86wP8AKFXFuTP6PtDrVdROf7uJrQfvuJP8g5oYNe6T123rKmbvzSHkdX6L0ZNh9ANL+2q6jsjiaz3vOt/sWjJnuVSl4RmK1kkbGXzdvVtl6ugWAS2DUQP7R3uC6TYuz4zXHn/BX5VzT3EZuI14jFhm47hw8SrTaO0Y40d2P7vT7Giih2PV9iuvcSSSbk71xdlkrJOUnq2WsYpLRHC8Ho190yyf1aFvGa/hkx35roP08v60n9iFmP4UjXkD3Uc1LUjIEMlHkDqv+q6OemTXZU/ToQ1/TcZG+K7EGRwPqPsNjMnmLXH0XBVUOVyq++haynpDU0C6B0sM9Y65O2jF+LpNcu5ZLv4zULIULx/oqWtU5m1eixjJMNax7Q4CSW4cLj17hcrtuUoZjlF6dET8Va19TN01w2BtDO5sMYIZkQ1oI8lo2dfbLJgnJ6a+T1fCKg3oU7oepY5H1IkY19mRW1gHWuX3tfyVz+oLJQjDdbXcjYkU29TZzaGKMOMcTGktcCWgAkWK5lXWTklKWvUnOKinoj5/oMNdO6YMzdGx8mrxDXZjldd9ZfGqMN7s9EVChvNmxOiXSLXZ1KR3pMBdETvLO1o42+S53b2Duy48Oz7k3Ft1+BkF0vf25n/1M/mcp+wfpX+X/o05fzEbbw72Mf3Gfyhclev6kvyyxh+1GQFqT07HrRM94quRu558t4UqrOyK/wBs2a5UQl3RkNxG5Bkja4jMOsA4HwVtR+obo9LFqv8ABGngQfWJH1uBU0shnp5n0s53ujNmvP77dx896v8AF27j2rdb/hlbds+cXrHo/sJabGo2367TuaBcvMVjbyG8q2jKmS1SIso3x9UU/GcdiddtVWy1RG+CBpp4T4SOOa3wrf8AakiJbav75N/Yq+MYzJUarSGsiZ7OGPKNg8u0+JzUmutQ/JFnY5/ZEathrLF0fV+xr4T2PJjPk7/uAtORHWBIxZ7tiZx+kBBatgf34SPwuH/JVKLwl+iRvVsHras5FxlLT4MYGt/jLkBpdpJzO85nzOZ+K9Ho3h0K0uzw2omtnLMW+YYAB8yqva1m5iyNuPHWxFsC4MuAhgseC+yHmV3GxfpEVOV8xkLiftX+a5faj/8AdzLDH+WjGVebwgNadNUno0reLpDyAH1XT/pyPWb/AAQM30IjSvDL4TQVFvUY1rvuyZt+Kl4N6WfbW/X/AINVsdaos9MX0hLsDgj1iXufsn8bRHWJ8sgF5x8Ld2lKWnRLX/J6lb/RR64lhOwwFlx6UkjJnf5vV/hsvNOTxdqPwloYlDdpJ/off/U3i/qyu9181XbfjpkJ/YkYb+AnNO/7BUfcULZn1UDbkfLZSehb2lV9yH5vV3+o/wBtf8/8ETD7s2jL6rvun5FcvX+9E+fY030WOAxBwt6zJB8e1djtn6SL8aFbjacRmNpbhkmGVzZYcmF21hPZv9Jh+I8ituBdDOxXCffTR/8AyebYumzVHPSPXtqJoKhnqywRkeBBOsDwsSsbKqlTVOqXo2L5b0kzc2G+xj+4z+ULjb/mS/LLOH7UZK0nsIAgBWH2DMbSjHpKR+GQsfq7eoDXjL0oyCCD/me0+5fQtmwcMaCfgpbus2yKx3GMNnqZaWug2TmPLWVDN9srFxGYPMKZDLdctCfZ+nnfjxur66rt6lex3QSeJu2pnCphIvrMsXgeIG/zCs6sqM+5yuTgWUvquxUlKRBPSCbUc1/cc134SD9FhrVaGYy0aZZf0gXazqGYDJ0Uvx2bh9VTaaM6KL1RIY1/VNFo4u2drB/qvMnyXkyaXK9GT6K0IpdjhFIwiznjXd43uflZc9+oLNKox8sl4a1m2SK5AswhgseC+yHmV3GxvpUVOV80hcS9q/z/ACXLbT+rn+Sxx/loxlANwQGqummT9pTNzybIfDMgfRdX+nFpCciuzX1SLW3ChPg7Ke2+mbq33hwbcfJVfMOraLs/7jeoa06Gn8DpX1M0FNnZz/V7tzd5t5BdflWRqqlb9v8A8K+tOUlE290lwj9WyAZBmpYeAIC5DY83LNTfqWGStKtCI6GH/wBXqBwlb8WBS/1FH+rB/Y14T1TLLp1/YKj7n1VZsz6qBIyPlspPQr7Sq+5D83q8/Uf7a/5ImF3ZtKX1XeR+RXL1/vRPl2NMdF//ALj/AJZF2W2Pol/BW43zTZWmuACtpnRj2jfTidwcOzyIyXN7NzHjXKXo+5Nvq34mhpC4eg641CRqn7JuLjmF3i3WnKPqiqeuujPo/DfYx/cZ/KF84v8AmS/LLqH7UZK0noIAgOWi5A4kL3XHemo+TEnomyuaWN2+kGG029sDHSnwyJHxjHNfSK47kFFFE2VfpGaBiM9uLTzaFEt/ed/sZ64cDC0f0kqaN2tC/wBHtjdmx3u7PMLEbJRN+Zs+nJjpNdfPqXKWgosYaZKe0FYBd0Zya/8AP7wz4q0xs16aM+fbW2DPHlr6ejNe11HJE98UrS17TZzT2fmDx7VaxkpLVHLyi4tqXcnulC89FhLhcuf6HOw+iqrVpNl7jy1rTJHp3lEVPQ0bdwuSPBjWtb8ytZuNOtj1iGdriG+9xDfqsg+o6iHZxQQ/9OJg5AD6LkP1DZrbGHgsMKPRsxlz77k4LBgseC+yHmV3GxvpUVOV80hcS9q/z/JcttP6uf5LHH+WjGUA3BAQWP6J0la9r6hry5o1RqvcwAeQU7F2lfjRca9OposojZ1ZMU0LY2NY31WAAXzNh4qJOUpycn3ZuSSWhF4foxRQTGeKENkOsda/e325qVbn5FtfDlLoa40wi9TNxfDYqmJ0ErSWPtcAkHI3yIWmi+dE1ZDuj1OCmtGYmj+jlNRB7adrgHkF2s4vuQLdq25ebbktOz08HmqmNa6GbiNDHPE+GQEseLOAJBI8CNy002ypmpx7o9SipLRkfo/oxS0ReadrgZA0O1nufk25Fr7t5UjK2hdlJKzToeK6Yw7EyW3uOIPLcoSlo9TY/BAYPobRUsu3hY8PzF3Pc4Z78ip+RtO++vhy0a/BqhRGD3kT6gM3lZxPQPD6iV08kT9d5u7Ue5gJ8grSnbGTVBQTWiI0sauT1LJDGGtDRuaAB25AWCrJScm2/UkJaLQ7ryZCAIDIw5l5Gjxup2za+JlQX31NOQ9K2VbRS9RpFXz72wMETTwPog/7l9AKcqvSJJrYjOeBaOTQoNv7j6BseOmHAri1loz0pal8b2yRuLXNNw4bwfqsptPVGuyqNkNyfVM2JMY8ZpC8ANrqduYH940bvMH4FWmHlPXRnzjb2xuBLej29H/wY9HSdYp8FbbNlY4EWzAYyWQg/gWzJ+YysxPlIq3TtXbTEhGD7GJjbdl3EvPwcOS0oklT0Oo9tX0kR3OmZyb6X+1DJ9HYu+8rvCwXCbXs38qX26Frix0rMRVZJCGCx4L7IeZXcbG+lRU5XzSFxL2r/P8AJcttP6uf5LHH+WjGUA3BAVnS3SGWlcxsbWnWBJ1r9itMDBhkRbl6Fjg4UchNy9DO0bxfrFPtX2DmlwcBuFs/ktOZi8G7cXZ9jRl43Bt3F6ldotNJpJ2x6kYY6QNvY31SbX38FZWbKrhU5NvXQn27LhGpy1eqReguf/BTHAcPNenF9w0VLTDGZ4JomRP1WuAuLDPMDtVvs/GqtqlKa7FrgYtdtUnJdi2A81UOOjKtpkLpRVVkbWGmZrEn0srnwy4eKnYFdM2+KyZh10Sb4rIzTHGKmBkBY7Uc9ri8WBzAbx8ypWzsWq2c0+qXYkYGNVdKal2XYtdM4ljSd5APwVROKUmkVc0lJo9AV5aa9DAWAEAQBZBnYQQHuf3Gk/8A7krvYNe9kOXhETMlpDQqXQezaMrqz/EVLyPIEn/euyKskNIejWOolfOyocx8hLiHAObc8LWIC0zoTepf4e3pUVxrlHVIqGI9G2IR5sDJR+4bHk6y0ypkuxd07fxZ/u1T+5Wa7DZ4cpYXs+80ge4rU4yXdFpXk029YSTMnRnF3UlTHO05AgP8WE+lf5+5ZjNxlqas/FjkUSg/4/JvKkwWIGN8dtVssk7Rw2rHNNvxk+9WLlvdT5oq+G3E+a9Pa7b4jVyb/wBq5oPgyzB8AsnsnOhWj2mKxuIuImSPPnazfmV5k9FqDctQ67nHiSvnOTPfunL7su61pBI81HPYQwWPBfZDzK7jY30qKnK+aQuJe1f5/kuW2n9XP8ljj/LRjKAbgsgommw162nj7CGC33nWV/sxuOPOSLzZr3ceckRlJWmmjrICbE+i371y0/CylzpV8q7ESLKlfKqxHg+kMElJlYuDHm/EuH/Ze+KrYWfY2K1Wws+3QmtMK2WWpbRseWt9EGxtcuzz8AFCwKa66XdJEPAphXS75LUwsboJMOljfFK4g559pG8EdoK241sM2Eozjpobca2GZCUZR0PTTqQvlp3DIujBHgSR+axsxKMLF6JmNmLdhNeGeeP4FLSNZOJ3OcTZxuQQ453B4L1i5VeRKVTijOJkwyJOtxPXSzEXyU1LLctLw7WsSM7WO5eMGmMLrIadjxgUxjdODRzpx7CjP/xn+VibM+Zal5MbN+Zb+TI0yxV7RDTtcWtLGl5G+2Qt9Vr2fjRbnZJatPoedn48ZOdklq0+hBvrYqeWN9JPI7vh4tfdzBzU1VSthJXRS8aEzhSuhKN0UvGhtSJ1wCO0A81yklo2jmWtG0dl5MBAFkHTGKzq+HVs43tifq+J1Tb4ldT+nYfDOf30K7Nl1SK1o7jbcHwCnqDFrvkIsy+rdz3HefutuulIJ64T03UT8qiCWE8WgSN/hzAWBobA0fx+lrY9rTTCRoNjbe12+zh2FASUkbXCzgCPEAoeoyceqZX8S0Jw6e+tTNaT2s9A+8t3rW64v0J9O1curopv+SRqCympXG51YYnZnM2a07z7l7SIM5ucnJ+p8jSSFxLiblxJJ4km/wBV7PJtfoCpbOrKi2TWMjB4HNx+BCi5c1CmUn4PUFrJI2EvnTerLxBYAQwWPBfZDzK7jY30qKnK+aQuJe1f5/kuW2n9XP8AJY4/y0YygG4LIKhj+FTyV0MrYyY2bO7uwWddXOHkVwxZQb6vUtcXIrhiyhr1epjaQ6MTS1hexn7N5aXOuMu9ce5bMTPhDG3W+qNuLnQrx92T6o9tL8HmkmhdFGXNY0DK2ViPovGBlVxqmpvqzXg5NcapKb6s50twGd0zaqnF3AN1m9oLdxHFMHNqUHTb2GDl1qDqs7GBV0NfXyM20WyY3Ik5eZt2lSIXY2HCXDerZuhbjYkHuPVsy9LsEnllhEMd2sYGh18hY9vC1gtWBl111y4j6s14OVXXCXEfVmFiNPidXqwSRaoac3Ws09msT2rdVZiUf1IvVs3VWYlGtkH1Zm6U4DKYaeKFheIwQSLcFpwcyCsnOx6amnBy4Kyc7HpqNLMJqJYaVscZcWMs4cDZv5FYwMquFljb7sxg5Fddljk+57aU4BLKIpogC+NrQ5nabZ5cV5wc2uuUoTfR+p5w8yFcpQn2b7mNSSVxcxrqCMZjWcWAZdvktlix0m42s2WLHSbVj/yXcBULKY5WAEAKAr3SzPqYRswbOnlYweILs/gu42JXu4qfnqVOU9bCR0w0HdW4fS0jJmxPgbGQHeo4hmqbgZ9pVuRjUuLdGGL0+fV9q3vQkOP4d6GTanQfgU1LRyOmjdG+aUnVeCDqtAa02O66wYNZ6S6fYk2vqHQ1UjGNkcxrPRLNVhtuI8Cfesgk8K6a6+MjrEMUzcrlt43W7bbwTyWAbM6T8V1MHnlAttWMYAcjaUhvOzkB8zBej0bz6G6XZ4VLL2zzO/hOp9FU7Zs3MWX36G7GWtiLSuFLcIAhgseC+yHmV3GxvpUVOV80hcS9q/z/ACXLbT+rn+Sxx/loxlANwQEXjGOw0xaJNb0rkaovuUvHw7MhPc9CRRiWX67noZOGYhHPGJY76puM8iLb7rVdRKme5I13UyqnuS7kZDpZSulEQL9Yu1B6OV723qXLZt0Yb77aEmWzrlDffYnrKvb1ISeoWAEAQxoEMgIwE6dgFkBYAQBAcFZSBWek5gmq8JoOx0okPuyzX0TDhw6Ix+xSWPWTZR+mbE5H4s8BzmmFjGNsXN3jWJbb71rjgpRrIrC+kPFaUehVve0Z6s37UG3Zd13fFAfSFPi7W0bauotGBE2WTeQ0aocfFYBqiqw7RbEpHPjqjTSvJc7Mxhzj2kSDVzPCyA8o+hV5kjfDXRyQ6zXOdq56oINhqkhxO5ATP6QNYGUlPTty15bkfuMY76lqyDRRKyej6P0QpdjhNHHaxcwPcPFw1j81zf6hs0rjDyyXhL4mzNXJlkEAQwWPBfZDzK7jY30qKnK+aQuJe1f5/kuW2n9XP8ljj/LRjKAbggKFp83XqYI+IA/E630XQ7Je7TKRe7L+Gqcjz0bxMwU1XGfWjuWg8TdtuYuveXj8W+uS7MzmUcW6uS7MhKKExy0zj9stf7tbJTbJ71U0vToTrZqdc0vQumlWkr4HtggbeR1iSc7XyAA7SVS4OBG2Lts7FLh4UbIuyx9COk0hr6WRratrXNcL5WBtfOxHaOCkLBxsiDdLeqN8cPHyIN0vqjM0o0kmp5Y9lqlj2B1iMzfx7OxacLAruhLf7o1YWFXbCW/3TI6q0mxCB7XTMaGP9IMsPV4A8bKRHAxbYtVvqiTDBxrYtVvqic0n0jMDYxEA58ou2+4A2zPE3KhYWArZS3+yIGHhcWUt99ERUmkNdSvZ1oMcx+Z1bXAyvmNxF9yl8jj3xfB1TRLWJj3QfC1TXkyMQ0iqIaxsT9XYuLSDq5lr8hn4Gy01YNNmO5r9yNdWHXZjua/cjvi+P1ArG0sBbY6oJIubnf5ZLzj4VfLu2w804lbx3bZqWxVJWBYAQHeFt3NHEj5rdRDftjH7o8TekWytVLttpM2+bKSmv5OIuvo0VotCkIfEOk/CKuRzK3DtaMOIbLZkhsMgbb89+S9mBh+hmjmIyN6nVvjdfWMF/SIGZGq8XaPJAbC6Q8MmlwuenpmFzyxrQwWu5oIuBxOqCsA+ZcQw2eA6s8L4yN4e0gc9yyC99BUsv6yDWyO2eykLm6xLD6oble2+6wDL/SArtethh/6UJP8AqO/8FlA1lHCZCI273kNHm42HzWQfUlfHqNiiGWpG0W8gB9Fx36gnrdGPhFnhL4WzEVATAgCGCx4L7IeZXcbG+lRU5XzSFxL2r/P8ly20/q5/kscf5aMZQDcEBRNKTfEqccNl/PddBgrTCnr9y7wumHN/kitKKJza2SJpylc0gcdY/Q3UvDtTx1KXoSsO1PGUn/aZ2mcQinpmjIMa0A/dIWjZ89+mxv1bNGz5b9Vkn66jS6J8NaypLSWHUN+y7RYjwyzTBlG3HdWvXqMCUbMd1Lv1PLSnFmVskUVO1x8xnc+HAL3g47xIylYz3hY7xIylbodtNYtSWmZfNsbR7wQF42bJSrsfls87PlvV2PzqZnSXuh8nfILXsbo5mvY/eZi6Y0jtWnmsSzZtaSOw5W8rhbdnWx3pw166mzZ9qUpw9dTEjiwx+q3Xnu4gWyyJy32W1vMim9FobZPLim9I6IsGnmG3gZK3fDYX7dU9vuKr9l5GlrhL+4gbMv0tcJf3GDoLA6aokqn56osD+8QB8gpG1JxrqVUTftOarqVUS+Bc72KMIAgMvCo7yt8M1ZbJr38qP26mjJlpWyodHsHWsQxipuQHu2DT3cjuXeFOUHGOiXFKe+pG2dg+1ERrWG70DnfwCA7dFOBVH62g2kMkex15Ha7HNtZpaA64yvrfBZBsTpk0zqqA08dK8MfJrPcSA67W2Fs9wJKwCpYf0yyuaGV1HFO3tLRb+B1weazoDZPR3UYVUMfVUFO2Jznako1dV7SM7G2XbfLLNYBo3pQrttilU7eGuEYPg0D6krJkw9BKLbYjSR8Zmu/B6ef4UYPojFX3ld4ZclwW1p7+VL/BbYq0rRiqtJAQBAWPBfZDzK7nY30qKjK+YQuJe1f5/kuV2n9XP8ljj/LRjKAbgmoPN9OwnWLAXDttnzXpWSS0T6HpTklomdjG0m5AJ4opyS0TMJtLRHWWnY71mg23XAKzGyUezEZSj2ZzLE1w1XNBHA5hYjOUXrFhNxeqPOmooo/Uja2/dAC9TunNaSZ6nZOf7mzvJTscbuYCRuJANliNkorRMxGcorRMS07H+s1rrcRdI2Sj2YjOUezOxYCNUgW3W7F53mnqjGr119THZh0DTdsLAeIaLra77Gusme3dY1o5Mrml8FbM8U8TbxOAJIyG/wC2eHgrPZ86KoOyb6osMCePUnZPuidwLDG00LYhmRm48XHeq/LyHda5MhZN7uscmSCjGgIAgMnDp9SQE7tx96sNmXqjJjJ9uxpyIb8Giiw4nJo/X1O3hkfQ1T9qyWMa2o479b5WXfJ6rVFMX/A9OcNq/Y1TCe646jh5hyAsItvHPisAqGnugEGKaj3yPjkjBa1zbEEE3s5p35hZBqrG+hvEobmF0dQ3gCWP9zXZHms6g2Z0WYHLh+HHrDNSUukle24JAHqgkZX1WhAfOdZU7WSSXftHvf8AicSPgUMl66D6PaYmHEZRRPffxNmj5lYlLRNjQ27K67nHiSvm+RPftlL7l3BaRSOq0nsIAgLFgvsh5ldxsX6RFRlfMZE4jE4yuIaTnwXObRx7ZZM2ovuTqJxVa1Zj7B/dPIqDyt3tZu4kfI2D+6eRTlbvaxxI+RsH908inK3e1jiR8jYP7p5FOVu9rHEj5Gwf3TyKcrd7WOJHyNg/unkU5W72scSPkbB/dPIpyt3tY4kfI2D+6eRTlbvaxxI+RsH908inK3e1jiR8jYP7p5FOVu9rHEj5Gwf3TyWeVu9rHEj5ONg/uu5Jyt3sf+Bvw8gQP7p5LHK3e1/4HEj5Odg/unkU5W72scSPkbB/dPIpyt3tY4kfI2D+6eRTlbvaxxI+TjYP7p5LPK3e1jiR8mVHNJq6j4tozuvbcfFWuJnZlEd1xbRGspql1T0IDFdAMIqjrPpHQvvfXiu3PibZFXlO1FP98Gv4Ik6NOzTIoaA4xR+lhuKOe3fsp87+FzcW5KzjJTWqNDWhz/SBjFDliWGOc0b5qe+r+XxXowWTA+k/Can0RUiJ/cm/Zm/AE5H3IDI6RMbigw2okEjdZ0bmx+kPSc4WAbbfvQHy6LAAe4L0ZN2dDGj8tLBPWztLDOGsia4EO1W6x1rHdcu+CgbQvjTRJs2VR35pFwXz8ukFgBAEBKYRXtYNR2QubFdFsjaUKY8KzovRkHKocnvRJYVcffbzC6Hncf3ohcKfhjrcffbzCc7je9GOFPwx1uPvt5hOexvehwp+GOtx99vMJz2N70OFPwx1uPvt5hOexvehwp+GOtx99vMJz2N70OFPwx1uPvt5hOexvehwp+GOtx99vMJz2N70OFPwx1uPvt5hOexvehwp+GOtx99vMJz2N70OFPwx1uPvt5hOexvehwp+GOtx99vMJz2N70OFPwx1uPvt5hOexvehwp+GOtx99vMJz2N70OFPwx1uPvt5hOexvehwp+GOtx99vMJz2N70OFPwx1uPvt5hOexvehwp+B1uPvt5hOex/ejPCn4HW4++3mE53H96HCn4HWo++3mE53G96HCn4HW4++3mE53H96HCn4HWo++3mE57H96HCn4K7jeiOEVdzNTxFx+02zHX822v71nnqPehwp+Cj1nQvQFwMVa9jB9l2q8j7pyssc/jr+9GeFPwWDA9EcKobGKDbSj+9l9I+6+Q9wVbk7dqh0rWr/8ABuhiSl+7oS1VVPkN3HyA3Bc1l5tuS9Zv+CfXTGvseKhm0IAgCAWToDiyA5sgFkAsgFkAsgFkAsgFkAsgFkAsgFkAsgFkAsgFkAsgFkAsgFkAsgFkAsg0CGAhkIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAID//Z', false, 'MOBILE_MONEY', 'Momo', '2022-01-15 18:04:18.701871', 2, '2022-01-15 18:04:18.701871', 2, 2, 'MOMO');
-      INSERT INTO public.billing_payment_method (id, guid, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (6, 'bd31cccf-9613-4965-8cd3-d75e1efabfe6', NULL, true, NULL, 5, 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxITEhUTERITFhUXGBcXGRgWFxseGRggFRcWIBkdGRoaHiggGBslHRgXIjEjKCkrLi8uGh8zODMtNygtLisBCgoKDg0OGhAQGzUlICY1LS0tLS41LS8vLS8tLS0vLS0uLS0tLS0uLy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLf/AABEIAOEA4QMBEQACEQEDEQH/xAAcAAEAAgMBAQEAAAAAAAAAAAAABQYEBwgCAwH/xABOEAABAwICBAcOAwQIBAcAAAABAAIDBBEFEgYHITETNUFRYXHSCBciMlJydIGRkpOxsrMUVKFCc8HRFSMzNENTYsIkY4PhJUSCosPw8f/EABsBAQACAwEBAAAAAAAAAAAAAAABAwIEBQYH/8QAPBEAAgECAwQHBgYABQUAAAAAAAECAxEEBTESIVFxBhMyQWHB0SI0gZGhsRQkM0Jy8CNDguHxFlJTYqL/2gAMAwEAAhEDEQA/ANk6eaaQYZAJZQXvccscbd7zy7f2WjlKjUGlqjXpiRcSyKla3kGR5IHSS/afUEsgfPv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIDv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIDv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIDv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIDv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIDv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIDv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIDv5Yp5FJ8J3bSyA7+WKeRSfCd20sgO/linkUnwndtLIHqPXniYNyykI5uDft9j0sgbb1b6w4cUa5uXgp2AF8d7gg/tMPKL7OcIC73S4OcO6JnccRiYScradhA5AXPkufXYewItAasUgIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIC76mKhzcYpcpIzGRrukGJ+w+sA+oIDqa6qJOce6G4zZ6NH9cqsWhBrBSAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgLlqf44o/Pf8AakQHVaqJOce6G4zZ6NH9cqsWhBrBSAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgLlqf44o/Pf9qRAdWKok5w7objNno0f1yqxaEGsFICAIAgCAIAgCAIAgCAIAgCAIAgP0BAWvR7QOpqY3Sn+qjDSQXNN32F/BbsuDzrl4vN6GHmoL2n4d3N+RkotlVIXVMT8soB+IAgCAIAgCAuWp/jij89/wBqRAdWKok5w7objNno0f1yqxaEGsFICAIAgCAIAgCAIAgCAIAgCAIDJoKKSZ4jiYXvdsAH/wB2BYVKsKcXObskDbOh+rqOHLLV2kk3hm9jea/lH9F5PMM8lVvChujx736FkYmwGhedbZYiDk0Iw5xJNKy5273cvUVvrN8Yv8x/T0GxExZdXOGH/wAuR1SSdpWxzzGr9/0XoOriYU+qugPimZvU+/zCuh0gxS1s/gR1cSIrNUDf8GqI89l/1aVu0+kr/fT+TIdIruIasK+O5a2OUf8ALft9jgF0aWfYSe53jz/2uYOm0VSvw+WF2WaN7HczgR7L711aVWnVjtU5JrwMLGIrAEBctT/HFH57/tSIDqxVEnOHdDcZs9Gj+uVWLQg1gpAQBAEAQBAEAQBAEAQBAEB+oCwaLaKz1jvAGWMHwpDuHQPKK0cbmFLCx9rfLuRKVzc+jmjsFGzLC3abZnnxndZ5uheLxmOq4qV5vd3LuRYlYmAtFkntqxZkj2FiZn6oCP0IAgCA+FZSxytLJWNe08jhcfqradWdN7UHZ+BDVzW+lurNhDpKK4dtJiJ2HzCdx6DsXpsvz6V1DEb1x7/j/blUqfA1VNE5ri1wIINiDvBC9SmpK60Ki3an+OKPz3/akUg6sVRJzh3Q3GbPRo/rlVi0INYKQEAQBAEAQBAEAQBAEAQBAT2idJSPk/4ybI0bm2Nndbv2QtTGTrxp/wCDG7/vcQ7m8cKdDwbRAY+DA8HgyMoHRbYvD4mNTbfWXv46/UziZ60yw9BQwegsWZI+gWJkfqglH6EAQBAfikHykVkSGae1uYU1kzJ2i3CAh1uUttY9dvkvZ5FiHOk6b7tPiUTW8wNT/HFH57/tSLumB1YqiTnDuhuM2ejR/XKrFoQawUgIAgCAID3HGXEAC5PIFDdldmcISnJRirtkvDo7IRclregk3/Ra8sVBaHdpdHMTNXk1Hw3v7GBW0LojZ46iNxV0Kimro5eMwNXCT2aq5PuZiLM0wgCAIAgP26XBk0GIzQuzQyPYf9JI9o5VXVpQqq01deILrgus+oZYVLGzN8oWa/8ATYfYuNicgoT30nsv5olSL7gem9FU2DZODef2JLNPqN7H2rgYnKMTQ3tXXFFikmWZq5TM0e7rGxkY8+JwM8eaJvW9v81dHDVZ9mDfwYukR02l9A3fVRep1/ktiOV4uWlNkbceJgy6xMNb/j36mOP8FfHI8a/2fVEbcT4O1m4d/mSHqjP8VYuj+M4L5kdZE8jWbh3lyj/plT/0/jOC+Y6yJkQae4c/dUBvnNc35hYSybGQ3uF+TTJ20Q+s6Fs9EXxkO4NzX7DyG4P1X9S38mcqOJ2ZK11YrlvKZqf44o/Pf9qRetKzqxVEnOHdDcZs9Gj+uVWLQg1gpAQBAEB9qaBz3BrRclYykoq7LqFCdeap01dst+G4e2JvO7ld/LoXNqVXUfge/wAuy2ng4bt8u9+XgjJina64a4G2+xWDi1qjdp16VRtQknbgzCx6DNC7nb4Q9W9W4eVprxObnlBVcHJ98d68/oU5dI+fnpguhKTe5Fiw3AhYOlvfyf5rSq4l6RPW5d0fjsqpidf+31MXSGgbHlcwWB2EdKsw9VzupGlnuXU8M4zpKye5rxIVbJ549xRFxAaLk7gFDaSuzOnTlUkowV2yUdgMoZm2X8m+3+SoWJg3Y7Muj+KjSc3a67v7uIpwWwcMuejeq7E6xgkjhbHG4Xa+Z2UO6htd67WQFqh0L0hw5maExzRt2mNj84A6Guyn1NWlicuw+J/Ujv4rcyU2jHfrDhqaaanq4zDI+N7LgEtzWIFx4zfCtv3LiLJKuHrwq0XtJNPg/Qs201ZlB0b0Yq655ZSQukI8Y7A1vnOcQB816gqLm7UfioF70xPkiU3/AFbb9UBRsfwCpo5OCqoXRv37bWI52uBIcOpAS+h2gVZiTHvpeCtGQ12d9jci4sLH2oCIxvBZqWofTSt/rWHKQ3aDcAix5b3RuyuDYerrVpLK7hpmjM3K5sbjsF9xdznZu9q5dbETxF6eH7tX5IxvfQnNYcbKaCVlQWhxblblO0lw2AfxWhh8PVhiFHvW98DFJpmv9T/HFH57/tSL0ZYdWKok5w7objNno0f1yqxaEGsFICAID3FGXEAC5OwBQ2krszp05VJKEVdvQt2G0LYGZnEXt4TuboXOq1HVlZHvcvwNPL6LnN+13vh4EHiuLukNm3DP1PX/ACW3SoKCu9TzOZ5xUxT2Iboffn6GNhlQWStI5wD0glZ1YqUHc0suryo4mEo8Un4plrxd1oX+bb2rn0f1Ee7zWSWDqN8H9SkhdQ+blh0ewz/FePNH8Vp4mr+1HrchyzTE1V/FefoSkeItdKYm7SASTybLbOnetd0mobTO1TzKlVxLw8N9k233bu4jtKj4DB/qPyV+E1Zyekz/AMKmvF/YrbRdbp49K+hbMEw4RNzP8Yj3RzLnV6u27LQ91k+WxwtPrKnaf0XD1JUe1a52001daEZq+wRlVi0MDxeMSuc4c7Y7useg2A9ZXXh2UfMcVFRrziu5tfU3Zri00mw2GFlKGCSUkAkXDGsA3DdfaOpZGuQep3WRVVtS6lrC15LHPY8NAPg2uDbfsN/UgKhr/wAFjgr2SxgNE7M7gBYZmmzj1nZdAbZ0Io48NwVkmUEiE1EnO9zml209GxvUEBqGl114mJw95jdHm2xBgAtzA7wbct0BtTXJhcVVhL57DNE1s0brbQDbML8xB/QIDX/c71MsdXKwtdwMsfjHY3OxwLbX3mxesHUipbN95F0XfT/CaaGr/GvDGuewAvfbZkuNl9xsR0rk5n1rkoR0fcuJjO5Y9X8sb6UzsN2vc7wuQhlxcdF7rZy7Dyo03tKzZMVZHM+neOurK6eYuJaZHBgvcBrdjcvMLAFb6ilvSMiR1P8AHFH57/tSKQdWKok5w7objNno0f1yqxaEGsFICA/WhCUruxa8Ew0RtzvHhEe6Fz69XbeytD3GTZYsNDrqvaf0X91MPFJZZzliY9zBygGxPXusrqUI01eT3nCznNfxE+qg/YX1fHlwMZmjtRa7mBo53OAVn4in3O5wtpH7S4VlkbmmivmGxpJJsegKJ1fZdkzby+PWYqnH/wBl9yY0h/sHdbfmFqYb9RHtc+f5Gfw+6IbBML4Q5nDwB+p5ltV62wrLU87k+V/ip9ZPsL6vhy4knjmI8G3g2eMRyfsj+aooUtp7T0OznWZLDw6il2mvkvUwNF23lceZp/UhW4p+wkcvo3C+JlLgvu0ZOlTdjDyXKwwmrN3pMvZpvmecBwrdI8eaP4lTiK37YleSZS7rEVl/FebPOkOI3PBsOweMefoU4elb2mYZ9mW0/wAPTe5dp8fAlsHP9Sy/Mtat+ozvZS28HTb4GdqalH9Nx3PjcMB03a4rpQ7KPA4qW1XnJd7f3Ld3SrD/AMG62z+tF/dWRrlW1AsJxZpHJDKT0CzR8yEBN90m4fiaQcoif+rx/JAbKrBnwA5Nt6IWty/1QQHM9HgEzxmcBG3ypDlHqG8qmVeC038jBzR0/pg9kODymVuZrKdgLeewaLbelZTTlCy3Mye9GiMO1jPiqIXxxtZGx7S7lOW4zAcg2XWtSwUYS2pO7MYwtvNq6/cM4bDWzM2mKRjhblEpyfNzVumZJY2/+jMALQbPjpWxAj/Mkblv7ziUBy2UBcdT/HFH57/tSIDqxVEnOHdDcZs9Gj+uVWLQg1jZSCbwnRepnsWsysP7T9g9Q3la1XF0qeru/AhtEy3R2OB4u8veN+yzQereStWWKlUW5WX1PVZDlm1bE1V/FcfH0PE+kEULiMhe4epo6zyqYYaU1duwz7NNq+GpP+T8vX5EXWaV1D9gLWD/AEj+JWzDC04+J5RRRDz1D3m73OcekkrYUUtyMj7YO600ZPlD9VhWV6bOhlUlHGUm+JdZGAixFweQrlptO6Pok4QqRcZK64MwMTxBsLLC2a3gt/iraVJ1Hd6HNzHMKeBpbMbbXcvPkVGaQuJcTcnaV0kklZHgKlSVSTnJ3b3sltFpLSOHO35ELXxS9lM7/Ruoo4mUeK+zLM+MHxgDbbtWgm1oeyqUoVF7avz4kXjeKCMZGnwz/wC3/utihR2ntPQ4mcZqsPF0qb9t/QqjiugeHbuWA40xsAay+fLbdu5z0rT6huo29D1DzqlSwUaVLt2ty4v0sR2CYq+lqIqiI+HE9rxflsdoPQRcHrW4eXOjItJ8FxqnbFUvjB2OMUrsj2OttLHbL794PKhB7oJsBwVj3xSxMc4bbPMkjuYAAk2v6kBobWDpU7Eax85GVniRt5mN3X/1HeUBs3VDrOpo6ZlFXvEfB3bHI4HI5pJIa4geCRci52WsgLQNGNHmyirL4CQc4Lqi7ARuOUutsUJJaApGuTWXDVRfgqJ2eMm8stiAcp2NZfeL7Sd2wWUg02UB01q+0woq3D44KmaMSsa1kjJHBpPB2yuF948EHZzICn6+9M4Jo4qKllbJZ5fKWG7RlFmNuNhNySbbrBAaVQFy1P8AHFH57/tSIDqxVEnOHdC8aM9Gj+uVWLQgj9AdHonR/ipgHbSGNPity73G+w7fkuTj8VNT6qHx+PcYyZK1ekud5ZTgFjdhkO49DBy9aojhdlbVTXh6nYyfKXi6m3PsL6+HqVjHcT4MZWm7z+nT1rdw9Had3oejznM1hafU0u0//lf3QqbjddE8M3fez8QBAemutuQlNp3RPQY3M8BkcWZ58kEk9TQFqSw9OPtSdkeifSSv1eyora4+dj1LoliL7vdSzm+3a3b7N6rWY4NeyqiODUnUqScpu78SNp8DqXvMbKeYvG9vBuuOvZs9a2J4qhCO3KatxuV2Znu0YxCC0hpZxblDSflfYqI4/CVfZVRfMtpVKlGanDc0fCbH5SLWa084G3/srlhoJ3OxU6Q4qUNlWT4oi2hzzYXLieskn5lX7kt+hw5Scnd72TEeiFe5uYUk9ulhB9h2rTlmOEi7OovmRssiqqlfG7LIxzHDkcCD7CtuE4zW1F3XgQfEBZAlcP0brJhmippXN5w0gHqJ2FatXG4ek7Tmk+ZKi2eq7RmshGaWmma3yspIHWRsCUsdhqrtCab5hxaIhy2iD609O95DWNc5x3BoJPsCxlKMFtSdkCXfohXhuY0k9vMN/ZvWosywjez1i+ZOyyGmic0lrgQRvBFiOsHctxNNXTuiDIoMMmnJEEUkhG0hjS63XbcsKtanSSdSSV+O4JXPFbRyROySxvjdYHK9pabHlseRTTqQqR2oNNeAPeH4ZPOSIIZJMu05Gl1r7r23bljVr0qSvUklzdhY+dbRSROySsexw25XtIO3dsKyp1IVI7UHdcUC1an+OKPz3/akWYOrFUSc4d0Lxoz0aP65VbHQgydAsPbUYY6F5cA57xdpsRe36dC8zmdeVDGdZHgtSLq+8yKnQuSNlqZzHWGwPu0+s2IKrhmsJSvVTXLeeroZ/QpUNiFNppbuHqUqu0GxG5c6HOTvLXNP8V16ebYO1lK3NM81UnOpJzm7tmC7RCuG+ll9Qv8AJXxzLCP/ADEV7LLDpBq+eI2zUrSfBBdEfGBtty337eTetDDZvBycKr5Pu+JBQ3NtsO9dsHlAbp1RYRGykFRlBklc4ZuUBrrADm2gleMz/FTlX6m+6Nt3PeXU1uuYsmtJoqDF+HPBh+TNm2+Na9rK6PR5ujt7e+17fDQjrC741iTaeCWoLbhjc1hvdzBcPDUJV6saSer+Rm3ZXKtofrB/GVHAOhyEtJaQ6/i8h2DkuurmGS/haXWqV/hb1MYzu7FW1wYOyKaOaNoHChweBuLmkbesg/oup0fxM6lKVOW/Z05f8mNRbywap9HI44BVPaDJJfKT+w0G2zmJ33XPz7GynV6iL3LXxf8AsTCO65+YjrUhjmdGyF72NJaXhwBNt5aFNLo7UnTUpSSb7rB1Ca0qwiHEaPOwAuLOEifbbuvY9B2grSwOJq4HE7EtL2kv78zKSUkap1e4M2prWMkF2Nu9w58lrA9F7L1ea4l4fDOUNXuT595VFXZtTTTS9uHiNrYs7n3sL2DQ3/8AV5XLcseOcpOVku/xLJSsfPQnTQV7pI3RZHNANr3DgdiyzPKnglGaldP7iM7mttZuDMpqw8GLMkbwgaNzSScwHRf5r0mTYqVfDLb1W70K5qzNlaDYHFRUYleAJHM4SR/KBa4aOYAW9a81mmLqYvE9XHROyXn8SyKSVyIp9a8BlDXQPbGTbOSLjpLeb1rcn0cqRhtKacuBHWGTrR0djmpnVLABLEMxcP2m7Lg89t4PWqskxs6VdUZP2ZbuTJmt1yE1I+PVebH83rd6Sv2aXN+RjT7yH1v8Yf8ASj/3LbyD3T4sipqTOpHxqvqi+ci0+kulP/V5GVMhNbZ/8Qd+7j+RW7kHua5sxqanjU/xxR+e/wC1Iu0YHViqJOcO6F40Z6NH9cqtjoQetVWIt4F8V/Ca/N6nf9wvP5xQbmp+FjCRsFkl156dOwTPsHKhxM1I9hyrcTNMbFG9E7it6U6F09YC7+zm5Ht5fPH7XXvXUwOa1sN7OseHoGkzUWkOjNTSOtKzwb+DI3ax3r5Oor12Fx1HEq9N7+HejBqxuDVZxbB1yfdevHZ577P4fZF0NDSdR/eHfvT9a9tD9BcvIo7zeen3FtR+7HzavC5V77DmXy7Jq7VTxjH5sn0r1Ge+5y5r7ldPtFn12eLTdb/k1c3o3rU+HmZVC26H8WQW/wAj+BXJzBfnp/yMo9k58K+gFBv/AFf8WwX8g/Ny8Bmvvs+ZfDsmv9VXGUnmSfUF6DPfco819jCnqZWuz+1p/Mf9QVXRr9OpzQqHw1L/AN6l/df7gs+kf6EefkKep61y/wB7g/dj6io6O+7z5+Qqamz6wQ/hSKiwi4MZ73tlyi+7avM0nV/ELqu1fdzLHpvKUKXR3y4vekXa6zOeD+SMPYJLSDSrDzRTxRVMZJgfGxozXPgENG7qWthMuxixUKk4PtJt7uJLkrWK5qR8eq82P5vXR6S9mnzfkY0+8iNb/GH/AEo/9y28g90+LIqakzqQ8ar6ov8A5Fp9JdKX+ryJpkJrc4xd+7j+RW7kHua5sipqeNT/ABxR+e/7Ui7RgdWKok5w7objNno0f1yqxaEGvcJxKSnkEkZ2jeORw5QehYVaUasXGRDVza2j2lMU4GV2V/KwnaOrnC89icDKm9N3EqaaLLDWArmToEpmUyYLXlSaMrn0D1U4GSZ+5ljsE7R8qvgyxwlDCyxzZ7Zbct77LLOmpKScNe62ouedFvw/4dv4W3A5n5bXt45zWvyZsyxx/W9c+u7W6/y3fQvhoc+1A/4h370/WvoMP0Vy8ijvN6afD/w2o/dj5tXhcqX52HP1L5dk1dqq4xj82T6V6jPV+TlzX3KqfaLNrs8Wm65Pk1czo1rU+BnUJPVTjzJaYUziBJFcAE7XNN7Ec9txWtnuDlTr9clul9GTB7rEbiWqjPM50VQGRudfKWXLb7wLGx6Ny2aXSPZpqM4XkvHX6epDplpx/EIcOocrSBlZwcTb7XG1h/MlcvC0KmPxW0+93k+Bk3so11qgN65x/wCU/wCbV6LpAvyqtxXmV09TP12D+up/Mf8AUFr9G/06nNE1DH1L/wB6l/df7gs+kf6EefkKep+66P7zD+6/3FT0c3UJc/IVNS8aHYvFX0QjeQXhnBysvt3Wv1EbfWuJmGGqYPFbcdL3izOLuioz6o5MxyVTC3kzMN/XY2uutHpJC3tU9/Mw6sjdINW76WmfO6pa7JbwQwi9zbfm2b+ZbOEzyOJrRpKFr99yHCyuYuq/G2U1XaR2VkrchJ2AG4LSejYR61bnWElXw94K7i7+pEHZl/070H/HPZLFI1kgblOYEhwBJG7cRcrgZXm34SLpzV09+4slC571f6ISUHDGSRj+EDAMoOzJm5/OVebZnDGbGymrX18bExjYoGtzjF37uP5FegyD3Nc2V1NTxqf44o/Pf9qRdowOrFUSc4d0Nxmz0aP65VYtCDWCkHpkhBBBII3EI1fUFlwvTSoi2SWkb07He0b/AFrSq4GnPetxg4IteHad07tji6M/6hs9oXPqZZNabzHZaLLRYwyQZmPDhzg3XPqYRxdmiL2MfGdLYaZvhuu7kY3xj/IKaOXTrPdpxMldmsdJdLairNnOyRckbd3/AKj+0V38LgKWHV0rviZpGPh2lVbBGIoah7GC9mi1hc3O8c5U1svw1abnUgm+JkpNESZDfNfbe9+lbndYgmK3SytljMUtQ9zCAC02sQPUtOnl+GpzU4QSZLk2R2HYhLA8SQvLHi9nDft371sVaUKsdiauiDIxfHqmpy/iJXSZb5b22X37gq6GEo0L9VG1yW2zCp6h7HB7HFrhtBabEesK6cYzi4yV0QWGPT3EgLCqdbpawn2lt1z3lGCbu6f39TLaZCYjiU07s80jpHc7jf2cy3qVGnRjs01ZGL3n7heKTU7+EgkLH2IuLbjybVFehTrx2aiuiU7HvFsZqKktdUSukLRYE22A9QWNDDUqCtSjZBu5+YVi89M4vp5HRuIsSLbR61NfD068dmoroJ2GK4vPUuD6iR0jgLAm2wc2xKGHpUI7NONkG7nxoq2SFwfE9zHDlabFZ1KcKkdmauvEgsDdYGJAW/FH1sjJ9pbdaDyfBf8Aj+r9TLbZH4npRWVDSyaoe9p3t2AG3QAFfRwGHovapwSZDbZj4LhUlTK2GK2d17XNhsFztVuIxEKFN1J6IJXdi90eEY/TtyRSHKNwzscB1ZwbLg1MTlNd7U1v5NfYzSmi56EwYiBI7EZMxOUMb4Pg2zZj4IAF7j2LjZnPBPZjhVxu9/hbUzjfvNXaz6tsmIy5doYGMvzlrRf9Tb1L1GSUnTwcb99382VTe8+up/jij89/2pF1TE6sVRJzh3Q3GbPRo/rlVi0INYKQEAQBASdDjksURjjIbc3J5fUqp0ITltSMXFN7yPkeSSSSSd5O8q21tDI8IAgCAIAgCAIAgCAIAgCAIAgCAIDMwrEpKeRssLsr27ja+/oKrrUYVoOE1dMJ2LfFrVrhvbTu6Sxw+TwuPLo9hG9zkvj6oz6xnwxDWZXStLQYowdl42kO29LnGyso5FhKbUt8uf8AwHNspr3XJJ23512ORgXDU/xxR+e/7UiA6sVRJzh3Q3GbPRo/rlVi0INYKQEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEBctT/ABxR+e/7UiA6sVRJzh3Q3GbPRo/rlVi0INYKQEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEBctT/HFH57/tSIDqxVEnOHdDcZs9Gj+uVWLQg1gpAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQBAEAQFy1P8cUfnv8AtSIDqxVEnOHdDcZs9Gj+uVWLQg1gpAQBAEAQBAEAQBAEAQBAEAQBAe44y4gAEkkAAC5JO4AICzxaucWc0OFDPYi4uAD7CboCJwzRyrqM/wCHpppchs/IwnKeY23HYgI2RhaSCCCCQQd4I3goDygCAIAgCAIAgLlqf44o/Pf9qRAdWKok5w7objNno0f1yqxaEGsFICAIAgCAIAgCAIAgCAIAgCAIC7amqZr8Xpg8AgFzhfnaxxafUbFAbo0/gx91SP6LkYyAMbe/BXLrm/jtJtayAgu54zcHXZ/H4Zubrs6+7pugNH4jC59VKxjS5zpntaBvJLyAAOU3QFwptTeLPYH8DG24vldIA72ciAp2NYPPSymGpidHINuV3MdxHODzoCQ0W0NrMQLvwkJc1tg55NmAnkLjy9AQEppBqvxOkjMssIcxu1xjcHZRzkb7dKAitFNEKrEHPbSMa4xgF2ZwbYOJtv37igLH3mcX/wAmL4rUBUdIsBnop3U9S0NkaGkgEEWcLgghAT2p/jij89/2pEB1YqiTnDuhuM2ejR/XKrFoQawUgIAgCAIAgCAIAgCAIAgCAIAgL3qS44p+qT7bkBa9d2lVbTYiI6epljZwMbsrHWFy59z17AgJfub3EwVhO0mRhJ57tKAhdR+GMkxarlcAXQ5yy/IXyEX67A+1AYmnus/EYsTmbBNkihfkbHlBa7La+e+03N+VAWrXxSsnwynrMoDw6Ox5bStuW9V7IDPxivdhOjsLqWzZDHCM1v2pgC99ufabXQEbqO02q6yWemrJOFtHwjXOAuPCDXNNthHhD9UBrTH6+fC8SrIqCZ0LeEI8G3i+MBtG4ZtiA3Hq4qqyGhkxDF6qQsLM7GPtZrAL5iALlztlhzdaA0PpxpI7EK2Wpc3KHWaxvM1os0HpttPSSgJPU/xxR+e/7UiA6sVRJzh3Q3GbPRo/rlVi0INYKQEAQBAEAQBAEAQBAEAQBAEAQF71JccU/VJ9tyAk+6E40Ho8f1SIC3dzZ/YVn7xn0lAQOpfGY4MWqYpHBvDl7WkmwLmyEgdZ2oDK031RV1RiMssBjMMz8+ZzrFma2a7d5sb7t6AltfeJRQ0FPQtcDJdhtyhsTSA4jkuf4oCUloxjOj8UVO9olbHELE7A+EAFrvJvbf0oDF1PaBz4a+eqrXMjvHwYGYEBocHOc524eKEBU9EsBjxnGqmqdb8NHJnLT/ibxGOgHLmPRs5UBeNbGjGKYhkp6QRMpmWcQZMpkdyXaBsa3kHPt5AgNB6U6OT0E5p6nJwga13gG4s7dtQE1qf44o/Pf9qRAdWKok5y7odhGJxm2w00dumz5VYtCDVykBAEAQBAEAQBAEAQBAEAQBAEBmYTic1NK2ankMcjb2c3eLix39CA+mNY1UVcnC1MrpJLBuZ1r2F7DYOkoDJwLSmsow5tJUPiDyC4NttI3bwgIp07i4vzHMTmvy3ve/XdAWmn1lYsxgY2ulygWFwwn3nNJ/VAVuvr5ZnmSaR0j3b3ONyfWUBmYFpFV0bi6lnfETvynYbc4Ow+xAZuNac4jVM4Ooq5HsO9vgtB6wwC/rQGHgWklXRlxpJ3xF9g7Lbbbde4QEx3zMX/AD0vsb2UBAYzjE9VKZqmV0khAbmda9huGxAWbU5GTjFJYbnSH2RSXQHVWVVElL1naBNxOFuVwjnjvwbyNhB3tdy2PPyFWIg0XU6p8Ya4t/Bl1v2myRkHpHhX9oCkHy71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20A71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20A71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20A71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20A71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20A71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20A71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20A71uMfkX+/H20A71uMfkX+/H20A71mMfkX+/H20B6j1VYwTb8E4dckQHtL0BuXVRq1/o7NPUOa+peMoDfFjad4B5XHlKi4NkZVGyD9Klg+SrJP1AFACAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCAIAgCA/W8qkHsLNEH6sgf/9k=', false, 'MOBILE_MONEY', 'Flooz', '2022-01-15 18:04:18.706138', 2, '2022-01-15 18:04:18.706138', 2, 2, 'FLOOZ');
-      INSERT INTO public.billing_payment_method (id, guid, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (7, '0f9ceffe-19fa-4e75-91f5-7d9248bdca62', NULL, true, NULL, 4, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOIAAADfCAMAAADcKv+WAAAAyVBMVEUEBwf////1giAAAAAAAAbu8/rU2d/1+v92eXwwMzTCx8z5hCAABQcAAwPZdB39hiHFaRszHgvGx8fa29uyXxkVFxdhYmLtfh9SLA3nex9lNg+/ZhpvPRHxgCDScByWURZBJQ14QRKJShRbMg/n5+cXDgjo7fS1YRkODgmpWxgkFgpMKg05IQw9Pj6Njo51QBJxcnKARRMmKCiYmZknGArx8vK1trZEJgydVRZgNA8vHAq+v7+CholSVVdOUFMdICGeo6enqKjN0teIO9n/AAAOFklEQVR4nO2dC1viOBSGKwmiJrboMNaCFITBcnMUxxVwdFz9/z9qz0nL1TZNLzhLnn7PsztCr2+/5ORCkhrldVX00AZT2VjjO7h5fznSQD+fypUwxMrN+y3RRhcnN58QD97/EHJqaCKE/KhsIh7eE/K37ytXnRLyax2xcvhHHwcXIuS+skI8vNXLQl+n5P5mifiqIyEyHh0EiC96EmJaPfERTwxdEQ3y5wYRK5omUyHybwUQD/ULpiuRt4OyUfmpsYnAeFI2bi70RnypGIfHeiPel40PfeMpCmKqcaJztAHE40NA/Nt3sVMViDqoQNRBBaIOKhB1UIGogwpEHVQg6qACUQcViDqoQNRBBaIOKhB1UIGogwpEHVQg6qD9ReQ0EI/ZcV8ROR3OB1XH9K7GlMp33VNESlumxVAWG4zkRu4nIn2uMlYKxOwrKeNeItKRswRExlJHllb3EZGOzHVCZLyUMO4h4paHgtEcRifV/UP85KFgnETbuHeIIR4iYiM64iRFPE0xnUA6cInzuKJ7Q3Qa4iEy9vNBFPebWBwPi+CDyon4nypmuIcg6zkypSZAJOTh5Vsq/b4PhQS0K8913WpnGFdDWRzRDvcQENs5IJLXp4P0en/7dBHam5WCGorlxdRQgiPqER4C4ll2RHL0TwbCg4OP7RGhtF21VlnJkddQ/CPmkYQlq5c5L5JfmQBRmzNB6Iht1FBYJ46RXpUiCXOIqOQ2M+HBx3papY/uVg2lOZLnR9qN9rDEJFU4NUTy8CM74sH7OuLA2r5LR2qjzEOs3WRGPMqB8OBgFVY5DbnRa4mNUg9L1lXmOio5zwVxNaeHdkIqYV60jfSqKSFkrcwtjVOSC+HB7xViIwTRjCy+adeWeTiLDqeqiOR7Pojni7oc59WwW44KOHIPSzGxWA3x4UsQrYhWX4yHcaXN/8nFcEROJzLCOA+/OC+mQeT0jsk8nOTUyZhTRE2ByGlH4qCCh8qIL38JET2UACp4qIz49u2vIObgoXod9eJvIMZ5qESo3tL4+fWIEEuze6iOeJpHNTUZotxDxhRamIkQgfHPebZGcUJEuYeseafa4ZOo7+b11+/zKKnEoySI4OF2cyuVh4l74E6/h6v/plJyJkDkdJaPh4n7USO7UZXqBuqIUFrIPCype5hTbzgx1Go/yoictmSRBhrPCfqX80BU9FAdMU8Pc0Ek/LcaoSpirh7mgUgelCt3aohAmKOHOSAmIFRDzNnD7IhJCJUQYzx0ZL8H7wQxWRNEAZHKPbTniQkzIpLjRI2seETay9vDjIjke7JmpAJiLW8PsyEm9FAB0fBy9zATIukn7QqIQxwNZB42U3mYBTGxh7GIzN2BhxkQY/JhaNMyrjd8Fx6mRySv0vbx+WsaxF14mBqR3Ep/cPz4HtqdlRqROd3UhCkR4zwk4T12aRGZGz1YYUeIcR4+5IvInGkGwlSI5FVKCB5G9LumQ2TuOAthGsQYD88fSFTXcipE5kSPGtoRooKHeSIyNyNhcsQYD9/9BddyQ8zsYXLEGA+fgkEZeSFm9zAxIrlQ8TA3ROZkizQpEMm9tDx8Wg6syQeRuZlKizSIMT/Bva8WPswF0XKHlIdqZ4jKHuaDyKo9GqnddBXHePi0vnhlLoiNWpQGc6o4SDcRYgIPc0qoLFpNZyIZ2JcSMYmHudZuIvAtU7V5pfxDuNzDX1tjv3eOiAWKYiM5n+EMP7dHt38BYok1H5UYFUdPJfPwaxAhHikVHyqIcUMZPnn4RYilklJSVUA8jRk79dnDr0Jkg3wQU3j4ZS42lcqCOMQ0Hn4ZopXHALFUHn4dYvRkMGXEdB7uE2JKD6P6BlaINB9Elj0vxhAeRb7wh7x9hHq+2C79oVSdsJo5osbUae4lky9D51itZhTRYS6IsskrSogxv8wcyaaXho2Y/712nbCJGokJoyd2KCNKZ7vJPDTC0viP9alvtC2bIKSIqFYPlyDKh31JPRRHbw842nxrB61bGRktpbqNHFE2ASXGQzycvK8f8M/2e0lkEy5VLFQdVCxFlMxZjPPQZ1xrn5x/flUXHVUtScNeLstUHkQlQ/yTwUOfkVycf/vx48e3p+Pw6dJnNddMI7fRVe+hSoWo4qHQKSFvx8fHkZPeKVCmUU+9cypVXoRcleAtKiR6Vj+KR/cjSpTXSEbyPbxzf9/eZ5S4XPwUGf/3kiLehvTY7B1hTB310xSb/fMwDpHIayj7oZjG1On7OuC3fSSMa/UT8rJqbTw97COhQt+NcfH7B9ZQfj3s6Rtv4zsZg6I7bvWh/68UO/z31EChvVteK7kKRB1UIOqgAlEHFYg6qEDUQQWiDioQdVCBqINiEXmanxGUFJx541P+V4lHpPRy0qrNJvV+DmPtN8SHl6hglkLw6XEHjDGIdNhw8HdOq1S9Jvlens5tx3HsYFwJ7YhP9bwfpBGDyOl1E5fSE/9ZNen6lYlF6zhzmDkjf9UJ8au4dJ3TtJIi0pHNgK3pmjj0QG1opLJ8xGAJXjp1Sn8DkQ7h0TKnjr/l4oR7q4sLRKwWM19EIrEvfsXX4kfw9/KLjdiyjuhi4qAztkJcj0PL6y2PXW7kGzule00BLkWL85Q53rsLf1c5b19eTim9bnTwCt2Z53mdNt7EGcQKSie1xmwqrgZ/e43ZGR1BQEEEOm01vM547U4CxBI7g8P7jSUinnfgNVpneP90itczOg0PPvvnHbdg4xiYnruXl2LSGIWLd1Mtqs37VbZcI1esLG/PaYMx99FhVsOgV4547wpjVbibFvxRN8VgClyP19/Imi3YtUY5bVf9gRa11eyKBaIFV6BTILQFIqd1298XJ5/Ck2XmRHwhBqHQaXCixiPekUgCmI+ZnWoNfz7EO1gEdRx7aHUQ0YHLWg3abcIXDlCVrCoVK7g4loV51oKUfSkysSUCSg3SuXgaFiaEpY8CEc9lUrEQU3PAEBFXlg72NSG9wFWbJXFe1oQnOTWDjVajJ7Zh3mkzHGaUBpG28Q6XWWAgLMUExZqmOTA8uNA152cYCvv+yESvfmXCXi5F/0vV0XjW9BEBxG6dTRu+ZytE5s5E2qBw59WJQHyGZ2Z32iNPnAgxWHM27zjiAfeQqtWeeuLT3BKJDPNxU1LayBBHiLjYJjKmJxCb133Khw3TdDGfzxaI4BD1Uw+9xDDS9zcC4hWQTghkH0B1F0nVR8Q9Z3Rqw83eWYBIZvBtB/YVqaZNELFDKbmGr2ukC7sEG5lDaRNCBZTW8MGUTGdQR0SIASLCk8P5dT2DGr3n6TXcfoCIsQKv59Jryw+O9MxGxAGmKIhHI3wc8w1Ego+Ew9H2o38Q+GniLH5aR3hEtIaYGPFEBI536sGJ2BTPa53Rro2WRhJKEccioQaPh3pBQl0W1uOZVzWbYrCej3hJxYjoABGDHTec4LlgfsIsxazrTUTIxNYIzmqSCSIagChmmIhsVxWIEFLoGXyqEXftRGwC9SN8CpCPLdm8G2m4cVYPnQ+x1JggotkTZeIdxDnLdsxlXtxCHC0ROSI6gewtxEs4sOGUrGsf8RER8bEKqBXi2EFEZ/1EE9rHhE8XR6RBxCWEgiXZOQQ6MTsbEQ1xB1iItLrPa3lxhXjnBwK4MxtdhARgj9uo8bi9eJeQjygiCJYYYzpZJNQqFgCY/pi3hYhZsBucaDz0AzGuMCodXSwt+utNsXg86swWuCtEP5yBvBDES1sM+aV9T4QbDHmXuG9vPl+W0QGiX69hHvcRMS3aOG0Pw5t1t4UISEycaNjtzvtQIxHFaczoYhki2IjVtkanflXDqlxzSPkSEW7QwigJPn1C5Jg0mTmbYdkBiFBKsuojpY8NyzK3XKRjjFdQrgcu4qOrQg0HgmyJ9ekGIu6LIRmstywbawIe80teCWFMNXyIr5IBC7C9IV5cskIc4QOczVuihdDbQoQAyEQJHpSLuOCSU61iBaC+WS6KCgyce7hAFE/Habi2iG5biKIQEifyh75j9pG+1yYW0aDPNUvcK1RVcEbkCpEbNQyPENrg2qURVuCsNRdxOC3IrTsCEXK1r9JsvQKHNRsDYhPGCwMQGdZu2o1gIC7UEjhWGtYQOR8sNooxxVQEQTPTGv6Uz6s2yplgeufcsx3XEPXhXsuB7836HUS3DrZo7ZF4BrZTxaq0MYJ8N6Si0OC8X3fxLG53VUTTedNxoEFMx6aDlRMI0f6//YmJ+za6mBLhdE1RaLiODY05yuvifty6j0X9qoGMMLZjA1ss7dGoH7Rb+KrdAn8+t/siFhFsNJFFCwf+eG4NBh3cMsKSSyxDSPm4vdnmwR1FQ4Eu/l2eot8eB/vid3xzI2+P+0FjjmB9KW41HIUeuMhXXfGoVhoUohZr3vX7Y0i29nJJUPXOJ+m+i43QwjDN0nrNPly76WTE/FWyTBeysTWTP+P04tTCIFGKW2hkN4j4goiSaPTYLWMXHYf+RbCC6cROKtpRVzGnxqTmeYPr3k66Rn3R0bw+ih8Iv7PecL6rHuY1qV1glx3+CVc02ZWK3zR0UIGogwpEHVQg6qACUQcViDqoQNRBBaIOKhB1UIGogwpEHYSIH/s8jTZe5PbQONzPyeyqIhc3xs0fvRFfKkblSG/Ep7JR1jreEFIGxMqbxozkqIKIT/u68kK8yMMhuli+2cslUJREfpYFYvnQ0JSRvFYCxMqTnsU/FPvlABEY+/oxngJhZYlYrpzs63o2kSLk1ScMEMuVm6O9XdImTIQ8/OsDLhFBJxdR78feR70cLsFWiODkv0evt8d7r9uLl6dypRyGCJCVm0MNdFOprFP9B0KAoDCjKJkfAAAAAElFTkSuQmCC', false, 'MOBILE_MONEY', 'Orange Money', '2022-01-15 18:04:18.708824', 2, '2022-01-15 18:04:18.708824', 2, 2, 'OM');
-      INSERT INTO public.billing_payment_method (id, guid, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (8, '8e64bb40-16f2-4f48-a115-08b3578c20b1', NULL, true, NULL, 7, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAR0AAACxCAMAAADOHZloAAAA5FBMVEX///8AAIDUqgAAAHzq6vZvb7chIY2KisX8/P/y8vnSpgDUqRpVVaT068WFhbrw4qXatzwWFofT0+r589oAAHja2u3Bwd5gYKLev2A3N5KkpMsFBYjIyOJ/f7NXV6AAAHOTk8FsbKpCQpYdHZG1tdXi4vCamsP19fqwsNZ5ebLv7/nR0ebHx+CMjL4YGH/Dw+FMTJ4oKJBHR6AsLJs6Opujo9RCQqQrK4xdXawYGJRBQZImJoe4uN51dblbW6oyMpxTU6mRkcoAAGb79+jy5bL59eD17MrfwVjjyXcwMIgVFX8+Ppd6fKGvAAAIvUlEQVR4nO2dfX+ixhaAYQcVel1b7KDXlxXMgiC+RJNsTZpkk3Tb3rub7/99CgrDGcTzu7eLRPs7T/4SeZvHmTNnZtAoNeIgDWWgMqKYwUBRzcZLg9jn5VGtK2ytK0QRnhnZqWtvfRsnSpvsIJAdDLKDQXYwJDu6bxAxfpEdy2kRER/6WoGdzoa/dXJ6Ethdq8hOj6uEqvIDdthb39hJQHYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdjAN2vtpv/bW6k6D4u32zcZOIWLW8AjuKTuxQiuwQMmQH47Tt6H7EG/78zcnaMaxhJ+hPIvru3Arf5ibKtxNqoYyR38MDGIo1TGi3Z7O2t60pfttddF9NdfuTWyrbjFqBVXQtbSZoW37RHt9H+Xbc8QeZVr5pNMaCqaUvXi+2rEYxQbSz0XFGJuOcJbkpY5zVu31v/1qLUcZ4VmIhEsq3Y7WYlFPag7ydp/R9zheGP+bi5yW4PbLiE7yqLJ+0M252g3ztsC6yY+21W2IhEo4Qd8K+VDb+MWcnWKZvs66neF2wM1sovjviheMZxu8XuSu1TPB2/TzsKH5fBeXL2/EuhJyLTuTqa7Yv63X0fm+v3qTYz/J1pGEhM4NSC7HlKH2WNgW/NpK3MxVyTCd6ZwGrRzd0N4d/qMRuSCcKx1AjU8/FjjLcZDeesxPcCzvjqJ+2YMP65nivUA6zY0RD4w/SRfpL2U6/5EIox7ITtrJCyna8UdauhgqUFW359dIBcqJ4flWb1p6vVZvvyi/1WtYo1wIn5aeNx7FjOIfqTkvIWTrRS30BQ0d3VgdWVUfzowGhb8ycGx5t53fwRNGRsh22KD/hqdjOg4jBvBtvbsMKcP/iZnKY2s4O84Mbm9nP0I6bn6ljrb2087upwM5d9plq3bT4rLdNfl0TNqz2oy1e2Y/yGRvstwawIwX+3eHT8sdDx7fDBlm4WIiufvkpfu1LDasW3mRFtp3cOR/qMOxKSUNipyCZ/k6qsCPO/iBaA6/trt4ENWDZ19bAzlU+yHpgKCodmJxyfN52tHFaJN7bldQdwFQw9ICdqPIc7oN8Zz9jFFPlJVKhHX2StgbGL7dbYMcfVyfvSerQGwfDbEdoBPGt2T60+9/mOHb8IjtDkemlSe/sAtj49qBoTTkX/Dwr7qRFJWRXa3GhXf5ULkeyAwaiqZ2sl+GvSZtxwUfPNr5iLORoYn+cFN2Znh7HWOdZHMF652JHB11KYifbxM2kCWgfYJiJe/C5KccTzrrz/eZlrZLjeFf5nNnZdEouRYV2RCti3En2mt3AMBN/8lIg2u28meS7Ij8dbjBzptQyO/XztROKemLXkmCiw4bFn7bbrNFekse6HTn6iArGo7HDY2ZnUP4ET0V2MhN8k3a8UrqbBGp9PspP7zDem8BJdyPNt/lrdKaXzI56tnYs0a6yaRgLZDeMJc702dTMzw3y9QLoCRJ90Zmi4P4J2Cl/gqcaO37WX03TKKsHQIJ9I47V3K6a88O+ZXq8NFjxcXzXD9nI7AhTGFXY8bKum69EQqvVYMP6BA723DGT/bClmHFvJDqiIByvBF6C+ueUPoVRhZ3QSD9vNsj6FesOJDuqdAe61rllUnjmvcTqUOTbZjde8mkChYvSpzCqsOOnn7fKHSPbBVad5/wJtKAO2kx0ZDJ7c5Vt3S7USLuUvmJagZ2PgWhXo2ygGDZB6e39gKp7V1APX2/Tnk+SMhle/gTP8e2od+lYiMN8zQLDcz4o+tT9J6CCqZ14lXSA/LT6EaYwKrAjIgUDnYo+gVWnpisFJdOgC9aPYm4NqTrHmMKowk7RZ+vDUQSfK8rT4/5pGkAGn/jKUMQZsBKd7dE8Yzu8dwn2sGCx6lG1uPntea95DWHdcXVFTP8wdbvSPojJTnNR+nMGldmRV+N0WC3sVmTnF9uu52MzXKIYWGLUwNRpO8bTNM3I4jS7OWM7Uo+if4RrM3GpfuEq51euAfJd/QpMM38OvXSBNX44QZAly2w9L7kYldlhK2luCrYZfhU3qet4C2c3i5lm7Bb5vFuY27h6mluze1jHgB3zXO2wpbzK/ZiLt4pyt1sN5rZ6/bnRDwLndgD36YYdUXWmcMQwBFMYpU/wVGSHSyVS9IEcUZTUzlZQhG1zG1avzcxIV03Zrwdq4RGmMKqxw3Kd7SUs+e326liex9aB7yyTF98c6VTnb0eOFBG3MAvub6vV9eFEj907fnuVVp2RfLMwNeiXPYVxNDsQO/dgpQ8X+da7fji4L34gLm5Wk1Cfpq/u5Yd4FA+M6CZlT2EcbcWG7x6mjf/4Knf+F/DYpZ12z/uTXrsis2ZgKMHX5PFJu5ebpmjbPMX+UPYg/Vh1Z6CKNJbVL+V3retlXWCKPMjqj0yem/XirLeY6Yo2NtP9X3P3Oqz3UjatsstxpGfdPTcm6G/JB0uvAwHrnZa7aNZVURc4q48m87g+hHOxe359K5wPh/Pt33BunUfcSZG+zvO/EFrzYDEerXqbi1W31Z8f4wH2/4PT+56EbmieZc0sywvf/N8nn56dU4LsYEh2vvz+IxHz/kuBnfc//YuI+ffPhXZ+eEe8e/cD2UEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA4G2cEgOxhkB4PsYJAdDLKDQXYwyA7GQTtETKGdP//zExHz3z8K7Hz58z0Rk1Qd+sY1CtnBIDsYZAeD7GBs7azL/89T/wysbd2xQo3YJ7yM7KhqnSjEVGM7jChGrf8FcNIlqAisfssAAAAASUVORK5CYII=', false, 'BANK', 'Carte Visa', '2022-01-15 18:04:18.711232', 2, '2022-01-15 18:04:18.711232', 2, 2, 'VISA_CARD');
-      INSERT INTO public.billing_payment_method (id, guid, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (9, '6c868d94-65fa-46f1-8f2d-ca1444d7dfbb', NULL, true, NULL, 8, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAP8AAADGCAMAAAAqo6adAAACMVBMVEX///8AAAAPC0j4tyngHwD9hhCqqqoXBnn///3//v8JAkZubm6WlpagoKDZ2dnq6u/v7++lo7YkIFYhISFMTEwAAD0AAHZ2dnZmZmYAAG0PCks3NWR5dar8ixw8PDz4+Pj+8ubLy8sAAEnFw9taWlrm5ub9lDEtLS23t7fY2NgAAEvCwsLmHwClpaWJiYkVAHl/f38pKSlSSZUUFBQ3Nzfrchnl4+/1qyUoHYMAAGf/uycAADkAAEEZGRlTU1MAADD6lTyBfqxBOY7mXRj4zGbiKwAAACZcPyvraBePAADX1uXXAADvsCjkOCJMVXJdYYOHjKjYXSbup5ius7343aCjdzX96+TPJAiRHAB2Ljrrgj0lDzd4hJYpHDP87tJpT0oJABr33rbkSR6wHAdpFBmwei8ZGz5LDizzxbAAI0MyQF5CTWTxnGhaFiHHkC6OcEv52IO+tp7fw504Lo3brleLAAlXUpWjnscXACK9hSn6x0/wj3xDMU96X2E7ACnfrqRSZ24sEDTmYFC6AAC7V0oiABoyABRkAACjcWrBlFiId4OWXSCHb1B0UWDRu7VmboEiACqae0qrRxiEGx7eQitLRF9iES0hAADjc1vp3cX0w4/8ynH71rFBL0OhGhv5tnxZMjD7plvTnSOvrsrSgSH1miVSFyU9Eip4VTM9JSpXOCiHXyyyiIuoMAB+GC2xWy2FbmG9all6O0zQtn5WLEfplIm0nG3pdUzti2KePDxRQFk/gTH6AAAXXUlEQVR4nO2di0NTV5rATyCNNyGQiwkBUuQmgUhCLgQB0SYIvoIVou2IQrtYOoqv2pZxxwqCVqfSzs50p4Mdbdeq0BbsKmWm09lut7P71+13zrnP5CY5AZMg4SuWm/v+fed7nXNPuAhlEt4XbO/rMr2o4my2B31CRsIM7MGKYt//85F9HUFrzvRBFz24pbm90vKiSmV7n5Ni1IVzavp2clBFsCpnvW08CVmaCU0lqyMIhL7Wl9e7KqyE64gGmPa1wJ5dbWuNGhtVeDuOBNm9IID93lKAGyq4CFgDdVnaNQj7dGy2tpeFBy/oyujW4PnOzeT3yRLMbNzN2Q3kBRe+0WRqT7PNCq5vL+jdFENqIbUZb3Ft0sCXJODjHUbrm0sDnyjAwMzbSwWfoAaT1wVLwfdlgY5dSL8mAJG/OPdSDBG6TU59l9Bl2rW5E59eAkkxEGr+zVz2pIpF5wFCmpSwicVlalQ/QEAsJevHUqXJAbzJ1FbMeymK1Jqc8mK7qauYd1IcCagGwDoysrmkQo4AwdLzfiwhk4kOb/al6xBtcummPWGh1HK/LG0mE/4VpL9KTwLUASpMFcW+kyKJk6R9g85giUi7qZm4/2Z4yrMWIZ7vK1X3JzWwAEpoSV7f0awKr67sCygHupr7NkPOwJnPjp1AL3bNw2M5NkCwVAeI8APCzVAydQFeX+p4eEDDL48KVcLyLnkH/Gy4YDeZR2k0WUAHqcV/n0YBkgN042VpyCBs2iQlkwvYjYZ9KzX8dKuPLEuWAurZV8jbzJtUAJERv9YBaHSopR/IMs/8KJ1FBJ43DiVCmvXPUXDpZzjs36xRAI76wj66TKy+kq4MV6ZIusfrIeNNQqiyztXY0tLoqqvU1SCBcG2fq7ul29XcEcb+Z21LvRYcYNF8tAR9ITk/+VL3xmLnk28gLX+bhh83dVBaJqOETpOpjxycIq40/LtMBkUGX9moPbZPGY/01WnXO+2kRksR8MWW5HWNHUSNdoPd5ZZk49c6AIZSAiIi/WaSFWtZrkAEx8uUEbbgruSDaUjl65LXVxjyu3D4TpU6/nnwozrdYao6wpQbafm7KmolqQsZnIo8WDUlG0CHfHRtuMpHT9WI/d0neZqpuzJU1dYiXVS5frd8qdoKXuV3ahKWk0dBekMuVSn07tjtn0wCksWuUWgFSf4dOv6U+jFJQnQ33WWUg8MaDfFynjHJdQf1uw6VXzdSo/A3I161xm55s5rFjM0yEz+v4W8UutUP5JZCev4Ar4jRVaRg6tSsapePpXkkbJL4FUOjA7JCs6R0tSUF5VKCll9bs8g8aqvlzq9zAG05EHbJdaCqcacsXUYDaVXybmo3O6QcSRVGm3mXgBSTpXoRKKHG/rt2ydeC0+n4g8o+sgGsi189nV7wHbYl8Wu0Y3gRSVQ/UdKrXF1X1TZ2VwRkO9DccWXzrr42w/hn4vX8VdotzPy16fj5faa0IqTj32Vg/5pUEk5ZpXY9BEGrF02wxOuN+CuQnl+zj4+d356O3yi9a66m5d9VFSBS1WZ0pnb1QPmJm+pP+gN4Zaa5U38Ola2Op9fy2X1J/KqPPB9+1RaTJZzE35KpTtUGUvnGapNXSOJL0VQKv67bmVd+3pmOH+XCr6tFaH0oqHWLvl5QVb4+/qrnwa/zb20GaE/enokf37lGkaRlBHWFnl+tutfHj54Lv089YR2v+Q6IfDImflxHBdSD+/LHr8Z/OQmvk59XuxdBTTmg3BoTvxPnOI31VOn59f5vSb0IO7+asGXadfJrCnxB45qWlM0Z+KViUeXHCd+q+r/+yYN6kaSSmoVfKZ2UUcr18vvkwzvUAQCTSZk3xcLfTWOeJghWaY9MmnLnU3fLmV/tTymb18uvlP3YSztSTs/Ajxs0rLt/AqD6g75eVpWcI7+zWQkxGo2ul19mJllLbhvVYxn4XXIxrjGAgLYm6NPvr0YZfWDIxq9InZZ03fxSN4X2RehwhWaiTHZ+rLOWPixqV5z0nevS3JlPWa8UxgI7f7ddf7Z180uFCq85m8a8svM3m4yE1+YqedpdwNQd1h0hn9OOv46Sjb/bXmnxpXzHb938tHaX+mhVGl0k8ac5WtMj0wpuWjXTBWV+sqjWGS71Ko1s9U+KrJ+fEMi9NhwNtf6q8DvDPll0lgA7dMljr20aW+B199ZObg6HGqeg7Rp2kxAQojpS1jYrlwoVgB9fwSkztZn0+Trb+KfuiaG2G0xWagbYdrlcqmJ4jVO7+lqkAwwu1SgUgN+uiUSYQLstG3/SQ1K1P91FnCiQPM7rkg62JK2H+zMc/y0Ef5V2coRLP0nYaIBAcyGc5LRPVjUGID08CmgfADRrMl5Qq1q7YDz+Ae2vFOhJafT58eddQkFLm8USTBk358NB/AXmsOGA6nOT4vMXV7b4t/i3+Lf4S1W2+Lf4t/i3+EtVtvi3+Lf4t/hLVbb4t/i3+Lf4S1W2+Lf4i8zPcQhZCyccp31MvCH4CypU4bIUn197NwUSjQFo+NN8ZyhPos4T54TqwsowMuRvN3jEmD/RTGNw2GI1mSSWspB+16y7xGpi2wVD/nTfGcqPKPO+OOTYbitjEY+HabdsZ7G9nJbf6SqMdK+BnxXek0VPmfgL9QfwLDnxA05vb01NdgPwtNpsfptts/B7yL9Y/8D1i+9juXh9IFYjrdXvCG1us8X6x1ZWvj/yzcpH/bFef1odvDD8mCA28PTc4tyoWcRiHp1bPPe0P4a3eHT79fb2r6zOLC0lEuXlexJLS5OrK2O9vZ6kHV8w/jJP7JN7c6OiWTQTieP/iea5e0/79Y1vi62cWkpEo+WqRBNL51dirUZR44Xhjz19Y0hm14poXnwaU8Fsse9nElp2RQWTR7AN5MovHGjIq7Dxe8rGrhnBSxq4dp3uBOFhZabcgJ5ooHzym1QFZObnOOGqO5+yjYnf0//+aDp6ooHRc/2EpX81YQwv2cCpMVuSD2Rpf044GNmWP4nszc4P4XzgWiZ6agIDHk9sZTJN2ysaWFrx59T+aAPw17w1kQUfa2Dio/4jRo6fJIlntlz4i97+nrKapxltX1HAXEbbV2W1V1sRbXT+sjI2fLN5NxM9+MBqjSYRbnB+T9n154yPLUB7gQ3N7ynrZ/B9LGe/w7KHTQHP/Iz8RY///deY6BUtsPEnFvyyC2xofk/sfUZwyUhENi+ITto8L0T7v8Xo/ENE8C82D4gqIWBD89cwWn98jyJsDgAe0MoU/4pa/3ieMlr/7ux1T7IBnPczxv+99fkUdwZ+T4w19uvIGA1ghYaAbPzWpvxKJv5PGJs/vvvVV3cr8l1OBpCNH+VZuLT8nppsvR5DGTrEaAAXbAzxj96gcnNEH/KDI3Ux9aGSDEOXyW/8Iy3p6NPwe8oujK4BHxSQUwrIbfwH4oEsVvIRWZGVfpLWYmChqWl5eblpsEcmBDciWzmuqUlINao07f+fCpKYduwDy9lDkpw9Cz9n42wOUL7kXwO/o+FgJ5GDy1K7ClPw6aqjiayfgnNxy50Q1/DP3oYmK7UYoYFshb0OHuDY+D2xRQ10Bv54uvbOFgnpUIAnp/E/TnA0AFrE7Z7Gn6wcmq53u+sPoAN4NAd+I0enW8qYkYi7voEawHJ9BI7Z1jM91TnFIbb278fmHz8GAr/xr7gx/yFD9ujslUez0XQqwOujtBeQ8/gn1+AGOODHz47RoDsCnMixF0O7m5BjG94aIbktss29TKy9J0JU4m4CK5lmtH+S/MVL4HAjsODF7mOggHgcOn4JqfLZUy6bQvSRF5zN6r2SBn+c4x5FZ2w52z+ijSnzAwlWRn0TaqoHwoibR1NEOQchs02DG0yR0Ag7SfyoZ5CzsvH3ngOvf5OHw71m8VN8Me8Q1siQ7A/YJY6NCN5D8WPwHxGwEfxvR/SkQKZRoCtRsIQkI4BVPwUQdzi6FFsb/yBBPECi+SBwuw8idKB+Gyw0gB7wtil6yp6GQRIjmySPqJ9WMkJ2/rJ7wP/fmF8wz1VjTxsZEu/f+PnnByTI33/w840Hx/7AofFfYQ+BT/exNdyH5fv7f6pCdGLD4Wj5oytXDmMNzGLy2fLo7KNE9McQ8iZoDbwW/nqV/6AbbN3BIdn8D2Dd1C8jdW4FpIhO9zaFn0sNf2naH8Lf0LzAQWYRrwXwmW6LIzi8ohEgvS3gE934DIE1/dN8fwSbyT/jx2Dh4Q1h+DTs7R22D38VPcPhQ7yz0XJO8D7iTpafgT3PNAe4cTCDt9fLj5bdhAr11JN456D87garmuchQrrxNrz+deOCypA/Bl2/uQ58Eq/4f5BTOXTjf3HAtVrRpaETEIhh08enkdXq/QWoyeV+if+V474SuJd5hK6cOn/+7vnDAewFcIro/ziQ1+tNnIFTIOuwQPiPrJOf44CLdGEo9hQi4YA2tFVuacdVsJEGbCDkGFZ+HP4nqhGCex2tRj6wsTvHgZqHFhdGeeJIlyawX4wfuo3zEnA9Hv0U9MH55sEroiTGf+6T2mH2Rx40N/6TQMOPFZ2M0gSwZv/HT25I8ANjV8yftDVWQIMDyYY+VQ+aGcQGgI9h5h8bFcVrwxw6LXiPBtBpaPb45Xe33+2fB9YPgenT2DtzR8OIC//9joDGf+zH0KAPOEE1aO0KCXrRH09fLot9AdHgcC1WhNcCbhKuBm8ikXF1PfwQ2nvqSczjJPN3Qxs5pFBH6gOO7g020uS4GqHHsPJ7xiDCn6tCaJ7jPuM4oOaG5uJ3Tpy4LHDCF3CaSxDvf/Ah79/n/orQw/sfX3Cg8b8NI6v33YEQh2ZprJ95Mnvl8bwF+MH1UGVvCHEfnP/+ONzEI+A/tSZ+TuLnoGWhVXvgxAcI/1US61+JbIsQbUyR7oEVIiToqAdbSKTTIPilb38S/oXjnFCNbtsRNzJ0Z4TswfEXsLXzN8T/4pH37GiQBPsesII3QF/vjd4C95f4Z8fxAVCVfwA2ceb8PI4E0cQX4D6HwTpOrdH/pfYflKzfKpn/NIn3gxHZBKYEkvtgJ0iDeBglstfBbP8e4De/JnCBLwTBgf4xjKDBaUS1opHfV5OwBuEfjRybGKQz2DjrwzdBH4fEuw6E6KOQqBdJHbY/wgkeJU4jHBgSdRAL8dbVtfITW4ZCl1gBJGjJ/Gl2F6YjUhCAeNCDywJcKlP+HsP+dLr4P3qaQ3++CVr0HvUhdOLPCAWq532QCCdip3H+++pT4BfPhTguUBUKhXy/fAY2cDZ+lyeJHwB/C+cL4XAw/vkg4mY/eJ3wz9YK+Nea4x+15Skc6l4ZxM1Pgh6YPyJpD0zgIK2BDyArTgyRpp6eHloXNrHHP8+EOGHn0AngR5f+DfLYH0C/H0+8DyHxhDhx952wFbSBuEuE/8NP7t69/nsI/+hMXPwohDHBv2dxIPz3z1+GtX+CmBf9I2n/6BKo4QzmX1P+4yT+vXsjNAkgdDVCEyJpf5xfejoj1EVIOYg7QkoBzMwP9Q8O/w8+AgXfuQjrb8LCA/FNaPgbD+Lxa68hLhCG9r9/Dkx7/L4oxh/8xQ6RMB6/WA23MP7o8MmqYZwIsOufrMNNfgpH0ZOPvnKQ8L/G+kfixxVNxG0lfXsCCU7OYWMggNO4HIYqgFR+ESJSXWAkxvZ/D8K/gO6PcYgXvwC1DkDtg7zYwG7gv44LRj7sw5f8zbxU7I7/BXi/jYvXLkulR8CCowSuGB7N4yZfukxnO+PwD6VwYgFPBlgrPwC+MoibmzYylEHcdIM8wkProUFS+ZF5DvXEAEgHgJHf86V4C8J/fEzgbg9BIBj5jzCiY03CcVrUjbwZhOLa+6uxQXrR8Tcgvf2L2Tw6UE0KRRR8DeFfuB/wOgcVT+KtYdJlhzWzV67MJsZs62h/3MsjuLTmw64w5Y5M45NZG2g+HLxKO0dYBqVOM3P7ez4auhngT4hjgZE7c9UCf+PoBahjAh/6uNuvkV5EaPTocegeXYoffWcYZxrve+cC3Jmz0Ak631+Nb2N8cgAMgvttNRr/YBiNH4aEtx1Cg/dfq9B4+eEr5ZOta+v/8bQ/Q+odEBr9cY6DOtddH7m6t56Gv8EGvGKQKqlJ6jQy85fVTAwM/HpIfKv/qDgRG/i1KL7f/+7loxf7Lxzt73/3+Ls3j4rmW+/M/27OLE5ctx2fn788evHChWui+dih6MxA73z76VPRU/3HT7/9m+2Xz3+w/fjbOCOswoo/fX/8+KQc/tfQ/pzQSZ35ADXmJjn6L79C4wINde7lZVjCJR+Ji3IBzGz/ZbZFOuwnimS+H57lMzdEVphH5+boXLCJiSGz+dUdO57MzDzZuePJkyf7d+7c+R2e6jQzs4Snu8xM7inHEwHhHykIlmaWonuWJsmHhTXxQ4N3kjGfTgf96sQBqAJxroOoD14eoeG+vrMJgh+E/SZEh40HYTlSP8Xe/h7PxZSBP1G7INJxUdH8Kh7iSBnpikrjYElbotL/EtL4Z+7jX0hoOIhFymXcFP5wFXMKy1N7cajb1jndZEVNV2F1A0ECDTg68W5T7PUPOMCoIXvqGFiaQb7MQqrf7M8/cn0CIvT0pPzdxfTCZXj+Uea5l37QVye7v1NlD+Pod3niLZbxb2uO+Lk+L+IyPP+BEphRAfjhtyjSh+BDjM0/2cry/MvKfbszn7IfpePHE/cXc38ANrSTsf2/YeLnuP0v5VN2pOWX+sC5CmMwgBRZw/D8FxWX3/MDowHsxgP/Cc0DgKxy5PsVlud/ReZnnQFgZuaWmn/1m2dHWOJfcfnLPLcyPvlUhXHil4y/5L+wMLbx7R97AKsCyBNgthmw5Ymbfo+fbf5bkfnLcskBzLH/SKt6/g3OD90gZgUwToGNss9/3QD8HlYFiIyzwKKrfub533nl37F/hzF/WZleAUwuIC6yTP8HWfXrzl40/h2Pxx8ytD8Wlo7AvRr/wlJWBUQTR3T4ReT/+uHjr79m4/d8OZpxCozZPHoRbNo/NpNNAUsLrWUbhH//4/ce72DjL/OMLWbgF82LMfKdDn/rs0w+EC0/ZfMnnzlr/b8jT/LStw+/fmknW/vDz8UJ0VgDonniood8+Q328m8/n+H7bwutHk9O3//C0wryK2ztj2+05uKEWZQGftQJ70D/pfZ7nbbWhfMJg3lP0cTk27ZWg9Nmmf+c5xmgGfr/BkZw655GBSKB/+FW8jegW/03n00mNNN+YDExubrgbzX6JnjW+a86fqO/oJK0Od2uRvvkwE8t3NM79uUPi6NE5hbvfTlm9J1mj9/mv3nk1ORSgsrkqWcAb9D22fnzLRnmv6YxAfJ9yJpYrCxWk+LLmp1srX6/bfvNhYWb221+f6s/3Rkz86vvFs2nCG1r+vsX2cUD6LYsJ8vE3+UsjOzLEz+LZOIv2t8/KaD4e9PwF+nv3wD/y9sLKsn8++jrSAKhqsJJSH0hCcc5Ciu8JsO5gL1P95aWwkvh/wCWKo1g+/Y0b48pmBh8oSRvgvSzsfHLrYLS66yLJFwh+ZPLW/xqQ1/yywZLR6rwC6qE5Lewlo4ESdMnv4W0dKSDlPy1BfvDPxtNnORN9sFSDQAB6XXEyW8bLRVpkxq+T/9WyZKRbqnyC+reU1gyElLeC6i8kbCkpEJ5y7hd+1rfUpGAmvd5E0kEpSW1Jqey3F56EaBKW/YJyW8i3/ziUrwfi6XUaoC2pF6PS33PcSlIwKR/ly9eUUK9AKHFtCtp2m7QVORxsEJKnfa1zpK0l04S7DDs8teVypsw2rXvZdeIqzQsoD059slidZVCDKhIh4+ICzRv7jQYaMzYxmAbzs1cCEGWyxzk8A61m9UEAs0m074sg90BCAKbMwwK+BFvRfa2hb6Aqatys9lAANM7w9l3lBRlqmDa98UQa7AZIzGPcvF0NkSdZTM8GfJZ+kzEpHP4oh4Ewj46U8HZ11HZZnkxpc1e6+qiGHW5W7MQrC3YfJC8irN9za4s+IL2upZiA6xZuivagllc+P8BCS0BGxQPyBQAAAAASUVORK5CYII=', false, 'ASSOCIATE', 'Visa / MasterCard', '2022-01-15 18:04:18.713825', 2, '2022-01-15 18:04:18.713825', 2, 2, 'HUB2');
-      INSERT INTO public.billing_payment_method (id, guid, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (10, 'c440ef2f-b612-4551-8925-d0b5036a6870', NULL, false, NULL, 6, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWEAAACPCAMAAAAcGJqjAAABDlBMVEX///8VNU7qYgHqXgDqXwAAKEXpUgD//PuUnKXqYwDpVgAALUjpWwAAIUDscjL52c4OMUv99PD2waf3xaPraxjypHoAK0cAJUPrZxHyqo7Dx8v98uz0rXrypG7viUT0sIH86uXvjWL64tpRYXEAHD7a3eBqdoP1t5L0somwtbvN0NTr7vAAFzrxmGD62cDz9PXsdTjxnnzwl3J4g47sekMrSF+rsbgAEjiKmaUePFTIz9Wqtr6cpq8+VWlBWW7xnGrnQgBca3pugZH74s7tdif4zrf0s5Rkcn+CjZc1S1+2wchMXW0qQlgACTTug030uqHwklf4zbHufjDueh3raR7vhzvuhFXsdjzyombxmFc0PvSsAAAWr0lEQVR4nO1cCVsayRYFu1kbTLs1iImi0ChgJBPEgIAOqMOik6hJJsn//yOv17qnemGTCS+TPt/7vjfprq66derW3aowFAoQIECAAAECBAgQIECAAAECBAgQIMBq8MeXdRtfdlctzH8S71OijdQfqxbm/x57ecJRPubVZAOa5Pe0B++FNRsBw1NxloombUSfj7ya3CVZk2jydShgeE7si4yuNfGVR4PYbopaZG9Cvy3DrzYJnqrogwPgL3XsYSZubmkNhH39yW/K8G40ZSEpbM3x3UYUdPg2727wilsC/cnvyjARkZ2H4dBnMBPJvOv1xg4wnDQeBQzPxzAqceqNy0zkE2AkvhqPftNobWGGY+jqPrsYPoIFiJpvd7+d2/j2G2UcizOMZiDqdJKxH2QSxMTGEgX+5bAww6F8EszEd8fLGBgJz1Dj98ELGN4mEsWE4+UZ0O/hB38nLM5w7BOaiRv+5Q96Jz7nlyfuL4jFGeYj3tf8OwzlNpck6tbTyaGBna2tmezO2YnZ2tH4bOsf4/GEL/NbT+/NsU62nmYT7thovnXmeoMMz9YXw9EzmIln7tUTGAmWU5+w4uX6OzbUJj1cP7GlPdD+keV5eXpcz2YTgoG1bHZ93yHsxi3186jXmUJn774kzNbrb6Hh2cds1nrsdB42Dva/ZLOiOVYim3333bFB726dMh+vm50K2e1z5DirV2qJijWq365f7/nxCtgEU/CFe/OWIgnh0Y4zdgQWD28zBdoUKUg+MJ6caFmm9q8oMryVSAqwLbTxhOQ2x/FGgvrZ39OXP8k+EFNMOv5xwkuPv0e14fmxovtcrLS5RmO9NqRLga5F9/OsZVTku4IP387C8F0Cvn2Db9YhkmBGYocaA8PUh6AxHNvKWuoPDJ8BLSBsahcWYQP62d/YeBUVsK2QMJZj41WKe6yttMOCxI7XUmtuCCksboHMGsN7uw7pUlRrjDo7oh5nYjh/CKp6CC/2vpCibN9NZhgGPdBy7TX7S2J4c42jhRAFijmGb946p5Y61CaUf3Q+Fm75suDGjuCxljr+hIaoFa/vbpPOtqn9ZTEc+gs2x3menl9Dxvye9TRNh8XXN3+QAjGGN10zoDaUGgLD4u2te0lSO7Gbfbd6pnYxG9p476XAJpJEMcr8nPBY/qitVS9m+AlC4sQJPQfdFv9iT6fp8Nr+O4z/YlMJ1hqxQYHhNdFLD7d3zr22QgIsbGwCwWtilm3GTRzLs+32shiOHXqWy87IDIu35I+m6fBaAsW1GN6Eh2IyqiGJRCVtz40Mz4PUCVmaayBYMMfC4svHGw+ZvSGeLYlhJE08ZzHNCRiJQ8/G3gxzMBm+eUd9JW/v9OPBo/0o9G9HiYsyLH5mM92C0Cj6eKSfLj5to1Z/mp3hR7Pln9oqYQ+pKMPjbAw/bdPXgi1ACKzp2s40ht3SGbAYxqMoZhHusqBaW54Ma9FsKiU4zYKoPxZ4ZxbN293SUOAA34Az37/xYtgYytGr+NFsGQu9KKfT8RHCMtvi3tH5kfgF4u8ZdFjUQnajxrmeNRi+I0MvHFNP8Fh868GwsP1ojHuS5cgUvnzXH5+9wbaMYeJSfIYUA0xH4s5LZit3OPiK8zinDl7I8GuwkreWXFCvsNdyAsMoV+Lj+y3zzc3xYYw7TU3t4LB/EBsfYy6GE4e28d/CLZo4tJf7GJTbjhFizHmIt3c4Fnna1CfbN8BMduzVyD/CctIEX8rwDfQqmIJtgJEQD6YyDJHP/mbe0Tvl5VHuxXGWfWSldly0RhEYl9gznxaDIzD7fIa65EL7UOgrWw7BSu0wHobMG01mdmkMh+BE2YotzyCES6E5nyWn43EHiQuXfO19Y28sqbmMg0a9S8JjRnwM8n2b4fckNbddoBArPrsYxorXHkRWWbJpL2X4NSjstiHAHRYusekMOZ0Dr9jkBEeV5h/iw3SAPgzno/CYVPsItr7NMKPHwUOMukiYFsWHYfTwkB28lOE9CPmSOsN74BpSHGdz6zB0Ja4fcqCClWDG4S9lGMPCc34siPlXwTCe6qd2tDkcgRtIclt7bh3OoxUVONBXqeUwvAVG1Hes5GSGYYLLZBhO9cXEHu5s66rPFIYn6PBRwjMn5bEkHT6eJWOZwvAJtVwmw3sgQfQotPFIax7lz5jnZ3iGSS+L4b9mWMxpDMMqLZNhPNUXfnBRU4JPDOe2EkeTij7sq+UwvDuh6MOwGoZ5HjA8cp7iz6/DAcOmtBD/Js/2yUgkHddU5tdhrtblg+j75TCMztNvrD9XwzCe6ov7Wfpv58Xtl9hh4fGVH46WwjDY4eyB71gbK2EYU4w1DNWcp/jzM0yRoCMscWOJsUTi2N09h5/O8M1Xbz9852g3fzwMHQtThHgpw1BUEK+njPXTGcZiGvD10Xlb8CU5nTPyc2GJOZ2j8uPGz2fYs+af+uRsNn/lB7OXr95jHx2ZvC2xLuFHRMz+0dXPZzj/j/uMUeQvjOiYv/JzBkuX8vo5zt6rzwmz6PtihkE64dDrhOfoU8I6+fn5DId23YbYQ8r5dXhvByt3boqPrlPC+pIYvoFbNF4Ub35M2vd05mQY1G8ntCCwbGITcuJqNb8OhzZBOnH9rzy+i23tngva0yUxzP1+TTjkte3oeDchsPPh+RjGSyUfuRnMgZjbTGy7N8T8OsxfERHXzq+tQ6bQ2dP1P9v64ePyGN5Dfy1kD6+frPOhra3r84T+cjGGtyhFWEv8FVoQ104zIfzjbrQAw46Slyhms9/eafj2ZVs0F3V5DIeeuZBIELe/GGO9y2atKy6LMYzXdtayb/OGtAcf38x2ms96gXUy8drdaAEroV/YdHRsHfazfy6P4dD2lLEWYxijFP2OoZ5+p1Kz3b0EvHMocdZ9U3khHdZ/I7Y2CctkeGN98lgLMrzjlZDNeueH4Q0vm/jOo81COjyN4mUyHMqfTxxrQYbx98euvmbGDX9Dy/mjAwOL6bD2ndf1Rsbw7RIZ1u88TKjELxatcQfeizPM/QhXy3G9Pl+U4djmc8pv3kLSygKWw3Aof5LwVeOUeLxITqd/4L4hOD/DnJkQP3s1WdBK6Onq8eekx8SFZPLxVd5ssySGQxtH12LSY8+kookTK0Gfn+HQnetm/fwM7/1J1wqjf3r+HYVrakB/BuATfOZlWkzE9vZeJ6Mp+o2AkEpFU/t3eSbmRpL6eQaGQaxnYBgev3X80GAj/2o/muTGSkYTb/P0l2A2QWb8ccUJyZB0aMvNo5CkHlNajzPevUQSEFNbTHvq9Xn+4OBHImn+pYavB8chvr1PP/M9tt+Gzg4OvlpDCT9en4X4RjN06u716eCH/Zcmvh/chSZPNkCAAL8QKjlCpbZqaf6LaBTTNk571VVL819EOsyQuVi1MKFhyRvDcVtdtWyL4gMxnK6sWpjQfUTyhPzQGnWbq5ZuIbRBh6WVMzx+CPtA1iCd/oocNxWaRHflG7Hdkv0oNu1Y4dfzxT2JGO6tnOHhZIK1bVb65Shu0JyU5sqlr0sT2DW0INxZtYxzogaGL1NetTTV3jSGNSX+xSLKcYbC4eLKGb68mmYlwuGH8aqlnA/VCmDl2jFuTCU4LK1cD35ldNDiZsydlZF4vf4/SIt+YcQjRPCVFdjUmvcBw0vDkIJzqceeVnucFjutRK1arao2tP+edTDrq+rEAIq69mznGPrfiMXYCHNMzRdqgaiUBvQc8xC5kcMv1FyuWerfnxZNyL1+vVxxhfUxFQqIptyV3ODK+Ko/9Kso1rSvSoOG2Xe31MlxHdfUSi436A9a1tin3VK/6a5O1i5pZPZ5reKUR5+L/vCS+7iq5soDa4TTbr+ee2nCctkFZW16P5cLNEr5oldQ0ooEllqWlHR4UHZIUh2csojpb32GuWEjbX0lRVpNL+VQy8OukmZ9y1Ik3Shc2B3XLoa9Rlp7DQmbJEUi3aYj1Ll8YMHahzrru8DkKT6YT8adQquYPi2g1ONh4TTDRtCmViw4ZzYnxmgM2iAlMKwMSYJRWvaK7jRRemVOl9R7aKd9WG8o8ECW+y6K1XghrDg7l+VI4cJs2v5b8R470qpz1Z02JRwyEx0mJOucVtuDcEbmZxcql1puCZTCi2pH5Qx11QJjgFI2SEdyDd/oWWrFkeJKi96UQs2CIzyRJWc227735E+joGvs4xp4DCcyXdzqTXrRYukoqJLU15Zz0LIkKpKKlh48h1BGFy+w9sjwAzyPg3kuIfH++Yms4HaqUAFR6vfCrsRRljklrtZ9C1CKudNrk5JPBbc6LAXlShc0UaUTatI8Ptjs5UY+S+yY2XxQsQrVBX4o05Mxo2t6SmC3lIA0YDjsKXkEy6Lqvb+C2gxPrAHqemmjzvqSifgLikqVdgFtgcVwOzJBeVoLxxQq5MwgZC1OE1aQCbtMJCtmkd6RmVDT6mBqQemKur0c+RMcls1ea9aSybIxtMMmy2QnnBbXnCgXfqJHsELUJsgrmwPABxEw1vOhAoNFbJtVzfXYgst83yVdDinz0K0bKIy4hfcPqL2gkBRX3HJoMYQOi0L5wXTAalH/h6J0C+bY3Ra3Kg/MTY9HxDCLP1W/8ovp6God2iGy3B3oA+Cqy62FGSbrFJbq47KOcY/iIc0hcc21AEGRS/GypTDqON7gyCGGW/hYYyajgVfrD6wxZyLkyFWpE4/HO/ctY53lkTlYM6Jl9aN4/NKyiZea40ddjNu9XcBDJn3Fz8akDRsIHly5urg0bEIOK+eni5oJsP8axVZVgjrONPjS8FjT2X6OG2yMAXWRGC4iaenGUF+7AdhmTWi7bQcfp7tlqxxWycV1NZXvTUPZjyjdOJcdVJtAGwVdHagDMMXO4UT1uWasuZ7qC1YtsTWODChJAZcZWbBGXutPspbyQ9zhQzvhvqsaOAZ+SC3HMKNio6IaLFW5edoMX0bgYfEChqyp2sxtQyl3O06PjuEFY7gGjs72YpoVwEGUdKt3YZQ2L7ppVa/DsLcKHjpVSLPRk86D6sTicMt1xFXzyNNVUCSJPYXlT5PScxGXvRwF3ASOGpOmAvbcVI99CvuYWQnOp7GJ9sEQ/T1ss3kY/1ElG9zAKUNX4GLmQtU/gTA57k7fHCr1AfEeUNkCoVWM4cxHWAFJu4cbfJhw2O2VW2CgycKVKi0jKbaN2IDRn85xb0jzMfKZB+rpRII1t5pu+aYzsVpN+1+tQvuPtlKMHJ18BcqnFuG5+agHJ+8znwvHjKFjJXLJIztqz5H4JI8K8hScnVX/Jpl4AV7OcIVzPd4kp927s6aX9yrNfr3eOz2FLsgdxOjSjdL3zkOs6WN6Psq5hnLBqCy26/1+v/HhFNMlmxvwCyQPqJLbopIzkns5FZArvNhK9CcE+mzUhkOx1FynVEgX04oG3shQSAO6GunQLojBVZGM6efhiVQPTUG1UjFqmxltaL7QQak9hEdUcrhMO8cFgPuV00VA2jMdmwvoeGRWbMzwvEkD3OblzlU6Inmb7wxrCK47A4qJ8Y+5HNUSiDDF6OfKw1Za8R6bMYw+jYJHChbcka1a9OrQgchiV58w1Zd7Y7s+PS7IGMRBba160ZMzvs5RbjDhMQqEGBZiCavyAwex8mhiVH85HCkTtpzNAB4psFACYxjZOcosG9lD82djGBwdlh+quQKXZdm6pQ7cNTKARDd1Ib5A51HDuMNofAF+bqIz6YxclVsECyU8fRqokjUuoDs5njJxulj9MgYMFzlre4n184gVaqoPriIZ929lyMQgs8fFBzUwun2jMVjNiaZu6FdZtPBg7xTwpQrrsEaGwH29ZjQLw8XQQgAvE47w/gxLTYrJsAqG37iXqf1fC8sPcFMXHAvmEFVa0ohRgccSnDRhIw65CpOs2WKZG5sicWCYLC5sVtc9tjGaSj8o3dBC4IrD/NJ2QHyT4WoRJik9jAr1drvNWdwMY7gDCT0yDA7QXA5MwBT/m0XgqDQWGveFTrt9yeUWNgO1ktOX6gBT67qw3YaZjgo+uF/wji/muwMHwzSsxTCkf3JrwK7Hg2WlsA52QAtvAsBymBen1e4sDOdQ0FFzbGkhaB+zMDVYspaX45WdDOOhwtLvhUCYglGrDjwUM1J+zMZGsNPgMVlcmqZdezRx5VyOSmMGhqEwE5YK1B8eW7DaNji6HpPSx/EawMx72QxjhdGxebgbmUZxG4MgOPIE4iF5g1OGe+zYlSBfIsN+dlgFLwdFjhq4kYi9OjAny5fqIDPsTsyxerTsa7xtSGYU/l5GGW2urgsqJLdwfSLUoT7Ip6nknhUuT6Nc2kpoUYclH1tXg4tfePSugpdM22RCzkxVHC7DdHYPOhyJO1++EGAJ5AanwypGMEa6BHYZZ4l9MD1CA8kJDdO3Lk7jrQr53iWhWtdWF+piXEKG30Y85KH4E1TJfWEbZsbpDqHWHMxakXLA99cOfS7Obem7t++zl2D2D0xnMBDBxmBPreXgirktp36pV5GCxjBQgJXHCtbv7IcDr6op1j5cxr4NU/W8MN/uSoUFz5BAUaW+WrPQKfzNZU/mGQNIzjEcBovLZlQH2tG4Qs7csKwSHmPh1ZeQXmEoynoSA0F0WAaGYUfQtmp5+bSCj+N10RA+dVb3Yu1WWlbqL2c4LBVPLTivDciGTAOP85pQDE+UIVmixjJ3GYeugbD9WOaGCnesw4daVW3qB6H6TkeHTDu/moONQi6ALL1EjtdjXAB3zlMsqOw+Z7Wqdlp6GSY9Q1XVC9N+5mXCMqSoww3rwEztNDApZKoNManM/agYLlrZWqHyN3nS3YHxY+94T4nYjCLDGkNmSa5SwgyTnQ9Wvaqm8MMZqe6uL4y52pp82u3HjXua49L9qVnmiizIMCYVvkhbngovmMit+87FRTnOX5ZgISleCcEbWXiil+n4SCGbh8B2zy0Hw2Gp0S9rY/cVbmEy9p/W8KyajmllPaMFx1GafuXTAKuTttymZSb0p6uwXLQlqnON5Ugmk+HNidxiFhePLTBY63h5y2phQrlO1l0Mf/VCWwLXzQuqSmDVlBwvtPSKeHPTztLuFwwlpt57Csukl53WtLZkcWFGXHjg7QDHHp3ZMGzp9N+jUVUOUp0uiz9JlUANEOXJFDsrCstjOIN3Ar1qfJEGFmPZQlNMys8IzDM6wM6p72bKmBdyPE4TZWUEcrBcBbwFydPzcbwMtcHEY45Fb6PkJtZFZVkKczfWLjOuJsqwTdOEPAQY5op+BR+X3o74FH/lorHTq3XXKYQkj4fEZpHpGBwDUo2hNzGUMFD2vvxtfhRZsFzhfxVYv93YunfWw5v8+YYsd3PYBzEMv4Hk0rTLkUdjA7VCy336JsvyyMqltICDP/Zs9bgtyI7DO1BKZbSM4U6a71nruOe+/a4LISkPhfqCZriZiXjjodvtDT3sVafHHLishK+aqp6kMUhsK+UarOc0noG3W6xx2nFZtHZRL0igybKsZEb3QzYzddiw/ao+515bPxhio2TY+WAzTQIxhtth9iwz4ZLqRX3EXZnV9CwijUqlxX8Pm4v7oH156W3Zq53+g+7I0w/3w45h0MbwGXMsKjxE8S7huTvAVDvx+8JD2uhf6haG8TGnOeP4laS/TF/1Om1dvBr0xn4E0KZndMlt8rg4RmdYKDQyJtLdwiDe+ek/N67mjPuvuX/nz45UVLP7cvlSdScGFfOV+3dlS0RNZSJoMqz8F9EBAgQIECBAgAABAgQIECBAgAABAgQIECBAgAD/Ev4HfD8RSN4sp/gAAAAASUVORK5CYII=', true, 'BANK', 'Virement bancaire', '2022-01-15 18:04:18.719393', 2, '2022-01-15 18:04:18.719393', 2, 2, 'VRB');
-      INSERT INTO public.billing_payment_method (id, guid, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (11, 'a9f01102-5533-4397-a239-d6fba953e919', NULL, false, NULL, 6, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAWEAAACPCAMAAAAcGJqjAAABF1BMVEX////rYgIVNU7rYgEVNU/qXADrYADqYwHqWgDrYQEALEfypIYAKUXwkmv0s4cVNEyQmKH98+zpVgDxmV/62sLufTH3ybnsaxn++fTtfUn52Mz73cnxk1z86NwAHj/87eDrbiPtfT375NMAETgAI0Hc3uHtdijz9PX86uQAGz3qUQD19vfxmXV4g4/Gys4AFzr0qYL5yq/m6etteYbviFszTGGjrri5wMYlQFdEV2n1u5NVZ3jU2t/wj1IAADBhb315iJTviUOJlJ/0spH2waTxmWnnQgCZprBKYHI8V20oRl1baXett76iqLArQ1e/xMjscg/2xaLsczT3xrH2tpr0rX361bbviE/vgzcAACUAACruil/zqozcKogDAAAeE0lEQVR4nO1ci0MTSdLPvB/O7kB8EEGiyAQkSJBkQ3hEiQjLw7i6Ppbvbu///zu+ruqq7k4yCUPU9eRSt3oy6enq/nX1rx7doVSayUxmMpOZzGQmM5nJTGYyk5nMZCYzmclMZvLfK88Mmf/Rg7mV8ntZSf3Fjx7MrZS6xeJ4/+MIf/m9nisvX3568HT6buuW4zjyz/86wr+GjjUsQRA4nh+GT54fTNvtbbXhg+dKfilogHkIRw5gHESRF/pTYnxbEb5b9nzfQ6nfK/aKQNjRO1r+CQQugfg/8Sfyni9PM5LbyhJ3vcCBPS6wKRdHeMSGAVz4KxIIB97a0hQjubU2DAjLed0c4QBeo7eFDVvCgi34ywumgLjuKLllCMO+vCnCcjcD8wby3/gPZgzh9K5uPpK6pyS8VQj7gj8l+93Uhh0HCQaRjQJH7YUgspxbhdHXiUR4WpZwHF84SiGIsHwc4V/Bs+877p9HAOGb8zDHEFbw8DeUtYUwAleH3g7cZvjl+47755GvYAnh2fwFiqGfLn3+wI8dERw7/pPvNuSfTKazYebhaEEHDZVTT4YSYMoi4jLeqFRKBwdfHkq5+vVgSTy4qVQq8wcHsocXB08Lvb90cCVaP7o31Hj+4BE8PiiN78TUtVRsrDsvoPnpwUhriCWC6VhiCOFSCSAOeEd4O/Lh08VPL1/Xy2GIhB2JP2FYri/cfTA8lKUHWkaql5UHr/16GEZI+l5YLr8YalN5MPz64ut6iK3L9dNFQ83zMg7FC+v385NY0CXG699E16N62ZPNwxdLgw2vfIhoMWLz3uj3JoE9xobF4BciiIvlh5w8f3DEWDHWAFcYYfhhiezauxrKrl/WdfVyWP3nK8+PYN0CsAYIVrxwZSBznF8ToITydaCu5UeRB5l8ACPyFt5wsxe+J1hMBpj6sSknV6EHTAc0KIzPR10nQ7qUBLBKp4GHGRcMLPCCB9xwGSqykeVwlBWJEdIY6/83DcKlvz2LIwrHp9HXcaAinoO9Aj5Q/AC5SeSXgwEg7/oBieMNIvzACT3hRyNkeEgbobPIq780tsH8fVg8xDR68rR04oe4GgF5GYoel8U2AP1yGFZUPx2e3GJQ9rEXXE9HNnT88qAuHysE0Ap0hSHlAWKI8F6d12O5LBYKZu1w7MUJdOC/noxwPkuUvngOZndmbaHuBJSRgEWgBeMMxUz9yHz7rqey5tBEuHLiIfa007An/G8gr4FZW3Im/se/PksgsVWEb/gw65OFKJDrjdkoDMfgD9Ql4k40XzlUtGJMrryriqmLQ9zoidAlZwj4BXL9eA8ul9VwuebCYHvXIDzGhr9oGw40wqAkIAPGsFkmKqKpb1qxzC7l6hiPK49CNDeZT8OcI5wetAtXjFnzYydaWPMQGbJUnH5kCR7yZA1Qri+am7c2QLGPQoIhkLvektUs+Ld330TYolw2ELokBcIOo1eiaG2ZEJZj5oxDrKtPaF9nw2MQxmiCPvQOGGFL1t3kqC3ZIpDe1V8wEdaVH41w5UuZihWWysojft0JT9mygCUC9tmRtCon0Hmm43155OE2kuUUlrLJsG/KTkTFFsCLFcsePEOXr4bqRDKrxZfYvpzwMyGMHMzDiCRT4D+nZIm/fSuy6DP/T/msjHyGvg0qDj56K4dtoKzdXb4NP/BIFTz2F4JgwQfSkGiLXnmXS4R5J6KBIm9zZiRgt3w0XstxjF3rB3r4i2AAYJDCGFFXEHk+j0mAonX5qmqL3QE5IHQOZV3RB0IY1jpCD8hVXi5uTWXD8w99Jgnh6cjV10G58Gorz++ArKyVPQe3lDTiFUVvuTb8FOAUDgQMyj/FAHDpzUefQ3jH/zCEMD6mWrUq/CG+xBvIw9qGnbKiiadhhGkUAKZ1RaQrCgxdhg0j50UWcXFEj+vLEmFYZ1BP40A+KeTp8hF+4KEe2sAlRlhEnnc/PX0sf3y8/OlDSPNHpQrMXIRfeo5EK7LKKoJ+FhoALZkIBwRo4If1ugjCWQmGBQIkDx6LMNlA2PuVdT0KA+xDqNO65v2IVs2KtC5fL54IikR8L/6nipTwNMRel+FE07N0uFbWp5qa1nMRzmWJxTJuQPmZ2gW/B38P5zlfvEi5oPCTRniUJe7B5vNxwzuG11+G4Fjufu/URJhYwpfB9uNfF3zFEhCt+r/9CRb7ZkHtcmEJz5UuCrcCZ8HQ9cyTukRrrUu9D87y4QGAsPQocFQFN/AfqQ6gAh+QrhvX1hwD4coJ0BfsRmkFlNKVPuX0+lwlkpaJ8IgNV55jegBxrfeoMtABtbT8h/MGwuQ/n5zQ1t+R0ZqMIb37nAo8LUfKiL3nSlckDcTyBqLkF57csJahS2+CaIF1lX71IvZpgf/QQFib8M2rl9HCvco8yK93P3rMQTAjf23StZ0dn3dURF43H+HlDxEHf/WBDk58rjIFdJxi8HD0RG+sO55mZ0cP6aUPW2MA4eUFYlzHqVdydCGH39MIU6eGrtJ9X9GEifBU9WG5w4R5RUhsgvG8CKMbi6Jf72RSD/cw/5C+XCVLOSzxrK5YJxjqIHKowkSbgG0Yopgnut5w4svTF2uwi8UyZzCO93dlSJc1pGuB83Wty7do/JGhq7QTBoolBhG2pqteYm5mWZSzqLgafvI/jitI/bmz8+KXhyrMtPTuz7HhFx6H18Ou9yPuUwC1/MBAWOZ0xqzvyaRDNjYQ9iT5QOuVxzQrdr7DgZTUBRM0ELY4pzMQni/rmsHX2rCiA5m6yxOOIKKZCFj+Gn5peXHx7kvw41DZiuTa4AQnIRxwWCZMfXFAeNai7WcD4WAY4ceBSlQjR4/maQAbUD4mhFVsF+TqQmcXsi6DJQyEn5V5vMM2PO0pElo/XQWQeYREOAqHL6Wc3LlfLovoHZtgDEmkHUy04bKjQkm/PCC8xpHjSZoZY8OlBUvFj0MIs0EQwqHK9JwhXXIxwXKULuXpBnTN60h7hCVuivDIjRQr4HQYUq+dgfbzJwt+GFFVwZLFJhVZmQiP8HA5GNEz+AfykEGEh3i4tCAzaFwM/XR5LeI+mCU8SewT9RkIOzm65j8EET8ftuHpeNiUwJGeXUS4V0O1xydlqlgGVBbU3DiZh++FurKQL6MIj9hwxBY0hLCyQonwPUX5E+Q6G/4QRfk8fHMbHlWOKZNIvXzr5WDrU9/3KcCQeXkkV9S/HuG/QhVqFUR4hIelDRdA+K9QpZnFEHZyEL7PvX69pxvZQdiHIGD/avDOGpTGMB13HCqG+54H2SyfNvkTWAIQnrxzi7GEVYAl/ropS1g5LHHfd/JZYtpoDRdLX9Qp14M3y0OJxqIviyJyRJ5I31/evbv4JuBM4hob1iwReXkitIffyIY9zUf5ujxD1zgb9oN8lpg6lhBG9NsvLAd5r4PDxtqdsFpv4TlVNHf03p/Iw+UgIiT8J7+MkzfX8nARhJ/qE+Hoel3fH2Fd+Zl85/heWe8y71S13VEVoomxRKWsdqj3Mq97Q76WJUqQ9Eui8K/XNZYlrG/KEqMV+BF55OksxzhU21GFn8k5XTlSwWww0vfwrL+OJUoe219QQNdYG1bkmWfD0U1ra9cjXFnxdV3JYOiiCKvCj2XVRzofnvXXRWultYgzpgK6xkRrYxGmEYQjqW6+jD9FGpalJ7IgCFWiD0MIF8k4oP5Ouso7I70PzforMw4o41J8Up5YtpqQcYxlCa5FF0e4oA3fW3Asrtnen8KGn5VVsO4/zK8lPV4cqQ9PxxLPyqpCdL2u6VjCCv+chJaWGyAccDnIioYQdopUfpYXVCkl8kYuj4CcrEQj9eHpWOIZHHzIQ2xnjK6PjlEfLs4SnjKnoreqi7PEPTjFIZYIhhCOCrBE6bOnarZB+GjYsuZ31jxvwUR4pD5cnCVKn2Fa6FojJ3yZp8tXum7EEh4dMYv1+HsSWlqK2/AS2AXfO9TktvS3p2oAE1kCjJjdj4jYfhvg4qVPK6EIsRa+kQ2Xlp/4jjzKEClo+NvO/KCusu+YCBe34R11butEvtocJ5P8yg2iNX28LxpTn5XPgadvy01GuPRFZTfCiv3o4SncjK1USn9+ebjg47lYAYQL8bDQVZZFbiyheP5HU1fkQ9XQRLgwDy+WuQQLtn118KxSeXa64l1zM7AgS5SufLqDAfXV8sqLBw8enHoh3Q0swBKlypovdclRwmVTOLSqwwVVDOT9AixRKOMQ8puHdw5lhdWJ4GIrnpCFfoD0EZksUTjjWP4QWVSFhbs+2KlI96e7VTUiB3AlQzaGsyWvHJY9rK3pG3KTbVg4S7QLLB3hXxZdzqLvR/rfzoZLS4GPiy+XVN4Eo3MyVOdPZcNwss7+mr7TaU19b21UsKxmqatigR/QDUWOMa5DGCCminJkVhflWIVtfUOEEWIUa0gVld2mQ/gE0q6h4V+LcFGWAAcNEVDAOT9YRuQDxnzWPJklAOInIXzXFF9RdQoZn0B/Qwh/DUtIXXSQYOqCYiuYylQsUaqAC5W3M3Ul9JvZcOk5XqFSNgwnId6bHdBW0IaFPPK9wBoqkOPGFah7o/clprdhGIXv4ZeHDVVoDcj5wVQ2LEJtD8/OIqPTb4fw/H04YlQ3aOEbuScyay6OcOnTVV3fTCZBOwvL9z+ZOd3XRGskD4SuyBpcTYjghJNd+zRy56cQwqVnayG4yuIIC0+O9ejQC6//AnPlTkjlO/gv9F+LUe544lUq2+sbKWVdyx+uQVXuvbYiiB/USWPkeaLbL+o3As2vhep1s6RqhUqV8e2o5Q+hx48/DiJcqiy9tnxTV+T7oOt0UFc4qsscwwDCpfm7YoV8ZiboMJyE8F93tPynwC86OPktDCXlhcEdbL9k9HDCCJ8YD3N6rez853TlfkQn7Gsrz+/smKtbeWMMysDM6NRIWeeN1p9z7n/t/OeX+yta19WdkyK6zOefh3p8/PnO1Rp9SyZYuX/nzc2/7zZBKot3F+Du1esXX/FLaqCfx4/5lsjy4+ubfztd3+ZXZ80vc4+Pv/foZzKTmcxkJjOZyUxmMpPJ0iSp/eiB3Fo5fLWB8qrzo0dyW6Vmp64tJD780SO5tdLP0lQg7GabP3okP5M0t0ha/Wvbbu7HtitATq5vOhMltdUYJImzs+sbCyO2BVHEre8/rtsjuwlQq+26bhH/tR8DT6TtWThRXI5iRFgAVwS1hitMWNDELJooLpepLY14r0jrzVacuqkbH33vYd0iySTAdnxeqPmmaA9M/J1HdYukIWnYTpPjYi/MJQJhN9v9vsO6RUKOzrar3WIvNPdWhbyaJR1F5ThmhJs/eii3VLYI4XRvhvB3kfXD2JWO7nD9R4/ldkqXg7Wiju4nlO7uVqvVOsuppXQ7Zy0pu/1vYWDdzhz2dmZUFRou0TCXGvo4mvdjumjgx61WZwyl9I/Fh71vUrXon40MtqB0/7Uq5dWZ2KSNy40MywKrFw3dZrN7fJSsVjP8SEiWbVfPGwMot15RN1kTX+hfiAfjR1PrHm5Xs0SWILJVu0cJXKNKCEPOvP7+YlWOpro3mrTVztqvqjQiMZ6z4RRws3G+ihqSrHrULZ3TAF9t0bxtnrcOQ87+Tc/+NbBim7XDZFUN9lW7cTP7epe4ZDeNUv8oc11ZELRjW+PTXU3i1HahygJVAJFE2W6cvTXWQPCnBCY+F+o7rTiLXXevkaMPpDnXrsYp1R/grzSJtzA6m0tScnTd0vtWFtv4Y+q6WWe4i72MB469ZPbgem62kljMBZqIrHpvS7TBvjJq1thz8UMzlO5xMJ6ZCHdaCQ2W8vnq4Y2qpQIaV2ap3R72hD8JMA2AGlXZBOYqq97wzzgz1qAtX0uTXmn9OAG40/jtGJVnduJCmiAVYf3Rdqt9ORoCvl3rxeD05Aq4CLkhuykYhrQFWHpY9cSssPXTRK0flJFi2VpuDmyQSMTtRFNQiwOZtrbS2mEc24QKS7x3E4jF0OjtdgLj1KuVtLgfubbqE9dGO4dFUWtA9Rpha412Ruacj/Bmi+rmNnWDOLhJk0Yju77cRwRSNTfT9W1uZXKJXPgr5dmv6j0zF6P5AqyptAwYNGzQSxpzP5OqU21IzX3qKdZG2rVjeBf3r4YZd2pR2eb3XNw1KS08biimtnO0LPXcJfuzky3u5b1EVcxnf49zBmHOedKWJpFSHwi0mHyG0G3zHGgsahXEltCTEiGd3P5unCQJ60vjNm/us0zAInWk9sA6uPtNWme21wtF4N090pW9049cF1ddatLQFA91Gpm2f1xxBZ9YKa5YSY6Is6oQYBK2ZjfhWVOiAC+7jElurWB9P0EtOPMYOpSAu5fwab+q+05dWlMazirr2jxKcKyCnNut4+O5fS4W2Qlp7OMYpVXAqDPwInJeXKxfv5A+JY2VlZTeK9tg+uu+oiHEyWHveO7Q5hbuRmGEYbPQpITLhlggTpVV29RoW3jr1XarIaTbO6rGag22edbnbBEGzWznhVCHCcAL+MTVy1YXOkzA68nVPE40F6Xgug36U75uCzhVLKObnDVhNzfnMqL0+Ah39zpsIyT3NMmO3jcanaMYuBq6ZkCbXP8wEealcomahQUjwaRZuwGTadbaNKC0Os6Lj8hxTEScxudnQFENBgtWTrbpbLdbfYPbe8rMGeFN3vKuNHYhSVzNU5dJahUA76vooCG8bYIbs6V1J3vnIvxsxwpyPlXqb9jk4niSKpBJXRyPcJeudHB2j5o0N4gEeWPVOCxM9GGVdnSSq/EYEGaUzQ0tgusWz4jAIGREw1nE5pGaZiw11TqDseYme3xtw6uMcJpsXx51hPT23VFtYBTob+xkICvuJauo4m3Ma+vOdcFqumq9Uyq2NYnHbVeT0Jn0xK67AZ12KUgTPyo+PU6Ikzeaxiuw2DoM3LzgzUyObreKTQS/a/O6lKyRFq75N89pmeJz1UtHIzwml1KmtkEwddT+aveam7KnzRx3O5ewt74Y+gCdVJM3YazCpffDjPSOuoh7+u1OliLC2KZ5mONqj8g3uquDU0htTaib7JKYq/+Q7O26RqDIh1yFEe62uQ6gNkJpnV2VO4pwrdtt9Dsc1biXtCzHqqo78XCtxgC7e7ntIAvA8SfKPrsMOq3m+h79nBk9vM8k9SDCNQY4fqtN7xyJ2CaHKmTfpQxEn47UNnhlJAMIM8cwIm4ZDMnGVRhhGceKbozsocQmbMcmnTf7vaOj/XZ7L1Phh4obWa8ykXzpKfeSz2L9GGMRwZZKsfAtFDRfIsK7ytCM9+QWEhADwqzEjTWNiM0xdD3okvy5sZl2Ew6CEAtgd3wrNmMilbsWRRhXH+Npw1x1uMZ2st5oxVgiwJV33WHD542pTCRfqozWmHPkd5CLoDmqfamKbbSabZUUrWrJKJBPIXpcpaG4f+hYpsGRLvu1hvQ9AqmeatRj45dm0q1irgi9rq5uk6ZttUH0e5NFbG88D0//MLhGRWtsJ7tHmY6COc+1dQCl+XNcoizHzJHhmFPOTYiqof7h6vsPDWYFGWw0dd5jCKeHqbDz7gbfZjOsrB/L/MPlIKvvUj+ZtiwuTduY/IDPwIiPigU2FmRU/ljkvgwKu+p43wheFZbyQL17jmmTq3rHyWDk2xiGYS5HhxJ06Bj9vMv9fP2CYhSdK2q3K1ez41IeYpRiNNAQD4NLwDqFmfC8Y+ZgpzXHDxK9m/ZlVcYl4riECBorI3m6snEF1SHhOHbANarURppaYy/GBAmiLMgdsyqGlqmOG6WJoN6JcfiWCkHyy7lNtk8TYZWwYddzsYTXzTFlsZ3PyCUAJttGLNNTkW5tAOE0vdQ58yVVWyiU2KYWunBjymSHo2Wd6wBmDWFXRTvgj7ptTDmFljjea2/NHTdqbSIJdV3sXcL2PQnhdRVGxWMQzskCGBtXruaxrIhRnWBYtjuG0800wk21Vd/Khyqii8/VUDoIKCRwaJ5dGVkIU8rTlGQFEe6zhZhbaovzCTS1rYRYId5/J4e3ri6NcI7POYp7MSlYq3GQl17mI3zGzjwxsgDao9LRNYkr3bR9PJcjtRLntam7Z1Qg1eagGKam/KfeLRRou3aCZqI2T5KrqSgNqzjWqCE091Vg0FRFPsj5uYk2fBpv84KKr5PvQIrYGyuO6TiEVdaqDWSdvY/sGo0RHE48jvAp9hB77tJAmDcHv9bleRuO413mylqRrMnuUnVzgG1uLipBNkpFUG3DUaL3vkgl66V6Z58Rh6kYugmBI06gN0mZmDyXR/MRviB2TXWs29ygdFyuZvNcVhfcsUfRUG5Er5waCKuzqZg2x3t6kGqE16kUkBJx7FIImE5Ooq4TVRIz4tgtOg7A66VNsiHXuMm/BZfxIGDn1W1uUzkymbh3ahdcxB5z24SDVtfIAjK5mHTW0zzn7Lc95uxTRL5YGU7NerLiZpueqdBXjxgiTqyzE3Hg5gVdX3XqreNYHUrsVjFCcWX6M+j1pOzHsp6dbmsYpP+ZfMkU4HGH2U9OGMsQXZstrac/kTkn+27B+DKKyYla1nsQXGIVHVfSsD1Vc+T7nJyZ6WsZm42E4lGaaaOaynOqdH9kJo3zojSs4ljt6PopVRdtDM7nlPtXCDf3+HiMDb8lWUJES5Pv6Wypcm9s7rzG2yqWnfqDoS9BQcpoNdVJaRoPbt5aZ78Kpo91DFnfv6DRbHbY0alMh6towr3MQatav7UhjyBTlSS/gp+BI4e5r9FKCn+tQc+JLWKOek0pgz9WoXqbWpzJQkGaar92IXN8N73mjulZos5y9pQR1Lb2YhkrnqnRGFkA+XdW349T9qptw46avbZI6aEXPGuj3HwfWtSOz2OOJdXeUZeUIUQ6OjpqJzEdigg+JCzatFPFtA6N1Wyc7yVuXPDaonCfNjNfDw4wjuwsJVdCRMcICzzdXdGiJVrgIohZK8MnCzb5M1eama1mVt2D7jq9yw1hldJoVZ6lr6yJPS8tS62mMtE0zeKjDoz6fcvehjBZFpAxreELB6urq9VEZyeqvKUKdpAh4lEKBYXADAxOkrrsV7clPp2tw1dVuCNgl4rJpt62blKVx1l89Ei3SeYSPrAVLJtV4RYEBwTq/mmNT9Ou/cLKUZLS+QT4rmomNYo5AsIqqh7IAlIZGSjieL8tT5nR1cJhihw2HKZKw4Kao0RYJrxYj+ADA+74MFb1DfQ6NhccBKjMfbLUz7QWV3G4MY5GbejrpMl0JGsnZKxYQIxpC3bx1M7MGlWWrm4w9GObvM9116TB19nqlJl3R+riCbs6A4u3VD32XUwncBlvSziB4RsbRh+AE2XEVXU8TcNS+vR9zrPM1skwFnQ4qDKcfiPmIsiAADpFv/vU1G+rqg7GvmlVcdxl7OrZwM0O+5LfYE8yF9M51PWRY20P658DK2ZTcNvlDZXoutA7ujZi3Edp7sO2zynHsOnDSb4eL5jfHj3QtxxqroyaqZVoc8hAGPWDftU1T3Z5vAOu+Jr5ciBuxwaI4idXQ9V19eE97Ofz2uVQBgolM/Jf11/5FVtvCGG4KoEmodMC5ajXlcEapb/181gfj6pe7LjKGaY+yk2hqHCojkmMw4o5WIaUuTdpN1RYappJZy/LKaylyZjK1aiwa7HtQ94lONSW2UE31WRd3euXahnWgVyVcMoZQd3tvIDi9XduNmDCcWL30Hv3EtmxeQmnTXd+Bg5yNvsXWTw48ThJzudYe22/ygaRVtu7pYY6MNCbY/2oypaTJu13WFJyjbtHPPmenQzQhLCxjb25ftFLVS1G2N1sHm4nibzmeNEZfL+2J68dJlm8K7R3/12Vsk2s27U35IPVYslP891lVeoSfSYb+3NkNBfbspuNP7Tq1Wpu183+0WqWcR9ZtnFxXDOAaZ7JW6I04kbGcZgRxa7rNi0YwBap2hjaiDUR7bAmMdxqfFS7QRbNp6AYoDQ7x1tbW708hunOwfeMx17ivbmsv+/38LvL/em/adjtnMnvP591cqaM/Z/J3mXxKh25C9o/1m0mSuc9fdW6c9PhqkC82FfXflZRteD9f/or/Mp5Fz7V+zlF3Yj+x78RpnPmb7f//xtlmy5hDdebvr/MxRSubNzqb7Y3qjIlSSfXVr+HHCcyFBp35HBLhNPotOi3TL+ZrL+l2uuNLnT/fAJxNgb6RY+Hv5noOkDvVv+anLfk0NPLfz6UoGg4yb8fcktkfZ8qEP98KCGvrEEkfqt/DxFcWXON06F/UFqr1Y3qhvgvKXxh/meU/irMEX7v3T8ekzZrLLeahtfVNG+1P5/JTGYyk5nMZCYzmclk+X8TpFMPPv7rbAAAAABJRU5ErkJggg==', true, 'BANK', 'Chèques', '2022-01-15 18:04:18.722776', 2, '2022-01-15 18:04:18.722776', 2, 2, 'CHQ');
-      INSERT INTO public.billing_payment_method (id, guid, password, online, username, default_cashier_id, logo, enabled, type, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (12, '911ca285-7a80-410f-800a-983268f2fd51', NULL, true, NULL, 9, 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAP8AAADGCAMAAAAqo6adAAACMVBMVEX///8AAAAPC0j4tyngHwD9hhCqqqoXBnn///3//v8JAkZubm6WlpagoKDZ2dnq6u/v7++lo7YkIFYhISFMTEwAAD0AAHZ2dnZmZmYAAG0PCks3NWR5dar8ixw8PDz4+Pj+8ubLy8sAAEnFw9taWlrm5ub9lDEtLS23t7fY2NgAAEvCwsLmHwClpaWJiYkVAHl/f38pKSlSSZUUFBQ3Nzfrchnl4+/1qyUoHYMAAGf/uycAADkAAEEZGRlTU1MAADD6lTyBfqxBOY7mXRj4zGbiKwAAACZcPyvraBePAADX1uXXAADvsCjkOCJMVXJdYYOHjKjYXSbup5ius7343aCjdzX96+TPJAiRHAB2Ljrrgj0lDzd4hJYpHDP87tJpT0oJABr33rbkSR6wHAdpFBmwei8ZGz5LDizzxbAAI0MyQF5CTWTxnGhaFiHHkC6OcEv52IO+tp7fw504Lo3brleLAAlXUpWjnscXACK9hSn6x0/wj3xDMU96X2E7ACnfrqRSZ24sEDTmYFC6AAC7V0oiABoyABRkAACjcWrBlFiId4OWXSCHb1B0UWDRu7VmboEiACqae0qrRxiEGx7eQitLRF9iES0hAADjc1vp3cX0w4/8ynH71rFBL0OhGhv5tnxZMjD7plvTnSOvrsrSgSH1miVSFyU9Eip4VTM9JSpXOCiHXyyyiIuoMAB+GC2xWy2FbmG9all6O0zQtn5WLEfplIm0nG3pdUzti2KePDxRQFk/gTH6AAAXXUlEQVR4nO2di0NTV5rATyCNNyGQiwkBUuQmgUhCLgQB0SYIvoIVou2IQrtYOoqv2pZxxwqCVqfSzs50p4Mdbdeq0BbsKmWm09lut7P71+13zrnP5CY5AZMg4SuWm/v+fed7nXNPuAhlEt4XbO/rMr2o4my2B31CRsIM7MGKYt//85F9HUFrzvRBFz24pbm90vKiSmV7n5Ni1IVzavp2clBFsCpnvW08CVmaCU0lqyMIhL7Wl9e7KqyE64gGmPa1wJ5dbWuNGhtVeDuOBNm9IID93lKAGyq4CFgDdVnaNQj7dGy2tpeFBy/oyujW4PnOzeT3yRLMbNzN2Q3kBRe+0WRqT7PNCq5vL+jdFENqIbUZb3Ft0sCXJODjHUbrm0sDnyjAwMzbSwWfoAaT1wVLwfdlgY5dSL8mAJG/OPdSDBG6TU59l9Bl2rW5E59eAkkxEGr+zVz2pIpF5wFCmpSwicVlalQ/QEAsJevHUqXJAbzJ1FbMeymK1Jqc8mK7qauYd1IcCagGwDoysrmkQo4AwdLzfiwhk4kOb/al6xBtcummPWGh1HK/LG0mE/4VpL9KTwLUASpMFcW+kyKJk6R9g85giUi7qZm4/2Z4yrMWIZ7vK1X3JzWwAEpoSV7f0awKr67sCygHupr7NkPOwJnPjp1AL3bNw2M5NkCwVAeI8APCzVAydQFeX+p4eEDDL48KVcLyLnkH/Gy4YDeZR2k0WUAHqcV/n0YBkgN042VpyCBs2iQlkwvYjYZ9KzX8dKuPLEuWAurZV8jbzJtUAJERv9YBaHSopR/IMs/8KJ1FBJ43DiVCmvXPUXDpZzjs36xRAI76wj66TKy+kq4MV6ZIusfrIeNNQqiyztXY0tLoqqvU1SCBcG2fq7ul29XcEcb+Z21LvRYcYNF8tAR9ITk/+VL3xmLnk28gLX+bhh83dVBaJqOETpOpjxycIq40/LtMBkUGX9moPbZPGY/01WnXO+2kRksR8MWW5HWNHUSNdoPd5ZZk49c6AIZSAiIi/WaSFWtZrkAEx8uUEbbgruSDaUjl65LXVxjyu3D4TpU6/nnwozrdYao6wpQbafm7KmolqQsZnIo8WDUlG0CHfHRtuMpHT9WI/d0neZqpuzJU1dYiXVS5frd8qdoKXuV3ahKWk0dBekMuVSn07tjtn0wCksWuUWgFSf4dOv6U+jFJQnQ33WWUg8MaDfFynjHJdQf1uw6VXzdSo/A3I161xm55s5rFjM0yEz+v4W8UutUP5JZCev4Ar4jRVaRg6tSsapePpXkkbJL4FUOjA7JCs6R0tSUF5VKCll9bs8g8aqvlzq9zAG05EHbJdaCqcacsXUYDaVXybmo3O6QcSRVGm3mXgBSTpXoRKKHG/rt2ydeC0+n4g8o+sgGsi189nV7wHbYl8Wu0Y3gRSVQ/UdKrXF1X1TZ2VwRkO9DccWXzrr42w/hn4vX8VdotzPy16fj5faa0IqTj32Vg/5pUEk5ZpXY9BEGrF02wxOuN+CuQnl+zj4+d356O3yi9a66m5d9VFSBS1WZ0pnb1QPmJm+pP+gN4Zaa5U38Ola2Op9fy2X1J/KqPPB9+1RaTJZzE35KpTtUGUvnGapNXSOJL0VQKv67bmVd+3pmOH+XCr6tFaH0oqHWLvl5QVb4+/qrnwa/zb20GaE/enokf37lGkaRlBHWFnl+tutfHj54Lv089YR2v+Q6IfDImflxHBdSD+/LHr8Z/OQmvk59XuxdBTTmg3BoTvxPnOI31VOn59f5vSb0IO7+asGXadfJrCnxB45qWlM0Z+KViUeXHCd+q+r/+yYN6kaSSmoVfKZ2UUcr18vvkwzvUAQCTSZk3xcLfTWOeJghWaY9MmnLnU3fLmV/tTymb18uvlP3YSztSTs/Ajxs0rLt/AqD6g75eVpWcI7+zWQkxGo2ul19mJllLbhvVYxn4XXIxrjGAgLYm6NPvr0YZfWDIxq9InZZ03fxSN4X2RehwhWaiTHZ+rLOWPixqV5z0nevS3JlPWa8UxgI7f7ddf7Z180uFCq85m8a8svM3m4yE1+YqedpdwNQd1h0hn9OOv46Sjb/bXmnxpXzHb938tHaX+mhVGl0k8ac5WtMj0wpuWjXTBWV+sqjWGS71Ko1s9U+KrJ+fEMi9NhwNtf6q8DvDPll0lgA7dMljr20aW+B199ZObg6HGqeg7Rp2kxAQojpS1jYrlwoVgB9fwSkztZn0+Trb+KfuiaG2G0xWagbYdrlcqmJ4jVO7+lqkAwwu1SgUgN+uiUSYQLstG3/SQ1K1P91FnCiQPM7rkg62JK2H+zMc/y0Ef5V2coRLP0nYaIBAcyGc5LRPVjUGID08CmgfADRrMl5Qq1q7YDz+Ae2vFOhJafT58eddQkFLm8USTBk358NB/AXmsOGA6nOT4vMXV7b4t/i3+Lf4S1W2+Lf4t/i3+EtVtvi3+Lf4t/hLVbb4t/i3+Lf4S1W2+Lf4i8zPcQhZCyccp31MvCH4CypU4bIUn197NwUSjQFo+NN8ZyhPos4T54TqwsowMuRvN3jEmD/RTGNw2GI1mSSWspB+16y7xGpi2wVD/nTfGcqPKPO+OOTYbitjEY+HabdsZ7G9nJbf6SqMdK+BnxXek0VPmfgL9QfwLDnxA05vb01NdgPwtNpsfptts/B7yL9Y/8D1i+9juXh9IFYjrdXvCG1us8X6x1ZWvj/yzcpH/bFef1odvDD8mCA28PTc4tyoWcRiHp1bPPe0P4a3eHT79fb2r6zOLC0lEuXlexJLS5OrK2O9vZ6kHV8w/jJP7JN7c6OiWTQTieP/iea5e0/79Y1vi62cWkpEo+WqRBNL51dirUZR44Xhjz19Y0hm14poXnwaU8Fsse9nElp2RQWTR7AN5MovHGjIq7Dxe8rGrhnBSxq4dp3uBOFhZabcgJ5ooHzym1QFZObnOOGqO5+yjYnf0//+aDp6ooHRc/2EpX81YQwv2cCpMVuSD2Rpf044GNmWP4nszc4P4XzgWiZ6agIDHk9sZTJN2ysaWFrx59T+aAPw17w1kQUfa2Dio/4jRo6fJIlntlz4i97+nrKapxltX1HAXEbbV2W1V1sRbXT+sjI2fLN5NxM9+MBqjSYRbnB+T9n154yPLUB7gQ3N7ynrZ/B9LGe/w7KHTQHP/Iz8RY///deY6BUtsPEnFvyyC2xofk/sfUZwyUhENi+ITto8L0T7v8Xo/ENE8C82D4gqIWBD89cwWn98jyJsDgAe0MoU/4pa/3ieMlr/7ux1T7IBnPczxv+99fkUdwZ+T4w19uvIGA1ghYaAbPzWpvxKJv5PGJs/vvvVV3cr8l1OBpCNH+VZuLT8nppsvR5DGTrEaAAXbAzxj96gcnNEH/KDI3Ux9aGSDEOXyW/8Iy3p6NPwe8oujK4BHxSQUwrIbfwH4oEsVvIRWZGVfpLWYmChqWl5eblpsEcmBDciWzmuqUlINao07f+fCpKYduwDy9lDkpw9Cz9n42wOUL7kXwO/o+FgJ5GDy1K7ClPw6aqjiayfgnNxy50Q1/DP3oYmK7UYoYFshb0OHuDY+D2xRQ10Bv54uvbOFgnpUIAnp/E/TnA0AFrE7Z7Gn6wcmq53u+sPoAN4NAd+I0enW8qYkYi7voEawHJ9BI7Z1jM91TnFIbb278fmHz8GAr/xr7gx/yFD9ujslUez0XQqwOujtBeQ8/gn1+AGOODHz47RoDsCnMixF0O7m5BjG94aIbktss29TKy9J0JU4m4CK5lmtH+S/MVL4HAjsODF7mOggHgcOn4JqfLZUy6bQvSRF5zN6r2SBn+c4x5FZ2w52z+ijSnzAwlWRn0TaqoHwoibR1NEOQchs02DG0yR0Ag7SfyoZ5CzsvH3ngOvf5OHw71m8VN8Me8Q1siQ7A/YJY6NCN5D8WPwHxGwEfxvR/SkQKZRoCtRsIQkI4BVPwUQdzi6FFsb/yBBPECi+SBwuw8idKB+Gyw0gB7wtil6yp6GQRIjmySPqJ9WMkJ2/rJ7wP/fmF8wz1VjTxsZEu/f+PnnByTI33/w840Hx/7AofFfYQ+BT/exNdyH5fv7f6pCdGLD4Wj5oytXDmMNzGLy2fLo7KNE9McQ8iZoDbwW/nqV/6AbbN3BIdn8D2Dd1C8jdW4FpIhO9zaFn0sNf2naH8Lf0LzAQWYRrwXwmW6LIzi8ohEgvS3gE934DIE1/dN8fwSbyT/jx2Dh4Q1h+DTs7R22D38VPcPhQ7yz0XJO8D7iTpafgT3PNAe4cTCDt9fLj5bdhAr11JN456D87garmuchQrrxNrz+deOCypA/Bl2/uQ58Eq/4f5BTOXTjf3HAtVrRpaETEIhh08enkdXq/QWoyeV+if+V474SuJd5hK6cOn/+7vnDAewFcIro/ziQ1+tNnIFTIOuwQPiPrJOf44CLdGEo9hQi4YA2tFVuacdVsJEGbCDkGFZ+HP4nqhGCex2tRj6wsTvHgZqHFhdGeeJIlyawX4wfuo3zEnA9Hv0U9MH55sEroiTGf+6T2mH2Rx40N/6TQMOPFZ2M0gSwZv/HT25I8ANjV8yftDVWQIMDyYY+VQ+aGcQGgI9h5h8bFcVrwxw6LXiPBtBpaPb45Xe33+2fB9YPgenT2DtzR8OIC//9joDGf+zH0KAPOEE1aO0KCXrRH09fLot9AdHgcC1WhNcCbhKuBm8ikXF1PfwQ2nvqSczjJPN3Qxs5pFBH6gOO7g020uS4GqHHsPJ7xiDCn6tCaJ7jPuM4oOaG5uJ3Tpy4LHDCF3CaSxDvf/Ah79/n/orQw/sfX3Cg8b8NI6v33YEQh2ZprJ95Mnvl8bwF+MH1UGVvCHEfnP/+ONzEI+A/tSZ+TuLnoGWhVXvgxAcI/1US61+JbIsQbUyR7oEVIiToqAdbSKTTIPilb38S/oXjnFCNbtsRNzJ0Z4TswfEXsLXzN8T/4pH37GiQBPsesII3QF/vjd4C95f4Z8fxAVCVfwA2ceb8PI4E0cQX4D6HwTpOrdH/pfYflKzfKpn/NIn3gxHZBKYEkvtgJ0iDeBglstfBbP8e4De/JnCBLwTBgf4xjKDBaUS1opHfV5OwBuEfjRybGKQz2DjrwzdBH4fEuw6E6KOQqBdJHbY/wgkeJU4jHBgSdRAL8dbVtfITW4ZCl1gBJGjJ/Gl2F6YjUhCAeNCDywJcKlP+HsP+dLr4P3qaQ3++CVr0HvUhdOLPCAWq532QCCdip3H+++pT4BfPhTguUBUKhXy/fAY2cDZ+lyeJHwB/C+cL4XAw/vkg4mY/eJ3wz9YK+Nea4x+15Skc6l4ZxM1Pgh6YPyJpD0zgIK2BDyArTgyRpp6eHloXNrHHP8+EOGHn0AngR5f+DfLYH0C/H0+8DyHxhDhx952wFbSBuEuE/8NP7t69/nsI/+hMXPwohDHBv2dxIPz3z1+GtX+CmBf9I2n/6BKo4QzmX1P+4yT+vXsjNAkgdDVCEyJpf5xfejoj1EVIOYg7QkoBzMwP9Q8O/w8+AgXfuQjrb8LCA/FNaPgbD+Lxa68hLhCG9r9/Dkx7/L4oxh/8xQ6RMB6/WA23MP7o8MmqYZwIsOufrMNNfgpH0ZOPvnKQ8L/G+kfixxVNxG0lfXsCCU7OYWMggNO4HIYqgFR+ESJSXWAkxvZ/D8K/gO6PcYgXvwC1DkDtg7zYwG7gv44LRj7sw5f8zbxU7I7/BXi/jYvXLkulR8CCowSuGB7N4yZfukxnO+PwD6VwYgFPBlgrPwC+MoibmzYylEHcdIM8wkProUFS+ZF5DvXEAEgHgJHf86V4C8J/fEzgbg9BIBj5jzCiY03CcVrUjbwZhOLa+6uxQXrR8Tcgvf2L2Tw6UE0KRRR8DeFfuB/wOgcVT+KtYdJlhzWzV67MJsZs62h/3MsjuLTmw64w5Y5M45NZG2g+HLxKO0dYBqVOM3P7ez4auhngT4hjgZE7c9UCf+PoBahjAh/6uNuvkV5EaPTocegeXYoffWcYZxrve+cC3Jmz0Ak631+Nb2N8cgAMgvttNRr/YBiNH4aEtx1Cg/dfq9B4+eEr5ZOta+v/8bQ/Q+odEBr9cY6DOtddH7m6t56Gv8EGvGKQKqlJ6jQy85fVTAwM/HpIfKv/qDgRG/i1KL7f/+7loxf7Lxzt73/3+Ls3j4rmW+/M/27OLE5ctx2fn788evHChWui+dih6MxA73z76VPRU/3HT7/9m+2Xz3+w/fjbOCOswoo/fX/8+KQc/tfQ/pzQSZ35ADXmJjn6L79C4wINde7lZVjCJR+Ji3IBzGz/ZbZFOuwnimS+H57lMzdEVphH5+boXLCJiSGz+dUdO57MzDzZuePJkyf7d+7c+R2e6jQzs4Snu8xM7inHEwHhHykIlmaWonuWJsmHhTXxQ4N3kjGfTgf96sQBqAJxroOoD14eoeG+vrMJgh+E/SZEh40HYTlSP8Xe/h7PxZSBP1G7INJxUdH8Kh7iSBnpikrjYElbotL/EtL4Z+7jX0hoOIhFymXcFP5wFXMKy1N7cajb1jndZEVNV2F1A0ECDTg68W5T7PUPOMCoIXvqGFiaQb7MQqrf7M8/cn0CIvT0pPzdxfTCZXj+Uea5l37QVye7v1NlD+Pod3niLZbxb2uO+Lk+L+IyPP+BEphRAfjhtyjSh+BDjM0/2cry/MvKfbszn7IfpePHE/cXc38ANrSTsf2/YeLnuP0v5VN2pOWX+sC5CmMwgBRZw/D8FxWX3/MDowHsxgP/Cc0DgKxy5PsVlud/ReZnnQFgZuaWmn/1m2dHWOJfcfnLPLcyPvlUhXHil4y/5L+wMLbx7R97AKsCyBNgthmw5Ymbfo+fbf5bkfnLcskBzLH/SKt6/g3OD90gZgUwToGNss9/3QD8HlYFiIyzwKKrfub533nl37F/hzF/WZleAUwuIC6yTP8HWfXrzl40/h2Pxx8ytD8Wlo7AvRr/wlJWBUQTR3T4ReT/+uHjr79m4/d8OZpxCozZPHoRbNo/NpNNAUsLrWUbhH//4/ce72DjL/OMLWbgF82LMfKdDn/rs0w+EC0/ZfMnnzlr/b8jT/LStw+/fmknW/vDz8UJ0VgDonniood8+Q328m8/n+H7bwutHk9O3//C0wryK2ztj2+05uKEWZQGftQJ70D/pfZ7nbbWhfMJg3lP0cTk27ZWg9Nmmf+c5xmgGfr/BkZw655GBSKB/+FW8jegW/03n00mNNN+YDExubrgbzX6JnjW+a86fqO/oJK0Od2uRvvkwE8t3NM79uUPi6NE5hbvfTlm9J1mj9/mv3nk1ORSgsrkqWcAb9D22fnzLRnmv6YxAfJ9yJpYrCxWk+LLmp1srX6/bfvNhYWb221+f6s/3Rkz86vvFs2nCG1r+vsX2cUD6LYsJ8vE3+UsjOzLEz+LZOIv2t8/KaD4e9PwF+nv3wD/y9sLKsn8++jrSAKhqsJJSH0hCcc5Ciu8JsO5gL1P95aWwkvh/wCWKo1g+/Y0b48pmBh8oSRvgvSzsfHLrYLS66yLJFwh+ZPLW/xqQ1/yywZLR6rwC6qE5Lewlo4ESdMnv4W0dKSDlPy1BfvDPxtNnORN9sFSDQAB6XXEyW8bLRVpkxq+T/9WyZKRbqnyC+reU1gyElLeC6i8kbCkpEJ5y7hd+1rfUpGAmvd5E0kEpSW1Jqey3F56EaBKW/YJyW8i3/ziUrwfi6XUaoC2pF6PS33PcSlIwKR/ly9eUUK9AKHFtCtp2m7QVORxsEJKnfa1zpK0l04S7DDs8teVypsw2rXvZdeIqzQsoD059slidZVCDKhIh4+ICzRv7jQYaMzYxmAbzs1cCEGWyxzk8A61m9UEAs0m074sg90BCAKbMwwK+BFvRfa2hb6Aqatys9lAANM7w9l3lBRlqmDa98UQa7AZIzGPcvF0NkSdZTM8GfJZ+kzEpHP4oh4Ewj46U8HZ11HZZnkxpc1e6+qiGHW5W7MQrC3YfJC8irN9za4s+IL2upZiA6xZuivagllc+P8BCS0BGxQPyBQAAAAASUVORK5CYII=', false, 'ASSOCIATE', 'Visa / MasterCard', '2022-01-15 18:04:18.725661', 2, '2022-01-15 18:04:18.725661', 2, 2, 'CINETPAY');
+      INSERT INTO public.billing_product (id, name, enabled, description, price, reference, catalog_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('f158787f-514b-4bb9-b4c7-449b668ebfc5', 'Software engineering service', false, 'Software engineering service', 0, 'SOFT_ENG_SERVICE', '482e9cf1-6053-407a-9972-847e3a8b6461', '2022-01-15 18:04:18.801406', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.801406', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'SOFT_ENG_SERVICE');
     </sql>
     <sql>
-      INSERT INTO public.billing_product (id, guid, name, enabled, description, price, reference, catalog_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, 'f158787f-514b-4bb9-b4c7-449b668ebfc5', 'Software engineering service', false, 'Software engineering service', 0, 'SOFT_ENG_SERVICE', 2, '2022-01-15 18:04:18.801406', 2, '2022-01-15 18:04:18.801406', 2, 2, 'SOFT_ENG_SERVICE');
+      INSERT INTO public.billing_product_catalog (id, name, currency_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('7c3ff09b-441b-40c8-9ceb-d9ba5ae873bf', 'Supervisor plans', '75932d0b-f391-4def-a2e0-854e45376f07', '2022-01-15 18:04:18.766095', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.766095', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'PLAN_CATALOG');
+      INSERT INTO public.billing_product_catalog (id, name, currency_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('482e9cf1-6053-407a-9972-847e3a8b6461', 'Software engineering', '75932d0b-f391-4def-a2e0-854e45376f07', '2022-01-15 18:04:18.768856', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.768856', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'SOFT_ENG_CATALOG');
     </sql>
     <sql>
-      INSERT INTO public.billing_product_catalog (id, guid, name, currency_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, '7c3ff09b-441b-40c8-9ceb-d9ba5ae873bf', 'Supervisor plans', 2, '2022-01-15 18:04:18.766095', 2, '2022-01-15 18:04:18.766095', 2, 2, 'PLAN_CATALOG');
-      INSERT INTO public.billing_product_catalog (id, guid, name, currency_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, '482e9cf1-6053-407a-9972-847e3a8b6461', 'Software engineering', 2, '2022-01-15 18:04:18.768856', 2, '2022-01-15 18:04:18.768856', 2, 2, 'SOFT_ENG_CATALOG');
+      INSERT INTO public.billing_tax (id, short_name, value_type, type, value, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('7bb3e50f-7a5f-481e-9d8f-34c0cdb64fb8', 'TVA', 'PERCENT', 'TVA_GROUP', 18, 'TVA', '2022-01-15 18:04:17.916364', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.916364', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'TVA');
     </sql>
     <sql>
-      INSERT INTO public.billing_software_engineering_service (id, guid, no, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, '71cdec73-c2ca-4f01-bc50-5d7f00108848', 1, '2022-01-15 18:04:18.831826', 2, '2022-01-15 18:04:18.831826', 2, 2, 'SOFT_ENG_SERVICE');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('2630ffb6-b138-4ff8-b99f-7180e02f7b3d', 'Créer un message de contact', 'NEW_CONTACT_MSG', '2022-01-15 18:04:18.004918', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.004918', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_CONTACT_MSG');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('f328f654-b593-4295-b044-629c5a98eedc', 'S''inscrire', 'ONE_REGISTER', '2022-01-15 18:04:18.008287', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.008287', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ONE_REGISTER');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('56032da5-acaa-4551-93a5-03b6cba02bae', 'Changer mot de passe oublié', 'CHANGE_FORGOTTEN_PASSWORD', '2022-01-15 18:04:18.010695', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.010695', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CHANGE_FORGOTTEN_PASSWORD');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('99be6967-9c05-426b-9324-c0de83f1a4cd', 'Créer une activité', 'NEW_ACTIVITY', '2022-01-15 18:04:18.013039', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.013039', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_ACTIVITY');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('f071f25d-8821-4302-9ed1-926d2f2eb201', 'Mettre des activités en interaction', 'INTERACTE_ACTIVITIES', '2022-01-15 18:04:18.015326', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.015326', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'INTERACTE_ACTIVITIES');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('3a01f575-b5fb-4a89-a05b-3126e2c17d0a', 'Créer un modèle d''activité', 'NEW_ACTIVITY_TEMPLATE', '2022-01-15 18:04:18.017304', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.017304', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_ACTIVITY_TEMPLATE');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('f6c6286b-38f7-4f7e-8cb9-111287174a0a', 'Créer un indicateur', 'NEW_INDICATOR', '2022-01-15 18:04:18.019677', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.019677', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_INDICATOR');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('61891bd0-a417-4cdf-a09b-964943a51345', 'Créer un modèle d''indicateur', 'NEW_INDICATOR_TEMPLATE', '2022-01-15 18:04:18.022124', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.022124', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_INDICATOR_TEMPLATE');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('13d04b82-d512-4915-bacc-aaa1356c53e7', 'Partager une activité', 'SHARE_ACTIVITY', '2022-01-15 18:04:18.024421', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.024421', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'SHARE_ACTIVITY');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('2a73196d-5518-4a0e-bff8-44dc7bd3e473', 'Se désabonner d''une activité', 'ONE_UNSUBSCRIBE_ACTIVITY', '2022-01-15 18:04:18.026586', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.026586', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ONE_UNSUBSCRIBE_ACTIVITY');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('90b7cff5-54e8-4908-ab81-1f33a5ba7829', 'Créer un modèle de feuille de données', 'NEW_DATA_SHEET_MODEL', '2022-01-15 18:04:18.029097', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.029097', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_DATA_SHEET_MODEL');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('8ff2f8ef-3bfd-4239-94f4-e7fc369e3c31', 'Partager un modèle de feuille de données', 'SHARE_DATA_SHEET_MODEL', '2022-01-15 18:04:18.031329', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.031329', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'SHARE_DATA_SHEET_MODEL');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('5362b8e5-0a18-46a9-ac0f-36fc71019f06', 'Se désabonner d''un modèle de feuille de données', 'ONE_UNSUBSCRIBE_DATA_SHEET_MODEL', '2022-01-15 18:04:18.0333', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.0333', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ONE_UNSUBSCRIBE_DATA_SHEET_MODEL');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('8e3d495b-7f1b-4e66-8f22-3157b86eaa9f', 'Créer un champ de données', 'NEW_DATA_FIELD', '2022-01-15 18:04:18.035435', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.035435', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_DATA_FIELD');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('def3efce-b2c7-47ec-8039-37da66a237f5', 'Créer une feuille de données', 'NEW_DATA_SHEET', '2022-01-15 18:04:18.037277', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.037277', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_DATA_SHEET');
+      INSERT INTO public.membership_access (id, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('6f8ebc7d-9814-4fad-a804-630d8ed7d658', 'Créer un champ de données table', 'NEW_DATA_FIELD_TABLE', '2022-01-15 18:04:18.040061', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.040061', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_DATA_FIELD_TABLE');
     </sql>
     <sql>
-      INSERT INTO public.billing_tax (id, guid, short_name, value_type, type, value, name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, '7bb3e50f-7a5f-481e-9d8f-34c0cdb64fb8', 'TVA', 'PERCENT', 'TVA_GROUP', 18, 'TVA', '2022-01-15 18:04:17.916364', 2, '2022-01-15 18:04:17.916364', 2, 2, 'TVA');
+      INSERT INTO public.membership_access_param (id, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('35f72de5-01b0-49f6-854f-fcaffa099bcb', 'Nombre maximal', '99be6967-9c05-426b-9324-c0de83f1a4cd', 'Vous ne pouvez créer que %s activité(s) !', '0', 'NUMBER', 'MAX', 'NEW_ACTIVITY_MAX_NUMBER', '2022-01-15 18:04:18.096692', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.096692', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_ACTIVITY_MAX_NUMBER');
+      INSERT INTO public.membership_access_param (id, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('8a0cacae-ac28-489f-b967-dcb13d660146', 'Nombre maximal', '3a01f575-b5fb-4a89-a05b-3126e2c17d0a', 'Vous ne pouvez créer que %s modèle(s) d''activité !', '0', 'NUMBER', 'MAX', 'NEW_ACTIVITY_TEMPLATE_MAX_NUMBER', '2022-01-15 18:04:18.100385', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.100385', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_ACTIVITY_TEMPLATE_MAX_NUMBER');
+      INSERT INTO public.membership_access_param (id, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('7274f58b-64e0-4fb6-ab25-2d3f0f7a056d', 'Nombre maximal', 'f6c6286b-38f7-4f7e-8cb9-111287174a0a', 'Vous ne pouvez créer que %s indicateur(s) par activité !', '0', 'NUMBER', 'MAX', 'NEW_INDICATOR_MAX_NUMBER', '2022-01-15 18:04:18.104462', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.104462', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_INDICATOR_MAX_NUMBER');
+      INSERT INTO public.membership_access_param (id, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('4c2d7961-8747-44dc-a0e8-1eab41e74e96', 'Nombre maximal', '61891bd0-a417-4cdf-a09b-964943a51345', 'Vous ne pouvez créer que %s modèle(s) d''indicateur par activité !', '0', 'NUMBER', 'MAX', 'NEW_INDICATOR_TEMPLATE_MAX_NUMBER', '2022-01-15 18:04:18.107158', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.107158', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_INDICATOR_TEMPLATE_MAX_NUMBER');
+      INSERT INTO public.membership_access_param (id, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('7d1e9e55-19b9-4ad8-b8e0-059f27fcd521', 'Nombre maximal d''abonnés', '13d04b82-d512-4915-bacc-aaa1356c53e7', 'Vous ne pouvez partager votre activité qu''avec %s membre(s)', '0', 'NUMBER', 'MAX', 'SHARE_ACTIVITY_MAX_SUBSCRIBER', '2022-01-15 18:04:18.109924', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.109924', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'SHARE_ACTIVITY_MAX_SUBSCRIBER');
+      INSERT INTO public.membership_access_param (id, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('ac55b72c-dcfe-4624-8b43-8802d8144e5a', 'Nombre maximal', '90b7cff5-54e8-4908-ab81-1f33a5ba7829', 'Vous ne pouvez créer que %s modèle(s) de feuille de données', '0', 'NUMBER', 'MAX', 'NEW_DATA_SHEET_MODEL_MAX_NUMBER', '2022-01-15 18:04:18.112627', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.112627', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_DATA_SHEET_MODEL_MAX_NUMBER');
+      INSERT INTO public.membership_access_param (id, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('2ed3ae03-979c-41a5-9f74-3a94e76a8017', 'Nombre maximal d''abonnés', '8ff2f8ef-3bfd-4239-94f4-e7fc369e3c31', 'Vous ne pouvez partager votre modèle de feuille de données qu''avec %s membre(s)', '0', 'NUMBER', 'MAX', 'SHARE_DATA_SHEET_MODEL_MAX_SUBSCRIBER', '2022-01-15 18:04:18.115835', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.115835', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'SHARE_DATA_SHEET_MODEL_MAX_SUBSCRIBER');
+      INSERT INTO public.membership_access_param (id, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('00e874da-44d5-46b9-a609-261b5af6b3cc', 'Nombre maximal', '6f8ebc7d-9814-4fad-a804-630d8ed7d658', 'Vous ne pouvez créer que %s table(s) !', '0', 'NUMBER', 'MAX', 'NEW_DATA_FIELD_TABLE_MAX_NUMBER', '2022-01-15 18:04:18.118293', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.118293', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NEW_DATA_FIELD_TABLE_MAX_NUMBER');
     </sql>
     <sql>
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, '2630ffb6-b138-4ff8-b99f-7180e02f7b3d', 'Créer un message de contact', 'NEW_CONTACT_MSG', '2022-01-15 18:04:18.004918', 2, '2022-01-15 18:04:18.004918', 2, 2, 'NEW_CONTACT_MSG');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, 'f328f654-b593-4295-b044-629c5a98eedc', 'S''inscrire', 'ONE_REGISTER', '2022-01-15 18:04:18.008287', 2, '2022-01-15 18:04:18.008287', 2, 2, 'ONE_REGISTER');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (3, '56032da5-acaa-4551-93a5-03b6cba02bae', 'Changer mot de passe oublié', 'CHANGE_FORGOTTEN_PASSWORD', '2022-01-15 18:04:18.010695', 2, '2022-01-15 18:04:18.010695', 2, 2, 'CHANGE_FORGOTTEN_PASSWORD');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (4, '99be6967-9c05-426b-9324-c0de83f1a4cd', 'Créer une activité', 'NEW_ACTIVITY', '2022-01-15 18:04:18.013039', 2, '2022-01-15 18:04:18.013039', 2, 2, 'NEW_ACTIVITY');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (5, 'f071f25d-8821-4302-9ed1-926d2f2eb201', 'Mettre des activités en interaction', 'INTERACTE_ACTIVITIES', '2022-01-15 18:04:18.015326', 2, '2022-01-15 18:04:18.015326', 2, 2, 'INTERACTE_ACTIVITIES');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (6, '3a01f575-b5fb-4a89-a05b-3126e2c17d0a', 'Créer un modèle d''activité', 'NEW_ACTIVITY_TEMPLATE', '2022-01-15 18:04:18.017304', 2, '2022-01-15 18:04:18.017304', 2, 2, 'NEW_ACTIVITY_TEMPLATE');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (7, 'f6c6286b-38f7-4f7e-8cb9-111287174a0a', 'Créer un indicateur', 'NEW_INDICATOR', '2022-01-15 18:04:18.019677', 2, '2022-01-15 18:04:18.019677', 2, 2, 'NEW_INDICATOR');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (8, '61891bd0-a417-4cdf-a09b-964943a51345', 'Créer un modèle d''indicateur', 'NEW_INDICATOR_TEMPLATE', '2022-01-15 18:04:18.022124', 2, '2022-01-15 18:04:18.022124', 2, 2, 'NEW_INDICATOR_TEMPLATE');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (9, '13d04b82-d512-4915-bacc-aaa1356c53e7', 'Partager une activité', 'SHARE_ACTIVITY', '2022-01-15 18:04:18.024421', 2, '2022-01-15 18:04:18.024421', 2, 2, 'SHARE_ACTIVITY');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (10, '2a73196d-5518-4a0e-bff8-44dc7bd3e473', 'Se désabonner d''une activité', 'ONE_UNSUBSCRIBE_ACTIVITY', '2022-01-15 18:04:18.026586', 2, '2022-01-15 18:04:18.026586', 2, 2, 'ONE_UNSUBSCRIBE_ACTIVITY');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (11, '90b7cff5-54e8-4908-ab81-1f33a5ba7829', 'Créer un modèle de feuille de données', 'NEW_DATA_SHEET_MODEL', '2022-01-15 18:04:18.029097', 2, '2022-01-15 18:04:18.029097', 2, 2, 'NEW_DATA_SHEET_MODEL');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (12, '8ff2f8ef-3bfd-4239-94f4-e7fc369e3c31', 'Partager un modèle de feuille de données', 'SHARE_DATA_SHEET_MODEL', '2022-01-15 18:04:18.031329', 2, '2022-01-15 18:04:18.031329', 2, 2, 'SHARE_DATA_SHEET_MODEL');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (13, '5362b8e5-0a18-46a9-ac0f-36fc71019f06', 'Se désabonner d''un modèle de feuille de données', 'ONE_UNSUBSCRIBE_DATA_SHEET_MODEL', '2022-01-15 18:04:18.0333', 2, '2022-01-15 18:04:18.0333', 2, 2, 'ONE_UNSUBSCRIBE_DATA_SHEET_MODEL');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (14, '8e3d495b-7f1b-4e66-8f22-3157b86eaa9f', 'Créer un champ de données', 'NEW_DATA_FIELD', '2022-01-15 18:04:18.035435', 2, '2022-01-15 18:04:18.035435', 2, 2, 'NEW_DATA_FIELD');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (15, 'def3efce-b2c7-47ec-8039-37da66a237f5', 'Créer une feuille de données', 'NEW_DATA_SHEET', '2022-01-15 18:04:18.037277', 2, '2022-01-15 18:04:18.037277', 2, 2, 'NEW_DATA_SHEET');
-      INSERT INTO public.membership_access (id, guid, name, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (16, '6f8ebc7d-9814-4fad-a804-630d8ed7d658', 'Créer un champ de données table', 'NEW_DATA_FIELD_TABLE', '2022-01-15 18:04:18.040061', 2, '2022-01-15 18:04:18.040061', 2, 2, 'NEW_DATA_FIELD_TABLE');
+      INSERT INTO public.membership_profile (id, name, code, parent_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id) VALUES ('83cf82a5-b5d8-447c-b778-e0beb4226f0e', 'Administrateur', 'ADMIN', NULL, '2022-01-15 18:04:17.961075', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.961075', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33');
+      INSERT INTO public.membership_profile (id, name, code, parent_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id) VALUES ('fa29b642-b78d-4ee5-abba-cd7cb472d051', 'Anonyme', 'ANONYMOUS', NULL, '2022-01-15 18:04:17.963899', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.963899', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33');
+      INSERT INTO public.membership_profile (id, name, code, parent_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id) VALUES ('a97cd0ed-84ae-4037-bd90-76fa1fd951c1', 'Utilisateur', 'USER', NULL, '2022-01-15 18:04:17.9663', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:17.9663', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33');
     </sql>
     <sql>
-      INSERT INTO public.membership_access_param (id, guid, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, '35f72de5-01b0-49f6-854f-fcaffa099bcb', 'Nombre maximal', 4, 'Vous ne pouvez créer que %s activité(s) !', '0', 'NUMBER', 'MAX', 'NEW_ACTIVITY_MAX_NUMBER', '2022-01-15 18:04:18.096692', 2, '2022-01-15 18:04:18.096692', 2, 2, 'NEW_ACTIVITY_MAX_NUMBER');
-      INSERT INTO public.membership_access_param (id, guid, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, '8a0cacae-ac28-489f-b967-dcb13d660146', 'Nombre maximal', 6, 'Vous ne pouvez créer que %s modèle(s) d''activité !', '0', 'NUMBER', 'MAX', 'NEW_ACTIVITY_TEMPLATE_MAX_NUMBER', '2022-01-15 18:04:18.100385', 2, '2022-01-15 18:04:18.100385', 2, 2, 'NEW_ACTIVITY_TEMPLATE_MAX_NUMBER');
-      INSERT INTO public.membership_access_param (id, guid, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (3, '7274f58b-64e0-4fb6-ab25-2d3f0f7a056d', 'Nombre maximal', 7, 'Vous ne pouvez créer que %s indicateur(s) par activité !', '0', 'NUMBER', 'MAX', 'NEW_INDICATOR_MAX_NUMBER', '2022-01-15 18:04:18.104462', 2, '2022-01-15 18:04:18.104462', 2, 2, 'NEW_INDICATOR_MAX_NUMBER');
-      INSERT INTO public.membership_access_param (id, guid, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (4, '4c2d7961-8747-44dc-a0e8-1eab41e74e96', 'Nombre maximal', 8, 'Vous ne pouvez créer que %s modèle(s) d''indicateur par activité !', '0', 'NUMBER', 'MAX', 'NEW_INDICATOR_TEMPLATE_MAX_NUMBER', '2022-01-15 18:04:18.107158', 2, '2022-01-15 18:04:18.107158', 2, 2, 'NEW_INDICATOR_TEMPLATE_MAX_NUMBER');
-      INSERT INTO public.membership_access_param (id, guid, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (5, '7d1e9e55-19b9-4ad8-b8e0-059f27fcd521', 'Nombre maximal d''abonnés', 9, 'Vous ne pouvez partager votre activité qu''avec %s membre(s)', '0', 'NUMBER', 'MAX', 'SHARE_ACTIVITY_MAX_SUBSCRIBER', '2022-01-15 18:04:18.109924', 2, '2022-01-15 18:04:18.109924', 2, 2, 'SHARE_ACTIVITY_MAX_SUBSCRIBER');
-      INSERT INTO public.membership_access_param (id, guid, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (6, 'ac55b72c-dcfe-4624-8b43-8802d8144e5a', 'Nombre maximal', 11, 'Vous ne pouvez créer que %s modèle(s) de feuille de données', '0', 'NUMBER', 'MAX', 'NEW_DATA_SHEET_MODEL_MAX_NUMBER', '2022-01-15 18:04:18.112627', 2, '2022-01-15 18:04:18.112627', 2, 2, 'NEW_DATA_SHEET_MODEL_MAX_NUMBER');
-      INSERT INTO public.membership_access_param (id, guid, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (7, '2ed3ae03-979c-41a5-9f74-3a94e76a8017', 'Nombre maximal d''abonnés', 12, 'Vous ne pouvez partager votre modèle de feuille de données qu''avec %s membre(s)', '0', 'NUMBER', 'MAX', 'SHARE_DATA_SHEET_MODEL_MAX_SUBSCRIBER', '2022-01-15 18:04:18.115835', 2, '2022-01-15 18:04:18.115835', 2, 2, 'SHARE_DATA_SHEET_MODEL_MAX_SUBSCRIBER');
-      INSERT INTO public.membership_access_param (id, guid, name, access_id, message, default_value, value_type, quantifier, code, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (8, '00e874da-44d5-46b9-a609-261b5af6b3cc', 'Nombre maximal', 16, 'Vous ne pouvez créer que %s table(s) !', '0', 'NUMBER', 'MAX', 'NEW_DATA_FIELD_TABLE_MAX_NUMBER', '2022-01-15 18:04:18.118293', 2, '2022-01-15 18:04:18.118293', 2, 2, 'NEW_DATA_FIELD_TABLE_MAX_NUMBER');
+      INSERT INTO public.membership_profile_access (id, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('198840ed-163f-478a-97ce-f898a44dae40', '2630ffb6-b138-4ff8-b99f-7180e02f7b3d', 'fa29b642-b78d-4ee5-abba-cd7cb472d051', '2022-01-15 18:04:18.180037', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.180037', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ANONYMOUS_NEW_CONTACT_MSG');
+      INSERT INTO public.membership_profile_access (id, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('195fb334-e1e9-47d9-8626-60e021ce757e', 'f328f654-b593-4295-b044-629c5a98eedc', 'fa29b642-b78d-4ee5-abba-cd7cb472d051', '2022-01-15 18:04:18.182867', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.182867', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ANONYMOUS_ONE_REGISTER');
+      INSERT INTO public.membership_profile_access (id, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('35c0026b-a490-4e53-8ede-8fe010d5ff10', '56032da5-acaa-4551-93a5-03b6cba02bae', 'fa29b642-b78d-4ee5-abba-cd7cb472d051', '2022-01-15 18:04:18.185872', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.185872', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ANONYMOUS_CHANGE_FORGOTTEN_PASSWORD');
+      INSERT INTO public.membership_profile_access (id, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('763c428b-0299-4db8-95ad-fba0a9d07b6c', '99be6967-9c05-426b-9324-c0de83f1a4cd', 'a97cd0ed-84ae-4037-bd90-76fa1fd951c1', '2022-01-15 18:04:18.19225', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.19225', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_NEW_ACTIVITY');
+      INSERT INTO public.membership_profile_access (id, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('055b4561-25ed-4e73-b6c9-3fda9657db09', 'f6c6286b-38f7-4f7e-8cb9-111287174a0a', 'a97cd0ed-84ae-4037-bd90-76fa1fd951c1', '2022-01-15 18:04:18.195799', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.195799', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_NEW_INDICATOR');
+      INSERT INTO public.membership_profile_access (id, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('b762780d-1dc5-40b2-82db-3f240be1e14f', '13d04b82-d512-4915-bacc-aaa1356c53e7', 'a97cd0ed-84ae-4037-bd90-76fa1fd951c1', '2022-01-15 18:04:18.201363', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.201363', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_SHARE_ACTIVITY');
+      INSERT INTO public.membership_profile_access (id, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('f259b9af-fb78-47b4-9dd3-4f0b069fba76', '2a73196d-5518-4a0e-bff8-44dc7bd3e473', 'a97cd0ed-84ae-4037-bd90-76fa1fd951c1', '2022-01-15 18:04:18.204901', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.204901', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_ONE_UNSUBSCRIBE_ACTIVITY');
+      INSERT INTO public.membership_profile_access (id, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('61dabe5a-eb28-4903-858a-b5c0b863b888', '90b7cff5-54e8-4908-ab81-1f33a5ba7829', 'a97cd0ed-84ae-4037-bd90-76fa1fd951c1', '2022-01-15 18:04:18.207091', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.207091', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_NEW_DATA_SHEET_MODEL');
+      INSERT INTO public.membership_profile_access (id, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('79c49d4e-8d34-4a52-8381-690ec5544762', '8ff2f8ef-3bfd-4239-94f4-e7fc369e3c31', 'a97cd0ed-84ae-4037-bd90-76fa1fd951c1', '2022-01-15 18:04:18.209192', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.209192', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_SHARE_DATA_SHEET_MODEL');
+      INSERT INTO public.membership_profile_access (id, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('1d3cf783-02b8-4da2-bb17-3697cad81f00', '5362b8e5-0a18-46a9-ac0f-36fc71019f06', 'a97cd0ed-84ae-4037-bd90-76fa1fd951c1', '2022-01-15 18:04:18.211493', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.211493', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_ONE_UNSUBSCRIBE_DATA_SHEET_MODEL');
+      INSERT INTO public.membership_profile_access (id, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('f343a0f8-6715-4017-9513-a2c7ec2e981e', '8e3d495b-7f1b-4e66-8f22-3157b86eaa9f', 'a97cd0ed-84ae-4037-bd90-76fa1fd951c1', '2022-01-15 18:04:18.213768', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.213768', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_NEW_DATA_FIELD');
+      INSERT INTO public.membership_profile_access (id, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('45a856c0-d5a2-4362-bfce-b21109722247', 'def3efce-b2c7-47ec-8039-37da66a237f5', 'a97cd0ed-84ae-4037-bd90-76fa1fd951c1', '2022-01-15 18:04:18.215827', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.215827', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_NEW_DATA_SHEET');
+      INSERT INTO public.membership_profile_access (id, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('5d7ccc94-ac0f-4ace-ae62-c4a07f092bba', '6f8ebc7d-9814-4fad-a804-630d8ed7d658', 'a97cd0ed-84ae-4037-bd90-76fa1fd951c1', '2022-01-15 18:04:18.218032', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.218032', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_NEW_DATA_FIELD_TABLE');
     </sql>
     <sql>
-      INSERT INTO public.membership_profile (id, guid, name, code, parent_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id) VALUES (1, '83cf82a5-b5d8-447c-b778-e0beb4226f0e', 'Administrateur', 'ADMIN', NULL, '2022-01-15 18:04:17.961075', 2, '2022-01-15 18:04:17.961075', 2, 2);
-      INSERT INTO public.membership_profile (id, guid, name, code, parent_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id) VALUES (2, 'fa29b642-b78d-4ee5-abba-cd7cb472d051', 'Anonyme', 'ANONYMOUS', NULL, '2022-01-15 18:04:17.963899', 2, '2022-01-15 18:04:17.963899', 2, 2);
-      INSERT INTO public.membership_profile (id, guid, name, code, parent_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id) VALUES (3, 'a97cd0ed-84ae-4037-bd90-76fa1fd951c1', 'Utilisateur', 'USER', NULL, '2022-01-15 18:04:17.9663', 2, '2022-01-15 18:04:17.9663', 2, 2);
+      INSERT INTO public.membership_profile_access_param (id, value, param_inherited_id, access_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('955d18de-a8e6-4d98-a619-54b3d70960e3', '1', '35f72de5-01b0-49f6-854f-fcaffa099bcb', '763c428b-0299-4db8-95ad-fba0a9d07b6c', '2022-01-15 18:04:18.26446', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.26446', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_NEW_ACTIVITY_MAX_NUMBER');
+      INSERT INTO public.membership_profile_access_param (id, value, param_inherited_id, access_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('c3e975f9-3c2d-471a-b37f-f7a421049b24', '10', '7274f58b-64e0-4fb6-ab25-2d3f0f7a056d', '055b4561-25ed-4e73-b6c9-3fda9657db09', '2022-01-15 18:04:18.267344', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.267344', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_NEW_INDICATOR_MAX_NUMBER');
+      INSERT INTO public.membership_profile_access_param (id, value, param_inherited_id, access_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('c205a8be-6646-452d-8991-92119c18a5f5', '10', '7d1e9e55-19b9-4ad8-b8e0-059f27fcd521', 'b762780d-1dc5-40b2-82db-3f240be1e14f', '2022-01-15 18:04:18.27031', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.27031', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_SHARE_ACTIVITY_MAX_SUBSCRIBER');
+      INSERT INTO public.membership_profile_access_param (id, value, param_inherited_id, access_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('cd60380e-6eaf-4eba-a874-49c3fa97db03', '10', 'ac55b72c-dcfe-4624-8b43-8802d8144e5a', '61dabe5a-eb28-4903-858a-b5c0b863b888', '2022-01-15 18:04:18.27355', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.27355', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_NEW_DATA_SHEET_MODEL_MAX_NUMBER');
+      INSERT INTO public.membership_profile_access_param (id, value, param_inherited_id, access_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('62fe65be-3718-4a83-a486-39be380c0158', '10', '2ed3ae03-979c-41a5-9f74-3a94e76a8017', '79c49d4e-8d34-4a52-8381-690ec5544762', '2022-01-15 18:04:18.275951', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.275951', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_SHARE_DATA_SHEET_MODEL_MAX_SUBSCRIBER');
+      INSERT INTO public.membership_profile_access_param (id, value, param_inherited_id, access_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('68cc5675-2221-49e3-bb29-e027fe0e66f2', '0', '00e874da-44d5-46b9-a609-261b5af6b3cc', '5d7ccc94-ac0f-4ace-ae62-c4a07f092bba', '2022-01-15 18:04:18.278258', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.278258', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'FREE_NEW_DATA_FIELD_TABLE_MAX_NUMBER');
     </sql>
     <sql>
-      INSERT INTO public.membership_profile_access (id, guid, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, '198840ed-163f-478a-97ce-f898a44dae40', 1, 2, '2022-01-15 18:04:18.180037', 2, '2022-01-15 18:04:18.180037', 2, 2, 'ANONYMOUS_NEW_CONTACT_MSG');
-      INSERT INTO public.membership_profile_access (id, guid, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, '195fb334-e1e9-47d9-8626-60e021ce757e', 2, 2, '2022-01-15 18:04:18.182867', 2, '2022-01-15 18:04:18.182867', 2, 2, 'ANONYMOUS_ONE_REGISTER');
-      INSERT INTO public.membership_profile_access (id, guid, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (3, '35c0026b-a490-4e53-8ede-8fe010d5ff10', 3, 2, '2022-01-15 18:04:18.185872', 2, '2022-01-15 18:04:18.185872', 2, 2, 'ANONYMOUS_CHANGE_FORGOTTEN_PASSWORD');
-      INSERT INTO public.membership_profile_access (id, guid, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (4, '763c428b-0299-4db8-95ad-fba0a9d07b6c', 4, 3, '2022-01-15 18:04:18.19225', 2, '2022-01-15 18:04:18.19225', 2, 2, 'FREE_NEW_ACTIVITY');
-      INSERT INTO public.membership_profile_access (id, guid, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (5, '055b4561-25ed-4e73-b6c9-3fda9657db09', 7, 3, '2022-01-15 18:04:18.195799', 2, '2022-01-15 18:04:18.195799', 2, 2, 'FREE_NEW_INDICATOR');
-      INSERT INTO public.membership_profile_access (id, guid, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (6, 'b762780d-1dc5-40b2-82db-3f240be1e14f', 9, 3, '2022-01-15 18:04:18.201363', 2, '2022-01-15 18:04:18.201363', 2, 2, 'FREE_SHARE_ACTIVITY');
-      INSERT INTO public.membership_profile_access (id, guid, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (7, 'f259b9af-fb78-47b4-9dd3-4f0b069fba76', 10, 3, '2022-01-15 18:04:18.204901', 2, '2022-01-15 18:04:18.204901', 2, 2, 'FREE_ONE_UNSUBSCRIBE_ACTIVITY');
-      INSERT INTO public.membership_profile_access (id, guid, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (8, '61dabe5a-eb28-4903-858a-b5c0b863b888', 11, 3, '2022-01-15 18:04:18.207091', 2, '2022-01-15 18:04:18.207091', 2, 2, 'FREE_NEW_DATA_SHEET_MODEL');
-      INSERT INTO public.membership_profile_access (id, guid, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (9, '79c49d4e-8d34-4a52-8381-690ec5544762', 12, 3, '2022-01-15 18:04:18.209192', 2, '2022-01-15 18:04:18.209192', 2, 2, 'FREE_SHARE_DATA_SHEET_MODEL');
-      INSERT INTO public.membership_profile_access (id, guid, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (10, '1d3cf783-02b8-4da2-bb17-3697cad81f00', 13, 3, '2022-01-15 18:04:18.211493', 2, '2022-01-15 18:04:18.211493', 2, 2, 'FREE_ONE_UNSUBSCRIBE_DATA_SHEET_MODEL');
-      INSERT INTO public.membership_profile_access (id, guid, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (11, 'f343a0f8-6715-4017-9513-a2c7ec2e981e', 14, 3, '2022-01-15 18:04:18.213768', 2, '2022-01-15 18:04:18.213768', 2, 2, 'FREE_NEW_DATA_FIELD');
-      INSERT INTO public.membership_profile_access (id, guid, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (12, '45a856c0-d5a2-4362-bfce-b21109722247', 15, 3, '2022-01-15 18:04:18.215827', 2, '2022-01-15 18:04:18.215827', 2, 2, 'FREE_NEW_DATA_SHEET');
-      INSERT INTO public.membership_profile_access (id, guid, access_inherited_id, profile_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (13, '5d7ccc94-ac0f-4ace-ae62-c4a07f092bba', 16, 3, '2022-01-15 18:04:18.218032', 2, '2022-01-15 18:04:18.218032', 2, 2, 'FREE_NEW_DATA_FIELD_TABLE');
+      INSERT INTO public.membership_user (id, profile_id, active, salt, password, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('4788fb05-d7ac-4739-9b64-70a80f5e7af4', '83cf82a5-b5d8-447c-b778-e0beb4226f0e', true, 'EqdmPh53c9x33EygXpTpcoJvc4VXLK', 'bLHHYH9H9uYbHSc4eNIz/XpJj/1ieARJf1taeqMpdxA=', '2022-01-15 18:04:18.562554', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.562554', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ADMIN');
+      INSERT INTO public.membership_user (id, profile_id, active, salt, password, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('71078f08-0531-4ffc-bd29-a11fc633c4c7', 'fa29b642-b78d-4ee5-abba-cd7cb472d051', true, 'EqdmPh53c9x33EygXpTpcoJvc4VXLK', 'bLHHYH9H9uYbHSc4eNIz/XpJj/1ieARJf1taeqMpdxD=', '2022-01-15 18:04:18.564807', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:18.564807', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'ANONYMOUS');
     </sql>
     <sql>
-      INSERT INTO public.membership_profile_access_param (id, guid, value, param_inherited_id, access_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, '955d18de-a8e6-4d98-a619-54b3d70960e3', '1', 1, 4, '2022-01-15 18:04:18.26446', 2, '2022-01-15 18:04:18.26446', 2, 2, 'FREE_NEW_ACTIVITY_MAX_NUMBER');
-      INSERT INTO public.membership_profile_access_param (id, guid, value, param_inherited_id, access_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, 'c3e975f9-3c2d-471a-b37f-f7a421049b24', '10', 3, 5, '2022-01-15 18:04:18.267344', 2, '2022-01-15 18:04:18.267344', 2, 2, 'FREE_NEW_INDICATOR_MAX_NUMBER');
-      INSERT INTO public.membership_profile_access_param (id, guid, value, param_inherited_id, access_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (3, 'c205a8be-6646-452d-8991-92119c18a5f5', '10', 5, 6, '2022-01-15 18:04:18.27031', 2, '2022-01-15 18:04:18.27031', 2, 2, 'FREE_SHARE_ACTIVITY_MAX_SUBSCRIBER');
-      INSERT INTO public.membership_profile_access_param (id, guid, value, param_inherited_id, access_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (4, 'cd60380e-6eaf-4eba-a874-49c3fa97db03', '10', 6, 8, '2022-01-15 18:04:18.27355', 2, '2022-01-15 18:04:18.27355', 2, 2, 'FREE_NEW_DATA_SHEET_MODEL_MAX_NUMBER');
-      INSERT INTO public.membership_profile_access_param (id, guid, value, param_inherited_id, access_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (5, '62fe65be-3718-4a83-a486-39be380c0158', '10', 7, 9, '2022-01-15 18:04:18.275951', 2, '2022-01-15 18:04:18.275951', 2, 2, 'FREE_SHARE_DATA_SHEET_MODEL_MAX_SUBSCRIBER');
-      INSERT INTO public.membership_profile_access_param (id, guid, value, param_inherited_id, access_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (6, '68cc5675-2221-49e3-bb29-e027fe0e66f2', '0', 8, 13, '2022-01-15 18:04:18.278258', 2, '2022-01-15 18:04:18.278258', 2, 2, 'FREE_NEW_DATA_FIELD_TABLE_MAX_NUMBER');
+      INSERT INTO public.supervisor_indicator_type (id, description, name, default_size_x, default_size_y, short_name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('872cefde-2e72-418d-8d29-fb9a0b6b0844', 'Cet indicateur donne le nombre d''éléments avec le taux d''accroissement sur une période.', 'Chiffre orienté', 1, 1, 'number-oriented', '2022-01-15 18:04:19.296489', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:19.296489', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NUMBER_ORIENTED');
+      INSERT INTO public.supervisor_indicator_type (id, description, name, default_size_x, default_size_y, short_name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('67012af0-be42-41a9-be6f-7e607ed28b2e', 'Cet indicateur donne un objectif à atteindre.', 'Chiffre objectif', 2, 1, 'goal-number', '2022-01-15 18:04:19.299431', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:19.299431', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'GOAL_NUMBER');
+      INSERT INTO public.supervisor_indicator_type (id, description, name, default_size_x, default_size_y, short_name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('7755fa12-d9f6-403f-8c69-5b1eb1efcf37', 'Cet indicateur donne la proportion en pourcentage de plusieurs entités.', 'Camembert', 2, 2, 'chart-camembert', '2022-01-15 18:04:19.302369', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:19.302369', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CHART_CAMEMBERT');
+      INSERT INTO public.supervisor_indicator_type (id, description, name, default_size_x, default_size_y, short_name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('98afb59e-e5bf-4557-997f-6d575c8472f6', 'Cet indicateur permet d''observer plusieurs niveaux d''alerte.', 'Jauge', 2, 2, 'gauge', '2022-01-15 18:04:19.304911', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:19.304911', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'GAUGE');
+      INSERT INTO public.supervisor_indicator_type (id, description, name, default_size_x, default_size_y, short_name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES ('8650514d-ef33-40ba-9251-2be47661247e', 'Cet indicateur permet d''afficher vos données de manière ordonnée dans un tableau à 2 colonnes.', 'Tableau dynamique à 2 colonnes', 3, 3, 'dynamic-table-2-col', '2022-01-15 18:04:19.307184', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:19.307184', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'DYNAMIC_TABLE_2_COL');
     </sql>
     <sql>
-      INSERT INTO public.membership_user (id, guid, profile_id, active, salt, password, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, '8c996d5d-ed4f-4fc2-8bea-4fcd4c9ef625', 1, true, 'EqdmPh53c9x33EygXpTpcoJvc4VXLK', 'bLHHYH9H9uYbHSc4eNIz/XpJj/1ieARJf1taeqMpdxA=', '2022-01-15 18:04:18.562554', 2, '2022-01-15 18:04:18.562554', 2, 2, 'ADMIN');
-      INSERT INTO public.membership_user (id, guid, profile_id, active, salt, password, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, '337b67c9-7232-436f-8978-30968b969b33', 2, true, 'EqdmPh53c9x33EygXpTpcoJvc4VXLK', 'bLHHYH9H9uYbHSc4eNIz/XpJj/1ieARJf1taeqMpdxD=', '2022-01-15 18:04:18.564807', 2, '2022-01-15 18:04:18.564807', 2, 2, 'ANONYMOUS');
+      INSERT INTO public.supervisor_indicator_type_param (id, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES ('be74d833-d66a-41e2-91ec-115acb6dac66', 'QTE', 'NUMBER', 1, 'DYNAMIC', 'Quantité', '872cefde-2e72-418d-8d29-fb9a0b6b0844', '2022-01-15 18:04:19.339617', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:19.339617', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'NUMBER_ORIENTED_QTE', NULL);
+      INSERT INTO public.supervisor_indicator_type_param (id, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES ('9d504054-6f5c-4ffe-80d2-1267183a0011', 'QTE', 'NUMBER', 1, 'DYNAMIC', 'Quantité', '67012af0-be42-41a9-be6f-7e607ed28b2e', '2022-01-15 18:04:19.342957', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:19.342957', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'GOAL_NUMBER_QTE', NULL);
+      INSERT INTO public.supervisor_indicator_type_param (id, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES ('c55cdd71-326d-421f-bfef-6f8714b4d0d4', 'GOAL', 'NUMBER', 2, 'DYNAMIC', 'Objectif', '67012af0-be42-41a9-be6f-7e607ed28b2e', '2022-01-15 18:04:19.345952', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:19.345952', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'GOAL_NUMBER_GOAL', NULL);
+      INSERT INTO public.supervisor_indicator_type_param (id, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES ('96463288-1859-4163-8bd2-60a208271afe', 'ENTITY', 'STRING', 1, 'DYNAMIC', 'Entité', '7755fa12-d9f6-403f-8c69-5b1eb1efcf37', '2022-01-15 18:04:19.348864', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:19.348864', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CHART_CAMEMBERT_ENTITY', NULL);
+      INSERT INTO public.supervisor_indicator_type_param (id, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES ('192ede43-d0e2-41fd-a6db-8a8ea8e6bf08', 'QTE', 'NUMBER', 2, 'DYNAMIC', 'Quantité', '7755fa12-d9f6-403f-8c69-5b1eb1efcf37', '2022-01-15 18:04:19.351683', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:19.351683', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'CHART_CAMEMBERT_QTE', NULL);
+      INSERT INTO public.supervisor_indicator_type_param (id, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES ('0b7850a6-c88d-42f3-a547-c11bfa938427', 'QTE', 'NUMBER', 1, 'DYNAMIC', 'Quantité', '98afb59e-e5bf-4557-997f-6d575c8472f6', '2022-01-15 18:04:19.354498', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:19.354498', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'GAUGE_QTE', NULL);
+      INSERT INTO public.supervisor_indicator_type_param (id, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES ('cf149819-03c0-4644-83bd-960fc726945f', 'ENTITY', 'STRING', 1, 'DYNAMIC', 'Entité', '8650514d-ef33-40ba-9251-2be47661247e', '2022-01-15 18:04:19.356654', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:19.356654', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'DYNAMIC_TABLE_2_COL_ENTITY', NULL);
+      INSERT INTO public.supervisor_indicator_type_param (id, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES ('41ecef64-903f-4ba4-b7fc-5c7c987bfb82', 'QTE', 'NUMBER', 2, 'DYNAMIC', 'Quantité', '8650514d-ef33-40ba-9251-2be47661247e', '2022-01-15 18:04:19.358518', '337b67c9-7232-436f-8978-30968b969b33', '2022-01-15 18:04:19.358518', '337b67c9-7232-436f-8978-30968b969b33', '337b67c9-7232-436f-8978-30968b969b33', 'DYNAMIC_TABLE_2_COL_QTE', NULL);
     </sql>
     <sql>
-      INSERT INTO public.supervisor_indicator_type (id, guid, description, name, default_size_x, default_size_y, short_name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (1, '872cefde-2e72-418d-8d29-fb9a0b6b0844', 'Cet indicateur donne le nombre d''éléments avec le taux d''accroissement sur une période.', 'Chiffre orienté', 1, 1, 'number-oriented', '2022-01-15 18:04:19.296489', 2, '2022-01-15 18:04:19.296489', 2, 2, 'NUMBER_ORIENTED');
-      INSERT INTO public.supervisor_indicator_type (id, guid, description, name, default_size_x, default_size_y, short_name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (2, '67012af0-be42-41a9-be6f-7e607ed28b2e', 'Cet indicateur donne un objectif à atteindre.', 'Chiffre objectif', 2, 1, 'goal-number', '2022-01-15 18:04:19.299431', 2, '2022-01-15 18:04:19.299431', 2, 2, 'GOAL_NUMBER');
-      INSERT INTO public.supervisor_indicator_type (id, guid, description, name, default_size_x, default_size_y, short_name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (3, '7755fa12-d9f6-403f-8c69-5b1eb1efcf37', 'Cet indicateur donne la proportion en pourcentage de plusieurs entités.', 'Camembert', 2, 2, 'chart-camembert', '2022-01-15 18:04:19.302369', 2, '2022-01-15 18:04:19.302369', 2, 2, 'CHART_CAMEMBERT');
-      INSERT INTO public.supervisor_indicator_type (id, guid, description, name, default_size_x, default_size_y, short_name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (4, '98afb59e-e5bf-4557-997f-6d575c8472f6', 'Cet indicateur permet d''observer plusieurs niveaux d''alerte.', 'Jauge', 2, 2, 'gauge', '2022-01-15 18:04:19.304911', 2, '2022-01-15 18:04:19.304911', 2, 2, 'GAUGE');
-      INSERT INTO public.supervisor_indicator_type (id, guid, description, name, default_size_x, default_size_y, short_name, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag) VALUES (5, '8650514d-ef33-40ba-9251-2be47661247e', 'Cet indicateur permet d''afficher vos données de manière ordonnée dans un tableau à 2 colonnes.', 'Tableau dynamique à 2 colonnes', 3, 3, 'dynamic-table-2-col', '2022-01-15 18:04:19.307184', 2, '2022-01-15 18:04:19.307184', 2, 2, 'DYNAMIC_TABLE_2_COL');
-    </sql>
-    <sql>
-      INSERT INTO public.supervisor_indicator_type_param (id, guid, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES (1, 'be74d833-d66a-41e2-91ec-115acb6dac66', 'QTE', 'NUMBER', 1, 'DYNAMIC', 'Quantité', 1, '2022-01-15 18:04:19.339617', 2, '2022-01-15 18:04:19.339617', 2, 2, 'NUMBER_ORIENTED_QTE', NULL);
-      INSERT INTO public.supervisor_indicator_type_param (id, guid, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES (2, '9d504054-6f5c-4ffe-80d2-1267183a0011', 'QTE', 'NUMBER', 1, 'DYNAMIC', 'Quantité', 2, '2022-01-15 18:04:19.342957', 2, '2022-01-15 18:04:19.342957', 2, 2, 'GOAL_NUMBER_QTE', NULL);
-      INSERT INTO public.supervisor_indicator_type_param (id, guid, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES (3, 'c55cdd71-326d-421f-bfef-6f8714b4d0d4', 'GOAL', 'NUMBER', 2, 'DYNAMIC', 'Objectif', 2, '2022-01-15 18:04:19.345952', 2, '2022-01-15 18:04:19.345952', 2, 2, 'GOAL_NUMBER_GOAL', NULL);
-      INSERT INTO public.supervisor_indicator_type_param (id, guid, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES (4, '96463288-1859-4163-8bd2-60a208271afe', 'ENTITY', 'STRING', 1, 'DYNAMIC', 'Entité', 3, '2022-01-15 18:04:19.348864', 2, '2022-01-15 18:04:19.348864', 2, 2, 'CHART_CAMEMBERT_ENTITY', NULL);
-      INSERT INTO public.supervisor_indicator_type_param (id, guid, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES (5, '192ede43-d0e2-41fd-a6db-8a8ea8e6bf08', 'QTE', 'NUMBER', 2, 'DYNAMIC', 'Quantité', 3, '2022-01-15 18:04:19.351683', 2, '2022-01-15 18:04:19.351683', 2, 2, 'CHART_CAMEMBERT_QTE', NULL);
-      INSERT INTO public.supervisor_indicator_type_param (id, guid, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES (6, '0b7850a6-c88d-42f3-a547-c11bfa938427', 'QTE', 'NUMBER', 1, 'DYNAMIC', 'Quantité', 4, '2022-01-15 18:04:19.354498', 2, '2022-01-15 18:04:19.354498', 2, 2, 'GAUGE_QTE', NULL);
-      INSERT INTO public.supervisor_indicator_type_param (id, guid, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES (7, 'cf149819-03c0-4644-83bd-960fc726945f', 'ENTITY', 'STRING', 1, 'DYNAMIC', 'Entité', 5, '2022-01-15 18:04:19.356654', 2, '2022-01-15 18:04:19.356654', 2, 2, 'DYNAMIC_TABLE_2_COL_ENTITY', NULL);
-      INSERT INTO public.supervisor_indicator_type_param (id, guid, code, type, no, category, name, indicator_type_id, creation_date, creator_id, last_modification_date, last_modifier_id, owner_id, tag, predefined_values) VALUES (8, '41ecef64-903f-4ba4-b7fc-5c7c987bfb82', 'QTE', 'NUMBER', 2, 'DYNAMIC', 'Quantité', 5, '2022-01-15 18:04:19.358518', 2, '2022-01-15 18:04:19.358518', 2, 2, 'DYNAMIC_TABLE_2_COL_QTE', NULL);
-    </sql>
-    <sql>
-      SELECT pg_catalog.setval('public.base_address_id_seq', 9, true);
-      SELECT pg_catalog.setval('public.base_country_id_seq', 5, true);
-      SELECT pg_catalog.setval('public.base_currency_id_seq', 2, true);
-      SELECT pg_catalog.setval('public.base_event_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.base_language_id_seq', 2, true);
-      SELECT pg_catalog.setval('public.base_person_id_seq', 9, true);
-      SELECT pg_catalog.setval('public.base_planned_task_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.base_sequence_id_seq', 5, true);
-      SELECT pg_catalog.setval('public.billing_order_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.billing_order_line_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.billing_order_tax_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.billing_payment_method_id_seq', 12, true);
-      SELECT pg_catalog.setval('public.billing_payment_receipt_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.billing_payment_request_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.billing_product_catalog_id_seq', 2, true);
-      SELECT pg_catalog.setval('public.billing_product_id_seq', 1, true);
-      SELECT pg_catalog.setval('public.billing_subscription_contract_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.billing_tax_id_seq', 1, true);
-      SELECT pg_catalog.setval('public.membership_access_id_seq', 16, true);
-      SELECT pg_catalog.setval('public.membership_access_param_id_seq', 8, true);
-      SELECT pg_catalog.setval('public.membership_plan_feature_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.membership_profile_access_id_seq', 13, true);
-      SELECT pg_catalog.setval('public.membership_profile_access_param_id_seq', 6, true);
-      SELECT pg_catalog.setval('public.membership_profile_id_seq', 6, true);
-      SELECT pg_catalog.setval('public.membership_registration_request_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_activity_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_activity_template_like_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_activity_template_release_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_activity_template_subscription_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_activity_template_view_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_data_field_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_data_field_of_sheet_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_data_link_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_data_model_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_data_sheet_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_expression_arg_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_formular_expression_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_formular_extended_to_model_source_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_formular_extended_to_parent_source_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_gauge_zone_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_indicator_dynamic_param_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_indicator_general_setting_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_indicator_static_param_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_indicator_type_id_seq', 5, true);
-      SELECT pg_catalog.setval('public.supervisor_indicator_type_param_id_seq', 8, true);
-      SELECT pg_catalog.setval('public.supervisor_list_data_field_source_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_mapped_data_field_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_model_filter_condition_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_model_filter_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_periodicity_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_shared_resource_id_seq', 1, false);
-      SELECT pg_catalog.setval('public.supervisor_when_case_id_seq', 1, false);
-    </sql>
-    <sql>
-      ALTER TABLE ONLY public.base_address
-        ADD CONSTRAINT base_address_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.base_country
-        ADD CONSTRAINT base_country_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.base_currency
-        ADD CONSTRAINT base_currency_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.base_event
-        ADD CONSTRAINT base_event_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.base_language
-        ADD CONSTRAINT base_language_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.base_person
-        ADD CONSTRAINT base_person_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.base_planned_task
-        ADD CONSTRAINT base_planned_task_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.base_sequence
-        ADD CONSTRAINT base_sequence_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.billing_address
-        ADD CONSTRAINT billing_address_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.billing_invoice
-        ADD CONSTRAINT billing_invoice_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.billing_order_line
-        ADD CONSTRAINT billing_order_line_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.billing_order
-        ADD CONSTRAINT billing_order_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.billing_order_tax
-        ADD CONSTRAINT billing_order_tax_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.billing_payment_method
-        ADD CONSTRAINT billing_payment_method_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.billing_payment_receipt
-        ADD CONSTRAINT billing_payment_receipt_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.billing_payment_request
-        ADD CONSTRAINT billing_payment_request_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.billing_product_catalog
-        ADD CONSTRAINT billing_product_catalog_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.billing_product
-        ADD CONSTRAINT billing_product_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.billing_purchase_order
-        ADD CONSTRAINT billing_purchase_order_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.billing_software_engineering_service
-        ADD CONSTRAINT billing_software_engineering_service_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.billing_subscription_contract
-        ADD CONSTRAINT billing_subscription_contract_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.billing_tax
-        ADD CONSTRAINT billing_tax_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.membership_access_param
-        ADD CONSTRAINT membership_access_param_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.membership_access
-        ADD CONSTRAINT membership_access_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.membership_plan_feature
-        ADD CONSTRAINT membership_plan_feature_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.membership_plan
-        ADD CONSTRAINT membership_plan_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.membership_plan_subscription_contract
-        ADD CONSTRAINT membership_plan_subscription_contract_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.membership_profile_access_param
-        ADD CONSTRAINT membership_profile_access_param_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.membership_profile_access
-        ADD CONSTRAINT membership_profile_access_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.membership_profile
-        ADD CONSTRAINT membership_profile_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.membership_registration_request
-        ADD CONSTRAINT membership_registration_request_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.membership_user
-        ADD CONSTRAINT membership_user_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_activity_param
-        ADD CONSTRAINT supervisor_activity_param_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_activity
-        ADD CONSTRAINT supervisor_activity_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_activity_template_like
-        ADD CONSTRAINT supervisor_activity_template_like_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_activity_template_published
-        ADD CONSTRAINT supervisor_activity_template_published_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_activity_template_release
-        ADD CONSTRAINT supervisor_activity_template_release_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_activity_template_subscription
-        ADD CONSTRAINT supervisor_activity_template_subscription_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_activity_template_view
-        ADD CONSTRAINT supervisor_activity_template_view_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_aggregated_model
-        ADD CONSTRAINT supervisor_aggregated_model_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_aggregated_model_shared
-        ADD CONSTRAINT supervisor_aggregated_model_shared_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_chart_camembert_setting
-        ADD CONSTRAINT supervisor_chart_camembert_setting_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_data_field_expression_arg
-        ADD CONSTRAINT supervisor_data_field_expression_arg_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_data_field_of_sheet
-        ADD CONSTRAINT supervisor_data_field_of_sheet_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_data_field
-        ADD CONSTRAINT supervisor_data_field_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_data_link_param
-        ADD CONSTRAINT supervisor_data_link_param_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_data_link
-        ADD CONSTRAINT supervisor_data_link_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_data_link_shared
-        ADD CONSTRAINT supervisor_data_link_shared_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_data_model
-        ADD CONSTRAINT supervisor_data_model_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_data_sheet_model
-        ADD CONSTRAINT supervisor_data_sheet_model_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_data_sheet
-        ADD CONSTRAINT supervisor_data_sheet_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_data_sheet_shared
-        ADD CONSTRAINT supervisor_data_sheet_shared_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_dynamic_table_2_col
-        ADD CONSTRAINT supervisor_dynamic_table_2_col_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_editable_data_field
-        ADD CONSTRAINT supervisor_editable_data_field_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_expression_arg
-        ADD CONSTRAINT supervisor_expression_arg_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_expression_value_arg
-        ADD CONSTRAINT supervisor_expression_value_arg_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_formular_case_expression
-        ADD CONSTRAINT supervisor_formular_case_expression_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_formular_condition
-        ADD CONSTRAINT supervisor_formular_condition_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_formular_data_field
-        ADD CONSTRAINT supervisor_formular_data_field_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_formular_expression
-        ADD CONSTRAINT supervisor_formular_expression_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_formular_extended_to_model_source
-        ADD CONSTRAINT supervisor_formular_extended_to_model_source_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_formular_extended_to_parent_source
-        ADD CONSTRAINT supervisor_formular_extended_to_parent_source_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_formular_simple_expression
-        ADD CONSTRAINT supervisor_formular_simple_expression_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_gauge_setting
-        ADD CONSTRAINT supervisor_gauge_setting_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_gauge_zone
-        ADD CONSTRAINT supervisor_gauge_zone_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_goal_number_setting
-        ADD CONSTRAINT supervisor_goal_number_setting_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_indicator_dynamic_number_param
-        ADD CONSTRAINT supervisor_indicator_dynamic_number_param_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_indicator_dynamic_param
-        ADD CONSTRAINT supervisor_indicator_dynamic_param_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_indicator_dynamic_string_param
-        ADD CONSTRAINT supervisor_indicator_dynamic_string_param_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_indicator_general_setting
-        ADD CONSTRAINT supervisor_indicator_general_setting_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_indicator_static_param
-        ADD CONSTRAINT supervisor_indicator_static_param_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_indicator_type_param
-        ADD CONSTRAINT supervisor_indicator_type_param_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_indicator_type
-        ADD CONSTRAINT supervisor_indicator_type_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_list_data_field_source
-        ADD CONSTRAINT supervisor_list_data_field_source_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_list_data_field_source_shared
-        ADD CONSTRAINT supervisor_list_data_field_source_shared_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_mapped_data_field
-        ADD CONSTRAINT supervisor_mapped_data_field_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_model_filter_condition
-        ADD CONSTRAINT supervisor_model_filter_condition_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_model_filter
-        ADD CONSTRAINT supervisor_model_filter_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_number_oriented_setting
-        ADD CONSTRAINT supervisor_number_oriented_setting_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_param_data_field
-        ADD CONSTRAINT supervisor_param_data_field_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_periodicity
-        ADD CONSTRAINT supervisor_periodicity_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_shared_resource
-        ADD CONSTRAINT supervisor_shared_resource_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_value_expression_arg
-        ADD CONSTRAINT supervisor_value_expression_arg_pkey PRIMARY KEY (id);
-      ALTER TABLE ONLY public.supervisor_when_case
-        ADD CONSTRAINT supervisor_when_case_pkey PRIMARY KEY (id);
       ALTER TABLE ONLY public.membership_user
         ADD CONSTRAINT membership_profile_id_fkey FOREIGN KEY (profile_id) REFERENCES public.membership_profile(id) ON DELETE CASCADE;
       ALTER TABLE ONLY public.base_address
@@ -2251,8 +1022,6 @@ SOFTWARE.
         ADD CONSTRAINT billing_product_catalog_id_fkey FOREIGN KEY (catalog_id) REFERENCES public.billing_product_catalog(id) ON DELETE CASCADE;
       ALTER TABLE ONLY public.billing_purchase_order
         ADD CONSTRAINT billing_purchase_order_id_fkey FOREIGN KEY (id) REFERENCES public.billing_order(id) ON DELETE CASCADE;
-      ALTER TABLE ONLY public.billing_software_engineering_service
-        ADD CONSTRAINT billing_software_engineering_service_id_fkey FOREIGN KEY (id) REFERENCES public.billing_product(id) ON DELETE CASCADE;
       ALTER TABLE ONLY public.billing_subscription_contract
         ADD CONSTRAINT billing_subscription_contract_invoice_id_fkey FOREIGN KEY (invoice_id) REFERENCES public.billing_invoice(id) ON DELETE CASCADE;
       ALTER TABLE ONLY public.billing_subscription_contract

--- a/src/main/resources/xsl/admin_layout.xsl
+++ b/src/main/resources/xsl/admin_layout.xsl
@@ -100,7 +100,7 @@ SOFTWARE.
         </div>
         <script src="/js/jquery-3.2.1.min.js"/>
         <script src="/js/jquery.resize.js"/>
-          <script src="/js/selectize.min.js"/>
+        <script src="/js/selectize.min.js"/>
         <script src="/js/angular.min.js"/>
         <script src="/js/angular-sanitize.min.js"/>
         <script src="/js/tagsinput.js"/>

--- a/src/test/java/com/minlessika/membership/takes/FakeBase.java
+++ b/src/test/java/com/minlessika/membership/takes/FakeBase.java
@@ -11,6 +11,7 @@ import org.takes.Request;
 import java.io.IOException;
 import java.sql.Connection;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Fake base.
@@ -24,8 +25,8 @@ final class FakeBase implements Base {
     }
 
     @Override
-    public long currentUserId() {
-        return 0;
+    public UUID currentUserId() {
+        return null;
     }
 
     @Override
@@ -34,7 +35,7 @@ final class FakeBase implements Base {
     }
 
     @Override
-    public void start(boolean inTransaction, long currentUserId) throws IOException {
+    public void start(boolean inTransaction, UUID currentUserId) throws IOException {
 
     }
 
@@ -44,7 +45,7 @@ final class FakeBase implements Base {
     }
 
     @Override
-    public void changeUser(long userId) throws IOException {
+    public void changeUser(UUID userId) throws IOException {
 
     }
 
@@ -84,7 +85,7 @@ final class FakeBase implements Base {
     }
 
     @Override
-    public <A1 extends Recordable> Record<A1> select(Class<A1> clazz, Long id) throws IOException {
+    public <A1 extends Recordable> Record<A1> select(Class<A1> clazz, UUID id) throws IOException {
         return null;
     }
 

--- a/src/test/java/com/minlessika/sdk/tests/utils/FkRecordable.java
+++ b/src/test/java/com/minlessika/sdk/tests/utils/FkRecordable.java
@@ -10,21 +10,15 @@ import java.util.UUID;
 
 public class FkRecordable implements Recordable {
 
-	private final Long id;
+	private final UUID id;
 	
-	public FkRecordable(Long id) {
+	public FkRecordable(UUID id) {
 		this.id = id;
 	}
 	
 	@Override
-	public Long id() {
+	public UUID id() {
 		return id;
-	}
-
-	@Override
-	public UUID guid() throws IOException {
-		
-		return null;
 	}
 
 	@Override
@@ -34,7 +28,7 @@ public class FkRecordable implements Recordable {
 	}
 
 	@Override
-	public Long creatorId() throws IOException {
+	public UUID creatorId() throws IOException {
 		
 		return null;
 	}
@@ -46,13 +40,13 @@ public class FkRecordable implements Recordable {
 	}
 
 	@Override
-	public Long lastModifierId() throws IOException {
+	public UUID lastModifierId() throws IOException {
 		
 		return null;
 	}
 
 	@Override
-	public Long ownerId() throws IOException {
+	public UUID ownerId() throws IOException {
 		
 		return null;
 	}

--- a/src/test/java/com/minlessika/sdk/tests/utils/ListOfUniqueRecordTest.java
+++ b/src/test/java/com/minlessika/sdk/tests/utils/ListOfUniqueRecordTest.java
@@ -1,5 +1,6 @@
 package com.minlessika.sdk.tests.utils;
 
+import com.supervisor.domain.User;
 import com.supervisor.sdk.datasource.Recordable;
 import com.supervisor.sdk.utils.ListOfUniqueRecord;
 import org.hamcrest.MatcherAssert;
@@ -16,15 +17,15 @@ public final class ListOfUniqueRecordTest {
 	public void addTest() throws IOException {
 		
 		List<Recordable> records = new ListOfUniqueRecord<>();
-		records.add(new FkRecordable(1L));
-		records.add(new FkRecordable(1L));
+		records.add(new FkRecordable(User.ADMIN_ID));
+		records.add(new FkRecordable(User.ADMIN_ID));
 		
 		MatcherAssert.assertThat(
 				records.size(), 
-				Matchers.equalTo(1)
+				Matchers.equalTo(User.ADMIN_ID)
 		);
 		
-		records.add(0, new FkRecordable(1L));
+		records.add(0, new FkRecordable(User.ADMIN_ID));
 		MatcherAssert.assertThat(
 				records.size(), 
 				Matchers.equalTo(1)
@@ -35,11 +36,11 @@ public final class ListOfUniqueRecordTest {
 	public void addAllTest() throws IOException {
 		
 		List<Recordable> subRecords = new ArrayList<>();
-		subRecords.add(new FkRecordable(1L));
-		subRecords.add(new FkRecordable(2L));
+		subRecords.add(new FkRecordable(User.ADMIN_ID));
+		subRecords.add(new FkRecordable(User.ANONYMOUS_ID));
 		
 		List<Recordable> records = new ListOfUniqueRecord<>();
-		records.add(new FkRecordable(1L));
+		records.add(new FkRecordable(User.ADMIN_ID));
 		records.addAll(subRecords);
 		
 		MatcherAssert.assertThat(


### PR DESCRIPTION
- We change type of `id` method in each business object
- We removed `guid` column from all tables and use `id` column as `uuid`. We migrated all data to the new schema.